### PR TITLE
early row output validation

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -37,10 +37,10 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration()
         ]) {
             let galaxy = Galaxy.new()
-            galaxy.set(\.name, to: "Messier")
-            try galaxy.mut(\.name) { $0 += " 82" }
+            galaxy[\.name] = "Messier"
+            galaxy[\.name] += " 82"
             try galaxy.save(on: self.database).wait()
-            guard try galaxy.get(\.id) == 1 else {
+            guard galaxy[\.id] == 1 else {
                 throw Failure("unexpected galaxy id: \(galaxy)")
             }
             
@@ -48,10 +48,10 @@ public final class FluentBenchmarker {
                 throw Failure("unexpected empty result set")
             }
             
-            if try fetched.get(\.name) != galaxy.get(\.name) {
+            if fetched[\.name] != galaxy[\.name] {
                 throw Failure("unexpected name: \(galaxy) \(fetched)")
             }
-            if try fetched.get(\.id) != galaxy.get(\.id) {
+            if fetched[\.id] != galaxy[\.id] {
                 throw Failure("unexpected id: \(galaxy) \(fetched)")
             }
         }
@@ -68,7 +68,7 @@ public final class FluentBenchmarker {
                 else {
                     throw Failure("unpexected missing galaxy")
             }
-            guard try milkyWay.get(\.name) == "Milky Way" else {
+            guard milkyWay[\.name] == "Milky Way" else {
                 throw Failure("unexpected name")
             }
         }
@@ -79,9 +79,9 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration()
         ]) {
             let galaxy = Galaxy.new()
-            galaxy.set(\.name, to: "Milkey Way")
+            galaxy[\.name] = "Milkey Way"
             try galaxy.save(on: self.database).wait()
-            galaxy.set(\.name, to: "Milky Way")
+            galaxy[\.name] = "Milky Way"
             try galaxy.save(on: self.database).wait()
             
             // verify
@@ -89,7 +89,7 @@ public final class FluentBenchmarker {
             guard galaxies.count == 1 else {
                 throw Failure("unexpected galaxy count: \(galaxies)")
             }
-            guard try galaxies[0].get(\.name) == "Milky Way" else {
+            guard galaxies[0][\.name] == "Milky Way" else {
                 throw Failure("unexpected galaxy name")
             }
         }
@@ -100,7 +100,7 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration(),
         ]) {
             let galaxy = Galaxy.new()
-            galaxy.set(\.name, to: "Milky Way")
+            galaxy[\.name] = "Milky Way"
             try galaxy.save(on: self.database).wait()
             try galaxy.delete(on: self.database).wait()
             
@@ -125,12 +125,12 @@ public final class FluentBenchmarker {
 
             for galaxy in galaxies {
                 let planets = try galaxy.get(\.planets)
-                switch try galaxy.get(\.name) {
+                switch galaxy[\.name] {
                 case "Milky Way":
-                    guard try planets.contains(where: { try $0.get(\.name) == "Earth" }) else {
+                    guard planets.contains(where: { $0[\.name] == "Earth" }) else {
                         throw Failure("unexpected missing planet")
                     }
-                    guard try !planets.contains(where: { try $0.get(\.name) == "PA-99-N2"}) else {
+                    guard !planets.contains(where: { $0[\.name] == "PA-99-N2"}) else {
                         throw Failure("unexpected planet")
                     }
                 default: break
@@ -312,17 +312,15 @@ public final class FluentBenchmarker {
                 .join(\.galaxy)
                 .all().wait()
             for planet in planets {
-                let galaxy = planet.joined(Galaxy.self)
-                let planetName = try planet.get(\.name)
-                let galaxyName = try galaxy.get(\.name)
-                switch planetName {
+                let galaxy = try planet.joined(Galaxy.self)
+                switch planet[\.name] {
                 case "Earth":
-                    guard galaxyName == "Milky Way" else {
-                        throw Failure("unexpected galaxy name: \(galaxyName)")
+                    guard galaxy[\.name] == "Milky Way" else {
+                        throw Failure("unexpected galaxy name: \(galaxy[\.name])")
                     }
                 case "PA-99-N2":
-                    guard galaxyName == "Andromeda" else {
-                        throw Failure("unexpected galaxy name: \(galaxyName)")
+                    guard galaxy[\.name] == "Andromeda" else {
+                        throw Failure("unexpected galaxy name: \(galaxy[\.name])")
                     }
                 default: break
                 }
@@ -492,7 +490,7 @@ public final class FluentBenchmarker {
     
     public func testNullifyField() throws {
         final class Foo: Model {
-            static let `default` = Foo()
+            static let shared = Foo()
             let id = Field<Int>("id")
             let bar = Field<String?>("bar")
         }
@@ -565,7 +563,7 @@ public final class FluentBenchmarker {
     
     public func testUniqueFields() throws {
         final class Foo: Model {
-            static let `default` = Foo()
+            static let shared = Foo()
             let id = Field<Int>("id")
             let bar = Field<String>("bar")
             let baz = Field<Int>("baz")

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -152,13 +152,13 @@ public final class FluentBenchmarker {
             
             for planet in planets {
                 let galaxy = try planet.get(\.galaxy)
-                switch try planet.get(\.name) {
+                switch planet[\.name] {
                 case "Earth":
-                    guard try galaxy.get(\.name) == "Milky Way" else {
+                    guard galaxy[\.name] == "Milky Way" else {
                         throw Failure("unexpected galaxy name: \(galaxy)")
                     }
                 case "PA-99-N2":
-                    guard try galaxy.get(\.name) == "Andromeda" else {
+                    guard galaxy[\.name] == "Andromeda" else {
                         throw Failure("unexpected galaxy name: \(galaxy)")
                     }
                 default: break
@@ -180,13 +180,13 @@ public final class FluentBenchmarker {
             
             for planet in planets {
                 let galaxy = try planet.get(\.galaxy)
-                switch try planet.get(\.name) {
+                switch planet[\.name] {
                 case "Earth":
-                    guard try galaxy.get(\.name) == "Milky Way" else {
+                    guard galaxy[\.name] == "Milky Way" else {
                         throw Failure("unexpected galaxy name: \(galaxy)")
                     }
                 case "PA-99-N2":
-                    guard try galaxy.get(\.name) == "Andromeda" else {
+                    guard galaxy[\.name] == "Andromeda" else {
                         throw Failure("unexpected galaxy name: \(galaxy)")
                     }
                 default: break
@@ -334,7 +334,7 @@ public final class FluentBenchmarker {
         ]) {
             let galaxies = Array("abcdefghijklmnopqrstuvwxyz").map { letter -> Galaxy.Row in
                 let galaxy = Galaxy.new()
-                galaxy.set(\.name, to: String(letter))
+                galaxy[\.name] = .init(letter)
                 return galaxy
             }
                 
@@ -356,8 +356,7 @@ public final class FluentBenchmarker {
             
             let galaxies = try self.database.query(Galaxy.self).all().wait()
             for galaxy in galaxies {
-                
-                guard try galaxy.get(\.name) == "Foo" else {
+                guard galaxy[\.name] == "Foo" else {
                     throw Failure("batch update did not set id")
                 }
             }
@@ -376,13 +375,13 @@ public final class FluentBenchmarker {
             guard let user = users.first, users.count == 1 else {
                 throw Failure("unexpected user count")
             }
-            guard try user.get(\.name) == "Tanner" else {
+            guard user[\.name] == "Tanner" else {
                 throw Failure("unexpected user name")
             }
-            guard try user.get(\.pet).name == "Ziz" else {
+            guard user[\.pet].name == "Ziz" else {
                 throw Failure("unexpected pet name")
             }
-            guard try user.get(\.pet).type == .cat else {
+            guard user[\.pet].type == .cat else {
                 throw Failure("unexpected pet type")
             }
 
@@ -465,24 +464,23 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration(),
         ]) {
             let galaxy = Galaxy.new()
-            galaxy.set(\.name, to: "Milky Way")
-            guard (try? galaxy.get(\.id)) == nil else {
+            galaxy[\.name] = "Milky Way"
+            guard galaxy.has(\.id) else {
                 throw Failure("id should not be set")
             }
             try galaxy.save(on: self.database).wait()
-            _ = try galaxy.get(\.id)
-            
-            
+            print(galaxy[\.id])
+
             let a = Galaxy.new()
-            a.set(\.name, to: "A")
+            a[\.name] = "A"
             let b = Galaxy.new()
-            b.set(\.name, to: "B")
+            b[\.name] = "B"
             let c = Galaxy.new()
-            c.set(\.name, to: "c")
+            c[\.name] = "c"
             try a.save(on: self.database).wait()
             try b.save(on: self.database).wait()
             try c.save(on: self.database).wait()
-            guard try a.get(\.id) != b.get(\.id) && b.get(\.id) != c.get(\.id) && a.get(\.id) != c.get(\.id) else {
+            guard a[\.id] != b[\.id] && b[\.id] != c[\.id] && a[\.id] != c[\.id] else {
                 throw Failure("ids should not be equal")
             }
         }
@@ -498,24 +496,24 @@ public final class FluentBenchmarker {
             Foo.autoMigration(),
         ]) {
             let foo = Foo.new()
-            foo.set(\.bar, to: "test")
+            foo[\.bar] = "test"
             try foo.save(on: self.database).wait()
-            guard try foo.get(\.bar) != nil else {
+            guard foo[\.bar] != nil else {
                 throw Failure("unexpected nil value")
             }
-            foo.set(\.bar, to: nil)
+            foo[\.bar] = nil
             try foo.save(on: self.database).wait()
-            guard try foo.get(\.bar) == nil else {
+            guard foo[\.bar] == nil else {
                 throw Failure("unexpected non-nil value")
             }
             
             guard let fetched = try self.database.query(Foo.self)
-                .filter(\.id == foo.get(\.id))
+                .filter(\.id == foo[\.id])
                 .first().wait()
             else {
                 throw Failure("no model returned")
             }
-            guard try fetched.get(\.bar) == nil else {
+            guard fetched[\.bar] == nil else {
                 throw Failure("unexpected non-nil value")
             }
         }
@@ -531,7 +529,7 @@ public final class FluentBenchmarker {
             try self.database.transaction { database -> EventLoopFuture<Void> in
                 let saves = (1...512).map { i -> EventLoopFuture<Void> in
                     let galaxy = Galaxy.new()
-                    galaxy.set(\.name, to: "Milky Way \(i)")
+                    galaxy[\.name] = "Milky Way \(i)"
                     return galaxy.save(on: database)
                 }
                 return .andAllSucceed(saves, on: database.eventLoop)
@@ -569,8 +567,8 @@ public final class FluentBenchmarker {
             let baz = Field<Int>("baz")
             static func new(bar: String, baz: Int) -> Row {
                 let new = self.new()
-                new.set(\.bar, to: bar)
-                new.set(\.baz, to: baz)
+                new[\.bar] = bar
+                new[\.baz] = baz
                 return new
             }
         }
@@ -608,9 +606,9 @@ public final class FluentBenchmarker {
             Galaxy.autoMigration()
         ]) {
             let a = Galaxy.new()
-            a.set(\.name, to: "a")
+            a[\.name] = "a"
             let b = Galaxy.new()
-            b.set(\.name, to: String("b"))
+            b[\.name] = .init("b")
             _ = try a.save(on: self.database).and(b.save(on: self.database)).wait()
             let galaxies = try self.database.query(Galaxy.self).all().wait()
             guard galaxies.count == 2 else {

--- a/Sources/FluentBenchmark/Galaxy.swift
+++ b/Sources/FluentBenchmark/Galaxy.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 struct Galaxy: Model {
-    static let `default` = Galaxy()
+    static let shared = Galaxy()
     let id = Field<Int>("id")
     let name = Field<String>("name")
     let planets = Children<Planet>(id: .init("galaxyID"))

--- a/Sources/FluentBenchmark/GalaxySeed.swift
+++ b/Sources/FluentBenchmark/GalaxySeed.swift
@@ -6,7 +6,7 @@ final class GalaxySeed: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         let saves = ["Andromeda", "Milky Way", "Messier 82"].map { name -> EventLoopFuture<Void> in
             let galaxy = Galaxy.new()
-            galaxy.set(\.name, to: name)
+            galaxy[\.name] = name
             return galaxy.save(on: database)
         }
         return .andAllSucceed(saves, on: database.eventLoop)

--- a/Sources/FluentBenchmark/Planet.swift
+++ b/Sources/FluentBenchmark/Planet.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 final class Planet: Model {
-    static let `default` = Planet()
+    static let shared = Planet()
     let id = Field<Int>("id")
     let name = Field<String>("name")
     let galaxy = Parent<Galaxy>(id: Field("galaxyID"))

--- a/Sources/FluentBenchmark/PlanetSeed.swift
+++ b/Sources/FluentBenchmark/PlanetSeed.swift
@@ -18,7 +18,7 @@ final class PlanetSeed: Migration {
             }
             let saves = planets.map { name -> EventLoopFuture<Void> in
                 let planet = Planet.new()
-                planet.set(\.name, to: name)
+                planet[\.name] = name
                 try! planet.set(\.galaxy, to: galaxy)
                 return planet.save(on: database)
             }

--- a/Sources/FluentBenchmark/User.swift
+++ b/Sources/FluentBenchmark/User.swift
@@ -10,7 +10,7 @@ final class User: Model {
     }
     
     static let entity = "users"
-    static let `default` = User()
+    static let shared = User()
     
     let id = Field<Int>("id")
     let name = Field<String>("name")
@@ -23,12 +23,12 @@ final class UserSeed: Migration {
     
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         let tanner = User.new()
-        tanner.set(\.name, to: "Tanner")
-        tanner.set(\.pet, to: .init(name: "Ziz", type: .cat))
+        tanner[\.name] = "Tanner"
+        tanner[\.pet] = .init(name: "Ziz", type: .cat)
 
         let logan = User.new()
-        logan.set(\.name, to: "Logan")
-        logan.set(\.pet, to: .init(name: "Runa", type: .dog))
+        logan[\.name] = "Logan"
+        logan[\.pet] = .init(name: "Runa", type: .dog)
         
         return logan.save(on: database)
             .and(tanner.save(on: database))

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -5,7 +5,7 @@ import Foundation
 /// when the app boots. It is also used to determine which migrations to revert when
 /// using the `RevertCommand`.
 public struct MigrationLog: Model {
-    public static var `default` = MigrationLog()
+    public static var shared = MigrationLog()
     public static var entity = "fluent"
     public let id = Field<Int>("id")
     public let name = Field<String>("name")

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -136,19 +136,19 @@ public struct Migrator {
     
     private func lastBatchNumber() -> EventLoopFuture<Int> {
         #warning("TODO: use db sorting")
-        return self.databases.default().query(MigrationLog.self).all().flatMapThrowing { logs in
-            return try logs.sorted(by: { try $0.get(\.batch) > $1.get(\.batch) })
-                .first?.get(\.batch) ?? 0
+        return self.databases.default().query(MigrationLog.self).all().map { logs in
+            return logs.sorted(by: { $0[\.batch] > $1[\.batch] })
+                .first?[\.batch] ?? 0
         }
     }
     
     private func preparedMigrations() -> EventLoopFuture<[Migrations.Item]> {
-        return self.databases.default().query(MigrationLog.self).all().flatMapThrowing { logs -> [Migrations.Item] in
-            return try logs.compactMap { log in
-                if let item = try self.migrations.storage.filter({ try $0.migration.name == log.get(\.name) }).first {
+        return self.databases.default().query(MigrationLog.self).all().map { logs -> [Migrations.Item] in
+            return logs.compactMap { log in
+                if let item = self.migrations.storage.filter({ $0.migration.name == log[\.name] }).first {
                     return item
                 } else {
-                    try print("No registered migration found for \(log.get(\.name))")
+                    print("No registered migration found for \(log[\.name])")
                     return nil
                 }
             }.reversed()
@@ -156,12 +156,12 @@ public struct Migrator {
     }
     
     private func preparedMigrations(batch: Int) -> EventLoopFuture<[Migrations.Item]> {
-        return self.databases.default().query(MigrationLog.self).filter(\.batch == batch).all().flatMapThrowing { logs -> [Migrations.Item] in
-            return try logs.compactMap { log in
-                if let item = try self.migrations.storage.filter({ try $0.migration.name == log.get(\.name) }).first {
+        return self.databases.default().query(MigrationLog.self).filter(\.batch == batch).all().map { logs -> [Migrations.Item] in
+            return logs.compactMap { log in
+                if let item = self.migrations.storage.filter({ $0.migration.name == log[\.name] }).first {
                     return item
                 } else {
-                    try print("No registered migration found for \(log.get(\.name))")
+                    print("No registered migration found for \(log[\.name])")
                     return nil
                 }
             }.reversed()
@@ -169,9 +169,9 @@ public struct Migrator {
     }
     
     private func unpreparedMigrations() -> EventLoopFuture<[Migrations.Item]> {
-        return self.databases.default().query(MigrationLog.self).all().flatMapThrowing { logs -> [Migrations.Item] in
-            return try self.migrations.storage.compactMap { item in
-                if try logs.filter({ try $0.get(\.name) == item.migration.name }).count == 0 {
+        return self.databases.default().query(MigrationLog.self).all().map { logs -> [Migrations.Item] in
+            return self.migrations.storage.compactMap { item in
+                if logs.filter({ $0[\.name] == item.migration.name }).count == 0 {
                     return item
                 } else {
                     // log found, this has been prepared

--- a/Sources/FluentKit/Model/ModelField.swift
+++ b/Sources/FluentKit/Model/ModelField.swift
@@ -17,8 +17,9 @@ public struct ModelField<Model, Value>: ModelProperty
 //        return self.model.storage.path + [self.name]
 //    }
 
-    public let dataType: DatabaseSchema.DataType?
-    
+    internal let dataType: DatabaseSchema.DataType?
+
+    #warning("TODO: auto migrate")
     struct Interface: Codable {
         let name: String
     }
@@ -32,13 +33,55 @@ public struct ModelField<Model, Value>: ModelProperty
         self.dataType = dataType
         self.constraints = constraints
     }
+
+    func cached(from output: DatabaseOutput) throws -> Any? {
+        return try output.decode(field: self.name, as: Value.self)
+    }
     
-    public func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
+    func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
         try encoder.encode(storage.get(self.name, as: Value.self), forKey: self.name)
     }
 
-    public func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
+    func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
         try storage.set(self.name, to: decoder.decode(Value.self, forKey: self.name))
+    }
+}
+
+
+extension ModelRow {
+    public subscript<Value>(_ field: Model.FieldKey<Value>) -> Value
+        where Value: Codable
+    {
+        get {
+            return self.get(field)
+        }
+        set {
+            return self.set(field, to: newValue)
+        }
+    }
+
+    func get<Value>(_ key: Model.FieldKey<Value>) -> Value
+        where Value: Codable
+    {
+        return self.get(Model.field(forKey: key))
+    }
+
+    func get<Value>(_ field: Model.Field<Value>) -> Value
+        where Value: Codable
+    {
+        return self.storage.get(field.name)
+    }
+
+    func set<Value>(_ key: Model.FieldKey<Value>, to value: Value)
+        where Value: Codable
+    {
+        self.set(Model.field(forKey: key), to: value)
+    }
+
+    func set<Value>(_ field: Model.Field<Value>, to value: Value)
+        where Value: Codable
+    {
+        self.storage.set(field.name, to: value)
     }
 }
 

--- a/Sources/FluentKit/Model/ModelField.swift
+++ b/Sources/FluentKit/Model/ModelField.swift
@@ -60,6 +60,12 @@ extension ModelRow {
         }
     }
 
+    public func has<Value>(_ field: Model.FieldKey<Value>) -> Bool
+        where Value: Codable
+    {
+        return self.storage.cachedOutput[Model.field(forKey: field).name] != nil
+    }
+
     func get<Value>(_ key: Model.FieldKey<Value>) -> Value
         where Value: Codable
     {

--- a/Sources/FluentKit/Model/ModelProperty.swift
+++ b/Sources/FluentKit/Model/ModelProperty.swift
@@ -1,10 +1,11 @@
-public protocol ModelProperty {
+protocol ModelProperty {
     var name: String { get }
     var type: Any.Type { get }
     
     var dataType: DatabaseSchema.DataType? { get }
     var constraints: [DatabaseSchema.FieldConstraint] { get }
-    
+
+    func cached(from output: DatabaseOutput) throws -> Any?
     func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws
     func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws
 }

--- a/Sources/FluentKit/Model/ModelRow.swift
+++ b/Sources/FluentKit/Model/ModelRow.swift
@@ -6,20 +6,21 @@ public final class ModelRow<Model>: Codable, CustomStringConvertible
         return self.storage.exists
     }
     
-    public var storage: ModelStorage
+    var storage: ModelStorage
     
-    public init(storage: ModelStorage) {
+    init(storage: ModelStorage) throws {
         self.storage = storage
+        try self.storage.cacheOutput(for: Model.self)
     }
     
-    public convenience init() {
-        self.init(storage: DefaultModelStorage(output: nil, eagerLoads: [:], exists: false))
+    public init() {
+        self.storage = DefaultModelStorage(output: nil, eagerLoads: [:], exists: false)
     }
     
     public convenience init(from decoder: Decoder) throws {
         let decoder = try ModelDecoder(decoder: decoder)
         self.init()
-        for field in Model.default.all {
+        for field in Model.shared.all {
             do {
                 try field.decode(from: decoder, to: &self.storage)
             } catch {
@@ -30,7 +31,7 @@ public final class ModelRow<Model>: Codable, CustomStringConvertible
     
     public func encode(to encoder: Encoder) throws {
         var encoder = ModelEncoder(encoder: encoder)
-        for property in Model.default.all {
+        for property in Model.shared.all {
             try property.encode(to: &encoder, from: self.storage)
         }
     }

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -19,7 +19,7 @@ public final class QueryBuilder<Model>
         self.database = database
         self.query = .init(entity: Model.entity)
         self.eagerLoads = [:]
-        self.query.fields = Model.default.all.map { .field(
+        self.query.fields = Model.shared.all.map { .field(
             path: [$0.name],
             entity: Model.entity,
             alias: nil
@@ -59,7 +59,7 @@ public final class QueryBuilder<Model>
     public func join<Parent>(_ key: Model.ParentKey<Parent>) -> Self
         where Parent: FluentKit.Model
     {
-        return self.join(Parent.default.id, to: Model.parent(forKey: key).id, method: .inner)
+        return self.join(Parent.shared.id, to: Model.parent(forKey: key).id, method: .inner)
     }
     
     @discardableResult
@@ -75,7 +75,7 @@ public final class QueryBuilder<Model>
     public func join<Foreign, Value>(_ foreign: Foreign.Field<Value>, to local: Model.Field<Value>, method: DatabaseQuery.Join.Method = .inner) -> Self
         where Foreign: FluentKit.Model, Value: Codable
     {
-        self.query.fields += Foreign.default.all.map {
+        self.query.fields += Foreign.shared.all.map {
             return .field(
                 path: [$0.name],
                 entity: Foreign.entity,
@@ -268,7 +268,7 @@ public final class QueryBuilder<Model>
     public func run(_ onOutput: @escaping (Model.Row) throws -> ()) -> EventLoopFuture<Void> {
         var all: [Model.Row] = []
         return self.database.execute(self.query) { output in
-            let model = Model.Row.init(storage: DefaultModelStorage(
+            let model = try Model.Row.init(storage: DefaultModelStorage(
                 output: output,
                 eagerLoads: self.eagerLoads,
                 exists: true

--- a/Sources/FluentKit/Relation/ModelChildren.swift
+++ b/Sources/FluentKit/Relation/ModelChildren.swift
@@ -7,11 +7,11 @@ public struct ModelChildren<Parent, Child>
         self.id = id
     }
     
-    public func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
+    func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
         #warning("TODO: fixme")
     }
     
-    public func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
+    func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
         #warning("TODO: fixme")
     }
 }
@@ -28,17 +28,17 @@ extension Model {
     
     
     public static func children<T>(forKey key: ChildrenKey<T>) -> Children<T> {
-        return self.default[keyPath: key]
+        return self.shared[keyPath: key]
     }
 }
 
 extension ModelRow {
-    public func query<Child>(_ key: Model.ChildrenKey<Child>, on database: Database) throws -> QueryBuilder<Child>
+    public func query<Child>(_ key: Model.ChildrenKey<Child>, on database: Database) -> QueryBuilder<Child>
         where Child: FluentKit.Model
     {
         let children = Model.children(forKey: key)
-        return try database.query(Child.self)
-            .filter(children.id, .equals, self.get(\.id))
+        return database.query(Child.self)
+            .filter(children.id, .equals, self[\.id])
     }
     
     public func get<Child>(_ key: Model.ChildrenKey<Child>) throws -> [Child.Row]

--- a/Sources/FluentKit/Relation/ModelParent.swift
+++ b/Sources/FluentKit/Relation/ModelParent.swift
@@ -22,8 +22,12 @@ public struct ModelParent<Child, Parent>: ModelProperty
     public init(id: Child.Field<Parent.ID>) {
         self.id = id
     }
+
+    func cached(from output: DatabaseOutput) throws -> Any? {
+        return nil
+    }
     
-    public func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
+    func encode(to encoder: inout ModelEncoder, from storage: ModelStorage) throws {
         if let cache = storage.eagerLoads[Parent.entity] {
             let parent = try cache.get(id: storage.get(self.id.name, as: Parent.ID.self))
                 .map { $0 as! Parent.Row }
@@ -34,7 +38,7 @@ public struct ModelParent<Child, Parent>: ModelProperty
         }
     }
     
-    public func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
+    func decode(from decoder: ModelDecoder, to storage: inout ModelStorage) throws {
         try self.id.decode(from: decoder, to: &storage)
     }
 }
@@ -47,7 +51,7 @@ extension Model {
         where ParentType: Model
     
     public static func parent<T>(forKey key: ParentKey<T>) -> Parent<T> {
-        return self.default[keyPath: key]
+        return self.shared[keyPath: key]
     }
 }
 

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -27,10 +27,10 @@ public final class SchemaBuilder<Model> where Model: FluentKit.Model {
     }
     
     public func auto() -> Self {
-        self.schema.createFields = Model.default.all.map { field in
+        self.schema.createFields = Model.shared.all.map { field in
             var constraints = field.constraints
             let type: Any.Type
-            if field.name == Model.default.id.name {
+            if field.name == Model.shared.id.name {
                 constraints.append(.identifier)
                 type = field.type
             } else {


### PR DESCRIPTION
This PR adds logic to validate a `Row`'s `DatabaseOutput` early, before the user attempts to fetch the properties. This allows for the properties to be fetched without throwing, since we know they have already been validated (or were omitted from the result set). If a property is accessed that was omitted from the result set, a `fatalError` will occur. 

More importantly, this PR will set the foundation for us to conform `Row` to `@dynamicMemberLookup` as computed properties cannot throw. 