### PR TITLE
add Model.Properties type

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -37,10 +37,10 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration()
         ]) {
             let galaxy = Galaxy()
-            galaxy.name.set(to: "Messier")
-            try galaxy.name.mut { $0 += " 82" }
+            galaxy.set(\.name, to: "Messier")
+            try galaxy.mut(\.name) { $0 += " 82" }
             try galaxy.save(on: self.database).wait()
-            guard try galaxy.id.get() == 1 else {
+            guard try galaxy.get(\.id) == 1 else {
                 throw Failure("unexpected galaxy id: \(galaxy)")
             }
             
@@ -48,10 +48,10 @@ public final class FluentBenchmarker {
                 throw Failure("unexpected empty result set")
             }
             
-            if try fetched.name.get() != galaxy.name.get() {
+            if try fetched.get(\.name) != galaxy.get(\.name) {
                 throw Failure("unexpected name: \(galaxy) \(fetched)")
             }
-            if try fetched.id.get() != galaxy.id.get() {
+            if try fetched.get(\.id) != galaxy.get(\.id) {
                 throw Failure("unexpected id: \(galaxy) \(fetched)")
             }
         }
@@ -68,7 +68,7 @@ public final class FluentBenchmarker {
                 else {
                     throw Failure("unpexected missing galaxy")
             }
-            guard try milkyWay.name.get() == "Milky Way" else {
+            guard try milkyWay.get(\.name) == "Milky Way" else {
                 throw Failure("unexpected name")
             }
         }
@@ -79,9 +79,9 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration()
         ]) {
             let galaxy = Galaxy()
-            galaxy.name.set(to: "Milkey Way")
+            galaxy.set(\.name, to: "Milkey Way")
             try galaxy.save(on: self.database).wait()
-            galaxy.name.set(to: "Milky Way")
+            galaxy.set(\.name, to: "Milky Way")
             try galaxy.save(on: self.database).wait()
             
             // verify
@@ -89,7 +89,7 @@ public final class FluentBenchmarker {
             guard galaxies.count == 1 else {
                 throw Failure("unexpected galaxy count: \(galaxies)")
             }
-            guard try galaxies[0].name.get() == "Milky Way" else {
+            guard try galaxies[0].get(\.name) == "Milky Way" else {
                 throw Failure("unexpected galaxy name")
             }
         }
@@ -100,7 +100,7 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration(),
         ]) {
             let galaxy = Galaxy()
-            galaxy.name.set(to: "Milky Way")
+            galaxy.set(\.name, to: "Milky Way")
             try galaxy.save(on: self.database).wait()
             try galaxy.delete(on: self.database).wait()
             
@@ -124,13 +124,13 @@ public final class FluentBenchmarker {
                 .all().wait()
 
             for galaxy in galaxies {
-                let planets = try galaxy.planets.get()
-                switch try galaxy.name.get() {
+                let planets = try galaxy.get(\.planets)
+                switch try galaxy.get(\.name) {
                 case "Milky Way":
-                    guard try planets.contains(where: { try $0.name.get() == "Earth" }) else {
+                    guard try planets.contains(where: { try $0.get(\.name) == "Earth" }) else {
                         throw Failure("unexpected missing planet")
                     }
-                    guard try !planets.contains(where: { try $0.name.get() == "PA-99-N2"}) else {
+                    guard try !planets.contains(where: { try $0.get(\.name) == "PA-99-N2"}) else {
                         throw Failure("unexpected planet")
                     }
                 default: break
@@ -151,14 +151,14 @@ public final class FluentBenchmarker {
                 .all().wait()
             
             for planet in planets {
-                let galaxy = try planet.galaxy.get()
-                switch try planet.name.get() {
+                let galaxy = try planet.get(\.galaxy)
+                switch try planet.get(\.name) {
                 case "Earth":
-                    guard try galaxy.name.get() == "Milky Way" else {
+                    guard try galaxy.get(\.name) == "Milky Way" else {
                         throw Failure("unexpected galaxy name: \(galaxy)")
                     }
                 case "PA-99-N2":
-                    guard try galaxy.name.get() == "Andromeda" else {
+                    guard try galaxy.get(\.name) == "Andromeda" else {
                         throw Failure("unexpected galaxy name: \(galaxy)")
                     }
                 default: break
@@ -179,14 +179,14 @@ public final class FluentBenchmarker {
                 .all().wait()
             
             for planet in planets {
-                let galaxy = try planet.galaxy.get()
-                switch try planet.name.get() {
+                let galaxy = try planet.get(\.galaxy)
+                switch try planet.get(\.name) {
                 case "Earth":
-                    guard try galaxy.name.get() == "Milky Way" else {
+                    guard try galaxy.get(\.name) == "Milky Way" else {
                         throw Failure("unexpected galaxy name: \(galaxy)")
                     }
                 case "PA-99-N2":
-                    guard try galaxy.name.get() == "Andromeda" else {
+                    guard try galaxy.get(\.name) == "Andromeda" else {
                         throw Failure("unexpected galaxy name: \(galaxy)")
                     }
                 default: break
@@ -305,8 +305,8 @@ public final class FluentBenchmarker {
             print(planets)
             for planet in planets {
                 let galaxy = planet.joined(Galaxy.self)
-                let planetName = try planet.name.get()
-                let galaxyName = try galaxy.name.get()
+                let planetName = try planet.get(\.name)
+                let galaxyName = try galaxy.get(\.name)
                 switch planetName {
                 case "Earth":
                     guard galaxyName == "Milky Way" else {
@@ -328,12 +328,12 @@ public final class FluentBenchmarker {
         ]) {
             let galaxies = Array("abcdefghijklmnopqrstuvwxyz").map { letter -> Galaxy in
                 let galaxy = Galaxy()
-                galaxy.name.set(to: String(letter))
+                galaxy.set(\.name, to: String(letter))
                 return galaxy
             }
                 
             try galaxies.create(on: self.database).wait()
-            guard try galaxies[5].id.get() == 6 else {
+            guard try galaxies[5].get(\.id) == 6 else {
                 throw Failure("batch insert did not set id")
             }
         }
@@ -350,7 +350,7 @@ public final class FluentBenchmarker {
             let galaxies = try self.database.query(Galaxy.self).all().wait()
             for galaxy in galaxies {
                 
-                guard try galaxy.name.get() == "Foo" else {
+                guard try galaxy.get(\.name) == "Foo" else {
                     throw Failure("batch update did not set id")
                 }
             }
@@ -363,19 +363,19 @@ public final class FluentBenchmarker {
             UserSeed()
         ]) {
             let users = try self.database.query(User.self)
-                .filter(\.pet.type == .cat)
+                .filter(\.pet, "type", .equals, User.Pet.Animal.cat)
                 .all().wait()
         
             guard let user = users.first, users.count == 1 else {
                 throw Failure("unexpected user count")
             }
-            guard try user.name.get() == "Tanner" else {
+            guard try user.get(\.name) == "Tanner" else {
                 throw Failure("unexpected user name")
             }
-            guard try user.pet.name.get() == "Ziz" else {
+            guard try user.get(\.pet).name == "Ziz" else {
                 throw Failure("unexpected pet name")
             }
-            guard try user.pet.type.get() == .cat else {
+            guard try user.get(\.pet).type == .cat else {
                 throw Failure("unexpected pet type")
             }
             
@@ -451,24 +451,24 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration(),
         ]) {
             let galaxy = Galaxy()
-            galaxy.name.set(to: "Milky Way")
-            guard (try? galaxy.id.get()) == nil else {
+            galaxy.set(\.name, to: "Milky Way")
+            guard (try? galaxy.get(\.id)) == nil else {
                 throw Failure("id should not be set")
             }
             try galaxy.save(on: self.database).wait()
-            _ = try galaxy.id.get()
+            _ = try galaxy.get(\.id)
             
             
             let a = Galaxy()
-            a.name.set(to: "A")
+            a.set(\.name, to: "A")
             let b = Galaxy()
-            b.name.set(to: "B")
+            b.set(\.name, to: "B")
             let c = Galaxy()
-            c.name.set(to: "c")
+            c.set(\.name, to: "c")
             try a.save(on: self.database).wait()
             try b.save(on: self.database).wait()
             try c.save(on: self.database).wait()
-            guard try a.id.get() != b.id.get() && b.id.get() != c.id.get() && a.id.get() != c.id.get() else {
+            guard try a.get(\.id) != b.get(\.id) && b.get(\.id) != c.get(\.id) && a.get(\.id) != c.get(\.id) else {
                 throw Failure("ids should not be equal")
             }
         }
@@ -476,20 +476,12 @@ public final class FluentBenchmarker {
     
     public func testNullifyField() throws {
         final class Foo: Model {
-            var properties: [Property] {
-                return [id, bar]
+            struct Properties: ModelProperties {
+                let id = Field<Int>("id")
+                let bar = Field<String?>("bar")
             }
-            
+            static let properties = Properties()
             var storage: Storage
-        
-            var id: Field<Int> {
-                return self.id("id")
-            }
-            
-            var bar: Field<String?> {
-                return self.field("bar")
-            }
-            
             init(storage: Storage) {
                 self.storage = storage
             }
@@ -498,24 +490,24 @@ public final class FluentBenchmarker {
             Foo.autoMigration(),
         ]) {
             let foo = Foo()
-            foo.bar.set(to: "test")
+            foo.set(\.bar, to: "test")
             try foo.save(on: self.database).wait()
-            guard try foo.bar.get() != nil else {
+            guard try foo.get(\.bar) != nil else {
                 throw Failure("unexpected nil value")
             }
-            foo.bar.set(to: nil)
+            foo.set(\.bar, to: nil)
             try foo.save(on: self.database).wait()
-            guard try foo.bar.get() == nil else {
+            guard try foo.get(\.bar) == nil else {
                 throw Failure("unexpected non-nil value")
             }
             
             guard let fetched = try self.database.query(Foo.self)
-                .filter(\.id == foo.id.get())
+                .filter(\.id == foo.get(\.id))
                 .first().wait()
             else {
                 throw Failure("no model returned")
             }
-            guard try fetched.bar.get() == nil else {
+            guard try fetched.get(\.bar) == nil else {
                 throw Failure("unexpected non-nil value")
             }
         }
@@ -531,7 +523,7 @@ public final class FluentBenchmarker {
             try self.database.transaction { database -> EventLoopFuture<Void> in
                 let saves = (1...512).map { i -> EventLoopFuture<Void> in
                     let galaxy = Galaxy()
-                    galaxy.name.set(to: "Milky Way \(i)")
+                    galaxy.set(\.name, to: "Milky Way \(i)")
                     return galaxy.save(on: database)
                 }
                 return .andAllSucceed(saves, on: database.eventLoop)
@@ -563,32 +555,23 @@ public final class FluentBenchmarker {
     
     public func testUniqueFields() throws {
         final class Foo: Model {
-            var properties: [Property] {
-                return [id, bar, baz]
+            struct Properties: ModelProperties {
+                let id = Field<Int>("id")
+                let bar = Field<String>("bar")
+                let baz = Field<Int>("baz")
             }
+            
+            static let properties = Properties()
             
             var storage: Storage
-            
-            var id: Field<Int> {
-                return self.id("id")
-            }
-            
-            var bar: Field<String> {
-                return self.field("bar")
-            }
-            
-            var baz: Field<Int> {
-                return self.field("baz")
+            init(storage: Storage) {
+                self.storage = storage
             }
             
             convenience init(bar: String, baz: Int) {
                 self.init()
-                self.bar.set(to: bar)
-                self.baz.set(to: baz)
-            }
-            
-            init(storage: Storage) {
-                self.storage = storage
+                self.set(\.bar, to: bar)
+                self.set(\.baz, to: baz)
             }
         }
         struct FooMigration: Migration {

--- a/Sources/FluentBenchmark/Galaxy.swift
+++ b/Sources/FluentBenchmark/Galaxy.swift
@@ -1,29 +1,15 @@
 import FluentKit
 
 final class Galaxy: Model {
-    var storage: ModelStorage
-    
-    var properties: [Property] {
-        return [id, name]
+    struct Properties: ModelProperties {
+        let id = Field<Int>("id")
+        let name = Field<String>("name")
+        let planets = Children<Planet>(id: .init("galaxyID"))
     }
+    static let properties = Properties()
     
-    var entity: String {
-        return "galaxies"
-    }
-    
-    var id: Field<Int> {
-        return self.field("id", .int, .identifier)
-    }
-    
-    var name: Field<String> {
-        return self.field("name")
-    }
-    
-    var planets: Children<Planet> {
-        return self.children(\.galaxy)
-    }
-    
-    init(storage: ModelStorage) {
+    var storage: Storage
+    init(storage: Storage) {
         self.storage = storage
     }
 }

--- a/Sources/FluentBenchmark/GalaxySeed.swift
+++ b/Sources/FluentBenchmark/GalaxySeed.swift
@@ -6,7 +6,7 @@ final class GalaxySeed: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         let saves = ["Andromeda", "Milky Way", "Messier 82"].map { name -> EventLoopFuture<Void> in
             let galaxy = Galaxy()
-            galaxy.name.set(to: name)
+            galaxy.set(\.name, to: name)
             return galaxy.save(on: database)
         }
         return .andAllSucceed(saves, on: database.eventLoop)

--- a/Sources/FluentBenchmark/Planet.swift
+++ b/Sources/FluentBenchmark/Planet.swift
@@ -1,29 +1,14 @@
 import FluentKit
 
-final class Planet: Model, Codable {
-    var storage: ModelStorage
-    
-    var properties: [Property] {
-        return [id, name, galaxy]
+final class Planet: Model {
+    struct Properties: ModelProperties {
+        let id = Field<Int>("id")
+        let name = Field<String>("name")
+        let galaxy = Parent<Galaxy>(id: Field("galaxyID"))
     }
-    
-    var entity: String {
-        return "planets"
-    }
-    
-    var id: Field<Int> {
-        return self.field("id", .int, .identifier)
-    }
-    
-    var name: Field<String> {
-        return self.field("name")
-    }
-    
-    var galaxy: Parent<Galaxy> {
-        return self.parent("galaxyID")
-    }
-    
-    init(storage: ModelStorage) {
+    static let properties = Properties()
+    var storage: Storage
+    init(storage: Storage) {
         self.storage = storage
     }
 }

--- a/Sources/FluentBenchmark/PlanetSeed.swift
+++ b/Sources/FluentBenchmark/PlanetSeed.swift
@@ -18,8 +18,8 @@ final class PlanetSeed: Migration {
             }
             let saves = planets.map { name -> EventLoopFuture<Void> in
                 let planet = Planet()
-                planet.name.set(to: name)
-                try! planet.galaxy.set(to: galaxy)
+                planet.set(\.name, to: name)
+                try! planet.set(\.galaxy, to: galaxy)
                 return planet.save(on: database)
             }
             return .andAllSucceed(saves, on: database.eventLoop)

--- a/Sources/FluentBenchmark/User.swift
+++ b/Sources/FluentBenchmark/User.swift
@@ -1,72 +1,41 @@
 import FluentKit
 
-
-
 final class User: Model {
-    var storage: ModelStorage
-    
-    var properties: [Property] {
-        return [id, name, pet.property]
+    struct Pet: Codable, NestedProperty {
+        enum Animal: String, Codable {
+            case cat, dog
+        }
+        var name: String
+        var type: Animal
     }
     
-    var entity: String {
-        return "users"
+    struct Properties: ModelProperties {
+        let id = Field<Int>("id")
+        let name = Field<String>("name")
+        let pet = Field<Pet>("pet", .json)
     }
     
-    var id: Field<Int> {
-        return self.field("id", .int, .identifier)
-    }
+    static let entity: String = "users"
+    static let properties = Properties()
     
-    var name: Field<String> {
-        return self.field("name", .string, .required)
-    }
-    
-    var pet: Pet {
-        return self.nested("pet", .json, .required)
-    }
-    
-    init(storage: ModelStorage) {
+    var storage: Storage
+    init(storage: Storage) {
         self.storage = storage
     }
 }
 
-enum Animal: String, Codable {
-    case cat, dog
-}
-
-final class Pet: NestedModel {
-    var storage: ModelStorage
-    
-    var properties: [Property] {
-        return [name, type]
-    }
-    
-    var name: Field<String> {
-        return self.field("name")
-    }
-    
-    var type: Field<Animal> {
-        return self.field("type")
-    }
-    
-    init(storage: ModelStorage) {
-        self.storage = storage
-    }
-}
 
 final class UserSeed: Migration {
     init() { }
     
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         let tanner = User()
-        tanner.name.set(to: "Tanner")
-        tanner.pet.name.set(to: "Ziz")
-        tanner.pet.type.set(to: .cat)
+        tanner.set(\.name, to: "Tanner")
+        tanner.set(\.pet, to: .init(name: "Ziz", type: .cat))
 
-        let logan =  User()
-        logan.name.set(to: "Logan")
-        logan.pet.name.set(to: "Runa")
-        logan.pet.type.set(to: .dog)
+        let logan = User()
+        logan.set(\.name, to: "Logan")
+        logan.set(\.pet, to: .init(name: "Runa", type: .dog))
         
         return logan.save(on: database)
             .and(tanner.save(on: database))

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -5,47 +5,21 @@ import Foundation
 /// when the app boots. It is also used to determine which migrations to revert when
 /// using the `RevertCommand`.
 public final class MigrationLog: Model {
-    /// See `Model`.
-    public var entity: String {
-        return "fluent"
+    public struct Properties: ModelProperties {
+        public let id = Field<Int>("id")
+        public let name = Field<String>("name")
+        public let batch = Field<Int>("batch")
+        public let createdAt = Field<Date>("createdAt")
+        public let updatedAt = Field<Date>("updatedAt")
     }
     
-    /// See `Model`.
-    #warning("TODO: make uuid")
-    public var id: Field<Int> {
-        return self.id("id")
-    }
+    public static let entity = "fluent"
+    public static let properties = Properties()
     
-    /// The unique name of the migration.
-    public var name: Field<String> {
-        return self.field("name")
-    }
-    
-    /// The batch number.
-    public var batch: Field<Int> {
-        return self.field("batch")
-    }
-    
-    /// When this log was created.
-    public var createdAt: Field<Date> {
-        return self.field("createdAt")
-    }
-    
-    /// When this log was last updated.
-    public var updatedAt: Field<Date> {
-        return self.field("updatedAt")
-    }
-    
-    public var properties: [Property] {
-        return [self.id, self.name, self.batch, self.createdAt, self.updatedAt]
-    }
-    
-    public var storage: ModelStorage
-    
-    public init(storage: ModelStorage) {
+    public var storage: Storage
+    public init(storage: Storage) {
         self.storage = storage
     }
 }
 
 private var _migrationLogEntity = "fluent"
-

--- a/Sources/FluentKit/Model/AnyModel.swift
+++ b/Sources/FluentKit/Model/AnyModel.swift
@@ -1,7 +1,6 @@
 public protocol AnyModel: class, Codable {
-    var properties: [Property] { get }
     var storage: Storage { get set }
-    var entity: String { get }
+    static var entity: String { get }
     init(storage: Storage)
 }
 
@@ -16,22 +15,22 @@ extension AnyModel {
     }
 }
 
-extension AnyModel where Self: Encodable {
+extension Model where Self: Encodable {
     public func encode(to encoder: Encoder) throws {
         var encoder = ModelEncoder(encoder: encoder)
-        for field in self.properties {
-            try field.encode(to: &encoder)
+        for property in Self.properties.all {
+            try property.encode(to: &encoder, from: self.storage)
         }
     }
 }
 
-extension AnyModel where Self: Decodable {
+extension Model where Self: Decodable {
     public init(from decoder: Decoder) throws {
         let decoder = try ModelDecoder(decoder: decoder)
         self.init()
-        for field in self.properties {
+        for field in Self.properties.all {
             do {
-                try field.decode(from: decoder)
+                try field.decode(from: decoder, to: &self.storage)
             } catch {
                 print("Could not decode \(field.name): \(error)")
             }
@@ -48,7 +47,7 @@ extension AnyModel {
 
 
 extension AnyModel {
-    public var entity: String {
+    public static var entity: String {
         return "\(Self.self)"
     }
     

--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -1,6 +1,84 @@
 public protocol Model: AnyModel, CustomStringConvertible {
+    associatedtype Properties: ModelProperties
+        where Properties.Model == Self
+    static var properties: Properties { get }
+}
+
+
+public protocol ModelProperties {
+    associatedtype Model: FluentKit.Model
     associatedtype ID: ModelID
-    var id: Field<ID> { get }
+    var id: ModelField<Model, ID> { get }
+    var all: [ModelProperty] { get }
+}
+
+
+extension ModelProperties {
+    public var all: [Model.Property] {
+        return Mirror(reflecting: self)
+            .children
+            .compactMap { $0 as? ModelProperty }
+    }
+}
+
+extension Model {
+    public typealias ID = Properties.ID
+    public typealias Field<Value> = ModelField<Self, Value>
+        where Value: Codable
+    
+    public typealias FieldKey<Value> = KeyPath<Properties, Field<Value>>
+        where Value: Codable
+    
+    public static func field<T>(forKey key: FieldKey<T>) -> Field<T> {
+        return self.properties[keyPath: key]
+    }
+}
+
+extension ModelStorage {
+    public func get<Value>(_ name: String, as value: Value.Type = Value.self) throws -> Value
+        where Value: Codable
+    {
+        if let input = self.input[name] {
+            switch input {
+            case .bind(let encodable): return encodable as! Value
+            default: fatalError("Non-matching input.")
+            }
+        } else if let output = self.output {
+            return try output.decode(field: name, as: Value.self)
+        } else {
+            throw ModelError.missingField(name: name)
+        }
+    }
+    public mutating func set<Value>(_ name: String, to value: Value)
+        where Value: Codable
+    {
+        self.input[name] = .bind(value)
+    }
+}
+
+extension Model {
+    public func get<Value>(_ key: FieldKey<Value>) throws -> Value {
+        return try self.get(Self.field(forKey: key))
+    }
+    
+    public func get<Value>(_ field: Field<Value>) throws -> Value {
+        return try self.storage.get(field.name)
+    }
+    
+    public func set<Value>(_ key: FieldKey<Value>, to value: Value) {
+        self.set(Self.field(forKey: key), to: value)
+    }
+    
+    public func set<Value>(_ field: Field<Value>, to value: Value) {
+        self.storage.set(field.name, to: value)
+    }
+    
+    #warning("TODO: better name")
+    public func mut<Value>(_ key: FieldKey<Value>, _ closure: (inout Value) throws -> ()) throws {
+        var value: Value = try self.get(key)
+        try closure(&value)
+        self.set(key, to: value)
+    }
 }
 
 extension Model {
@@ -28,7 +106,7 @@ extension Model {
     
     public func update(on database: Database) -> EventLoopFuture<Void> {
         precondition(self.exists)
-        let builder = try! database.query(Self.self).filter(\.id == self.id.get()).set(self.storage.input)
+        let builder = try! database.query(Self.self).filter(\.id == self.get(\.id)).set(self.storage.input)
         builder.query.action = .update
         return builder.run { model in
             self.storage = DefaultModelStorage(
@@ -42,7 +120,7 @@ extension Model {
     
     public func delete(on database: Database) -> EventLoopFuture<Void> {
         precondition(self.exists)
-        let builder = try! database.query(Self.self).filter(\.id == self.id.get())
+        let builder = try! database.query(Self.self).filter(\.id == self.get(\.id))
         builder.query.action = .delete
         return builder.run().map {
             self.storage.exists = false

--- a/Sources/FluentKit/Model/ModelField.swift
+++ b/Sources/FluentKit/Model/ModelField.swift
@@ -2,8 +2,8 @@ public enum ModelError: Error {
     case missingField(name: String)
 }
 
-public struct ModelField<Entity, Value>: ModelProperty
-    where Entity: FluentKit.AnyModel, Value: Codable
+public struct ModelField<Model, Value>: ModelProperty
+    where Model: FluentKit.Model, Value: Codable
 {
     public var type: Any.Type {
         return Value.self
@@ -13,84 +13,68 @@ public struct ModelField<Entity, Value>: ModelProperty
     
     public let name: String
     
-    public var path: [String] {
-        return self.model.storage.path + [self.name]
-    }
+//    public var path: [String] {
+//        return self.model.storage.path + [self.name]
+//    }
 
     public let dataType: DatabaseSchema.DataType?
-    
-    internal let model: Entity
     
     struct Interface: Codable {
         let name: String
     }
     
-    init(model: Entity, name: String, dataType: DatabaseSchema.DataType?, constraints: [DatabaseSchema.FieldConstraint]) {
-        self.model = model
+    public init(
+        _ name: String,
+        _ dataType: DatabaseSchema.DataType? = nil,
+        _ constraints: DatabaseSchema.FieldConstraint...
+    ) {
         self.name = name
         self.dataType = dataType
         self.constraints = constraints
     }
     
-    public func get() throws -> Value {
-        if let input = self.model.storage.input[self.name] {
-            switch input {
-            case .bind(let encodable): return encodable as! Value
-            default: fatalError("Non-matching input.")
-            }
-        } else if let output = self.model.storage.output {
-            return try output.decode(field: self.name, as: Value.self)
-        } else {
-            throw ModelError.missingField(name: "\(Entity.self).\(self.name)")
-        }
+    public init(
+        name: String,
+        dataType: DatabaseSchema.DataType? = nil,
+        constraints: [DatabaseSchema.FieldConstraint] = []
+    ) {
+        self.name = name
+        self.dataType = dataType
+        self.constraints = constraints
     }
     
-    public func set(to value: Value) {
-        self.model.storage.input[self.name] = .bind(value)
+    public func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
+        try encoder.encode(storage.get(self.name, as: Value.self), forKey: self.name)
     }
-    
-    #warning("TODO: better name")
-    public func mut(_ closure: (inout Value) throws -> ()) throws {
-        var value: Value = try self.get()
-        try closure(&value)
-        self.set(to: value)
-    }
-    
-    public func encode(to encoder: inout ModelEncoder) throws {
-        try encoder.encode(self.get(), forKey: self.name)
-    }
-    
-    public func decode(from decoder: ModelDecoder) throws {
-        try self.set(to: decoder.decode(Value.self, forKey: self.name))
+
+    public func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
+        try storage.set(self.name, to: decoder.decode(Value.self, forKey: self.name))
     }
 }
 
-extension AnyModel {
-    public typealias Field<Value> = ModelField<Self, Value>
-        where Value: Codable
-    
-    public func field<Value>(
-        _ name: String,
-        _ dataType: DatabaseSchema.DataType? = nil,
-        _ constraints: DatabaseSchema.FieldConstraint...
-    ) -> Field<Value>
-        where Value: Codable
-    {
-        return .init(model: self, name: name, dataType: dataType, constraints: constraints)
-    }
-    
-    public func id<Value>(
-        _ name: String,
-        _ dataType: DatabaseSchema.DataType? = nil,
-        _ constraints: DatabaseSchema.FieldConstraint...
-    ) -> Field<Value>
-        where Value: Codable
-    {
-        return .init(
-            model: self,
-            name: name,
-            dataType: dataType,
-            constraints: constraints + [.identifier]
-        )
-    }
-}
+//extension Model {
+//    public func field<Value>(
+//        _ name: String,
+//        _ dataType: DatabaseSchema.DataType? = nil,
+//        _ constraints: DatabaseSchema.FieldConstraint...
+//    ) -> Field<Value>
+//        where Value: Codable
+//    {
+//        return .init(name: name, dataType: dataType, constraints: constraints)
+//    }
+//
+//    public func id<Value>(
+//        _ name: String,
+//        _ dataType: DatabaseSchema.DataType? = nil,
+//        _ constraints: DatabaseSchema.FieldConstraint...
+//    ) -> Field<Value>
+//        where Value: Codable
+//    {
+//        return .init(
+//            model: self,
+//            name: name,
+//            dataType: dataType,
+//            constraints: constraints + [.identifier]
+//        )
+//    }
+//}

--- a/Sources/FluentKit/Model/ModelProperty.swift
+++ b/Sources/FluentKit/Model/ModelProperty.swift
@@ -5,8 +5,8 @@ public protocol ModelProperty {
     var dataType: DatabaseSchema.DataType? { get }
     var constraints: [DatabaseSchema.FieldConstraint] { get }
     
-    func encode(to encoder: inout ModelEncoder) throws
-    func decode(from decoder: ModelDecoder) throws
+    func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws
+    func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws
 }
 
 public struct ModelDecoder {

--- a/Sources/FluentKit/Model/NestedModel.swift
+++ b/Sources/FluentKit/Model/NestedModel.swift
@@ -1,134 +1,180 @@
-public protocol NestedModel: AnyModel { }
+public protocol NestedProperty { }
 
-extension AnyModel {
-    public func nested<Nested>(
-        _ name: String,
-        _ dataType: DatabaseSchema.DataType? = nil,
-        _ constraints: DatabaseSchema.FieldConstraint...
-    ) -> Nested
-        where Nested: AnyModel
+public struct NestedPath: ExpressibleByStringLiteral {
+    public var path: [String]
+    public init(path: [String]) {
+        self.path = path
+    }
+    public init(stringLiteral value: String) {
+        self.path = value.split(separator: ".").map(String.init)
+    }
+    
+}
+extension QueryBuilder {
+    public func filter<Value, NestedValue>(
+        _ key: Model.FieldKey<Value>,
+        _ path: NestedPath,
+        _ method: DatabaseQuery.Filter.Method,
+        _ value: NestedValue
+    ) -> Self
+        where Value: NestedProperty, Value: Codable, NestedValue: Codable
     {
-        let storage = NestedModelStorage(
-            name: name,
-            base: self,
-            dataType: dataType,
-            constraints: constraints
-        )
-        return .init(storage: storage)
+        let base = Model.field(forKey: key)
+        let field: DatabaseQuery.Field = .field(path: [base.name] + path.path, entity: Model.entity, alias: nil)
+        return self.filter(field, method, .bind(value))
     }
 }
 
-extension NestedModel {
-    public var property: ModelProperty {
-        return NestedProperty(entity: self)
-    }
-}
-
-// MARK: Private
-
-private struct NestedOutput: DatabaseOutput {
-    let name: String
-    let base: DatabaseOutput
-    init(name: String, _ base: DatabaseOutput) {
-        self.name = name
-        self.base = base
-    }
-    
-    var description: String {
-        return self.base.description
-    }
-    
-    func decode<T>(field: String, as type: T.Type) throws -> T where T: Decodable {
-        let base = try self.base.decode(
-            field: self.name,
-            as: DecoderUnwrapper.self
-        )
-        let decoder = try base.decoder.container(keyedBy: StringCodingKey.self)
-        return try decoder.decode(T.self, forKey: .init(field))
-    }
-}
-
-private struct NestedModelStorage: ModelStorage {
-    let name: String
-    let base: AnyModel
-    let dataType: DatabaseSchema.DataType?
-    let constraints: [DatabaseSchema.FieldConstraint]
-    
-    var path: [String] {
-        return self.base.storage.path + [self.name]
-    }
-    
-    var output: DatabaseOutput? {
-        return self.base.storage.output.flatMap { output in
-            return NestedOutput(name: self.name, output)
-        }
-    }
-    
-    var input: [String: DatabaseQuery.Value] {
-        get {
-            switch self.base.storage.input[self.name] {
-            case .none: return [:]
-            case .some(let some):
-                switch some {
-                case .dictionary(let dict): return dict
-                default: return [:]
-                }
-            }
-        }
-        set { self.base.storage.input[self.name] = .dictionary(newValue) }
-    }
-    
-    var eagerLoads: [String: EagerLoad] {
-        get { return self.base.storage.eagerLoads }
-        set { self.base.storage.eagerLoads = newValue }
-    }
-    
-    var exists: Bool {
-        get { return self.base.storage.exists }
-        set { self.base.storage.exists = newValue }
-    }
-}
-
-private struct NestedProperty<Nested>: ModelProperty
-    where Nested: NestedModel
-{
-    let entity: Nested
-    
-    init(entity: Nested) {
-        self.entity = entity
-    }
-    
-    public var name: String {
-        guard let storage = self.entity.storage as? NestedModelStorage else {
-            fatalError()
-        }
-        return storage.name
-    }
-    
-    var dataType: DatabaseSchema.DataType? {
-        guard let storage = self.entity.storage as? NestedModelStorage else {
-            fatalError()
-        }
-        return storage.dataType
-    }
-    
-    var constraints: [DatabaseSchema.FieldConstraint] {
-        guard let storage = self.entity.storage as? NestedModelStorage else {
-            fatalError()
-        }
-        return storage.constraints
-    }
-    
-    public var type: Any.Type {
-        return Nested.self
-    }
-    
-    func encode(to encoder: inout ModelEncoder) throws {
-        try encoder.encode(self.entity, forKey: self.name)
-    }
-    
-    func decode(from decoder: ModelDecoder) throws {
-        let model = try decoder.decode(Nested.self, forKey: self.name)
-        self.entity.storage = model.storage
-    }
-}
+//
+//
+//extension Model {
+//    public func set<ParentType>(_ key: Self.ParentKey<ParentType>, to parent: ParentType) throws
+//        where ParentType: Model
+//    {
+//        try self.set(Self.fields[keyPath: key].id, to: parent.get(\.id))
+//    }
+//
+//    public func get<ParentType>(_ key: Self.ParentKey<ParentType>) throws -> ParentType
+//        where ParentType: Model
+//    {
+//        guard let cache = self.storage.eagerLoads[ParentType.entity] else {
+//            fatalError("No cache set on storage.")
+//        }
+//        return try cache.get(id: self.get(Self.fields[keyPath: key].id))
+//            .map { $0 as! ParentType }
+//            .first!
+//    }
+//}
+//extension AnyModel {
+//    public func nested<Nested>(
+//        _ name: String,
+//        _ dataType: DatabaseSchema.DataType? = nil,
+//        _ constraints: DatabaseSchema.FieldConstraint...
+//    ) -> Nested
+//        where Nested: AnyModel
+//    {
+//        let storage = NestedModelStorage(
+//            name: name,
+//            base: self,
+//            dataType: dataType,
+//            constraints: constraints
+//        )
+//        return .init(storage: storage)
+//    }
+//}
+//
+//extension NestedModel {
+//    public var property: ModelProperty {
+//        return NestedProperty(entity: self)
+//    }
+//}
+//
+//// MARK: Private
+//
+//private struct NestedOutput: DatabaseOutput {
+//    let name: String
+//    let base: DatabaseOutput
+//    init(name: String, _ base: DatabaseOutput) {
+//        self.name = name
+//        self.base = base
+//    }
+//
+//    var description: String {
+//        return self.base.description
+//    }
+//
+//    func decode<T>(field: String, as type: T.Type) throws -> T where T: Decodable {
+//        let base = try self.base.decode(
+//            field: self.name,
+//            as: DecoderUnwrapper.self
+//        )
+//        let decoder = try base.decoder.container(keyedBy: StringCodingKey.self)
+//        return try decoder.decode(T.self, forKey: .init(field))
+//    }
+//}
+//
+//private struct NestedModelStorage: ModelStorage {
+//    let name: String
+//    let base: AnyModel
+//    let dataType: DatabaseSchema.DataType?
+//    let constraints: [DatabaseSchema.FieldConstraint]
+//
+//    var path: [String] {
+//        return self.base.storage.path + [self.name]
+//    }
+//
+//    var output: DatabaseOutput? {
+//        return self.base.storage.output.flatMap { output in
+//            return NestedOutput(name: self.name, output)
+//        }
+//    }
+//
+//    var input: [String: DatabaseQuery.Value] {
+//        get {
+//            switch self.base.storage.input[self.name] {
+//            case .none: return [:]
+//            case .some(let some):
+//                switch some {
+//                case .dictionary(let dict): return dict
+//                default: return [:]
+//                }
+//            }
+//        }
+//        set { self.base.storage.input[self.name] = .dictionary(newValue) }
+//    }
+//
+//    var eagerLoads: [String: EagerLoad] {
+//        get { return self.base.storage.eagerLoads }
+//        set { self.base.storage.eagerLoads = newValue }
+//    }
+//
+//    var exists: Bool {
+//        get { return self.base.storage.exists }
+//        set { self.base.storage.exists = newValue }
+//    }
+//}
+//
+//private struct NestedProperty<Nested>: ModelProperty
+//    where Nested: NestedModel
+//{
+//    let entity: Nested
+//
+//    init(entity: Nested) {
+//        self.entity = entity
+//    }
+//
+//    public var name: String {
+//        guard let storage = self.entity.storage as? NestedModelStorage else {
+//            fatalError()
+//        }
+//        return storage.name
+//    }
+//
+//    var dataType: DatabaseSchema.DataType? {
+//        guard let storage = self.entity.storage as? NestedModelStorage else {
+//            fatalError()
+//        }
+//        return storage.dataType
+//    }
+//
+//    var constraints: [DatabaseSchema.FieldConstraint] {
+//        guard let storage = self.entity.storage as? NestedModelStorage else {
+//            fatalError()
+//        }
+//        return storage.constraints
+//    }
+//
+//    public var type: Any.Type {
+//        return Nested.self
+//    }
+//
+//    #warning("TODO: this needs to interface w/ model storage")
+//    public func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
+//        try encoder.encode(self.entity, forKey: self.name)
+//    }
+//
+//    public func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
+//        let model = try decoder.decode(Nested.self, forKey: self.name)
+//        self.entity.storage = model.storage
+//    }
+//}

--- a/Sources/FluentKit/Query/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/DatabaseQuery.swift
@@ -8,17 +8,6 @@ public struct DatabaseQuery {
     }
     
     public enum Field {
-        static func keyPath<M, T>(_ key: KeyPath<M, ModelField<M, T>>) -> Field
-            where M: Model
-        {
-            let model = M()
-            return .field(
-                path: [model[keyPath: key].name],
-                entity: model.entity,
-                alias: nil
-            )
-        }
-        
         public enum Aggregate {
             public enum Method {
                 case count

--- a/Sources/FluentKit/Relation/ModelChildren.swift
+++ b/Sources/FluentKit/Relation/ModelChildren.swift
@@ -1,39 +1,67 @@
-public struct ModelChildren<Parent, Child>
-    where Parent: FluentKit.Model, Child: FluentKit.Model
+public struct ModelChildren<Parent, Child>: ModelProperty
+    where Child: Model, Parent: Model
 {
-    let parent: Parent
-    let relation: KeyPath<Child, ModelParent<Child, Parent>>
+    public let id: ModelField<Child, Parent.ID>
     
-    init(parent: Parent, relation: KeyPath<Child, ModelParent<Child, Parent>>) {
-        self.parent = parent
-        self.relation = relation
+    public var name: String {
+        return self.id.name
     }
     
-    public func query(on database: Database) throws -> QueryBuilder<Child> {
-        let field = Child()[keyPath: self.relation].id
-        return try database.query(Child.self).filter(
-            .field(path: [field.name], entity: Child().entity, alias: nil),
-            .equality(inverse: false),
-            .bind(self.parent.id.get())
-        )
+    public var type: Any.Type {
+        return self.id.type
     }
     
-    public func get() throws -> [Child] {
-        guard let cache = self.parent.storage.eagerLoads[Child().entity] else {
-            fatalError("No cache set on storage.")
-        }
-        return try cache.get(id: self.parent.id.get())
-            .map { $0 as! Child }
+    public var dataType: DatabaseSchema.DataType? {
+        return self.id.dataType
+    }
+    
+    public var constraints: [DatabaseSchema.FieldConstraint] {
+        return self.id.constraints
+    }
+    
+    public init(id: ModelField<Child, Parent.ID>) {
+        self.id = id
+    }
+    
+    public func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
+        #warning("TODO: fixme")
+    }
+    
+    public func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
+        #warning("TODO: fixme")
     }
 }
 
+
+
 extension Model {
-    public typealias Children<Model> = ModelChildren<Self, Model>
-        where Model: FluentKit.Model
+    public typealias Children<ChildType> = ModelChildren<Self, ChildType>
+        where ChildType: Model
     
-    public func children<Model>(_ relation: KeyPath<Model, ModelParent<Model, Self>>) -> Children<Model>
-        where Model: FluentKit.Model
+    
+    public typealias ChildrenKey<ChildType> = KeyPath<Self.Properties, Children<ChildType>>
+        where ChildType: Model
+    
+    
+    public static func children<T>(forKey key: ChildrenKey<T>) -> Children<T> {
+        return self.properties[keyPath: key]
+    }
+    
+    public func query<Child>(_ key: Self.ChildrenKey<Child>, on database: Database) throws -> QueryBuilder<Child>
+        where Child: Model
     {
-        return .init(parent: self, relation: relation)
+        let children = Self.children(forKey: key)
+        return try database.query(Child.self)
+            .filter(children.id, .equals, self.get(\.id))
+    }
+    
+    public func get<Child>(_ key: Self.ChildrenKey<Child>) throws -> [Child]
+        where Child: Model
+    {
+        guard let cache = self.storage.eagerLoads[Child.entity] else {
+            fatalError("No cache set on storage.")
+        }
+        return try cache.get(id: self.get(\.id))
+            .map { $0 as! Child }
     }
 }

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -23,11 +23,11 @@ public final class SchemaBuilder<Model> where Model: FluentKit.Model {
     
     public init(database: Database) {
         self.database = database
-        self.schema = .init(entity: Model().entity)
+        self.schema = .init(entity: Model.entity)
     }
     
     public func auto() -> Self {
-        self.schema.createFields = Model().properties.map { field in
+        self.schema.createFields = Model.properties.all.map { field in
             var constraints = field.constraints
             let type: Any.Type
             if let optionalType = field.type as? OptionalType.Type {
@@ -47,8 +47,10 @@ public final class SchemaBuilder<Model> where Model: FluentKit.Model {
         return self
     }
     
-    public func field<Value>(_ keyPath: KeyPath<Model, ModelField<Model, Value>>) -> Self {
-        let field = Model()[keyPath: keyPath]
+    public func field<Value>(_ key: Model.FieldKey<Value>) -> Self
+        where Value: Codable
+    {
+        let field = Model.field(forKey: key)
         return self.field(.definition(
             name: .string(field.name),
             dataType: field.dataType ?? .bestFor(type: Value.self),
@@ -61,36 +63,33 @@ public final class SchemaBuilder<Model> where Model: FluentKit.Model {
         return self
     }
     
-    public func unique<A>(
-        on a: KeyPath<Model, ModelField<Model, A>>
-    ) -> Self {
-        let a = Model()[keyPath: a]
+    public func unique<A>(on a: Model.FieldKey<A>) -> Self
+        where A: Codable
+    {
+        let a = Model.field(forKey: a)
         self.schema.constraints.append(.unique(fields: [
             .string(a.name)
         ]))
         return self
     }
     
-    public func unique<A, B>(
-        on a: KeyPath<Model, ModelField<Model, A>>,
-        _ b: KeyPath<Model, ModelField<Model, B>>
-    ) -> Self {
-        let a = Model()[keyPath: a]
-        let b = Model()[keyPath: b]
+    public func unique<A, B>(on a: Model.FieldKey<A>, _ b: Model.FieldKey<B>) -> Self
+        where A: Codable, B: Codable
+    {
+        let a = Model.field(forKey: a)
+        let b = Model.field(forKey: b)
         self.schema.constraints.append(.unique(fields: [
             .string(a.name), .string(b.name)
         ]))
         return self
     }
     
-    public func unique<A, B, C>(
-        on a: KeyPath<Model, ModelField<Model, A>>,
-        _ b: KeyPath<Model, ModelField<Model, B>>,
-        _ c: KeyPath<Model, ModelField<Model, C>>
-    ) -> Self {
-        let a = Model()[keyPath: a]
-        let b = Model()[keyPath: b]
-        let c = Model()[keyPath: c]
+    public func unique<A, B, C>(on a: Model.FieldKey<A>, _ b: Model.FieldKey<B>,_ c: Model.FieldKey<C>) -> Self
+        where A: Codable, B: Codable, C: Codable
+    {
+        let a = Model.field(forKey: a)
+        let b = Model.field(forKey: b)
+        let c = Model.field(forKey: c)
         self.schema.constraints.append(.unique(fields: [
             .string(a.name), .string(b.name), .string(c.name)
         ]))


### PR DESCRIPTION
This PR moves model properties to being a static, nested struct on the model. This makes declaring models more concise since fields can be declared as one-liners and all properties can be derived automatically using `Mirror` (since properties are now stored). This change should also reduce allocations required while building queries since Model field information is available statically, and we don't need to initialize a reference model for key path resolution.

### Before 

```swift
final class Planet: Model {
    var storage: Storage
    
    var properties: [Property] {
        return [id, name, galaxy]
    }
    
    var entity: String {
        return "planets"
    }
    
    var id: Field<Int> {
        return self.field("id")
    }
    
    var name: Field<String> {
        return self.field("name")
    }
    
    var galaxy: Parent<Galaxy> {
        return self.parent("galaxyID")
    }
    
    init(storage: Storage) {
        self.storage = storage
    }
}

let planet = Planet()
let name = try planet.name.get()
planet.name.set(to: "Earth")
```

### After

```swift
final class Planet: Model {
    struct Properties: ModelProperties {
        let id = Field<Int>("id")
        let name = Field<String>("name")
        let galaxy = Parent<Galaxy>(id: Field("galaxyID"))
    }
    static let entity = "planets"
    static let properties = Properties()
    var storage: Storage
    init(storage: Storage) {
        self.storage = storage
    }
}

let planet = Planet()
let name = try planet.get(\.name)
planet.set(\.name, to: "Earth")
```