### PR TITLE
first try at splitting id functionality

### DIFF
--- a/Sources/FluentKit/Model/Schema.swift
+++ b/Sources/FluentKit/Model/Schema.swift
@@ -1,0 +1,67 @@
+public protocol AnySchema: class, Codable {
+    init()
+}
+
+public protocol Schema: AnySchema {
+    associatedtype IDValue: Codable, Hashable
+
+    var id: IDValue? { get set }
+}
+
+extension AnySchema {
+    // MARK: Codable
+
+    public init(from decoder: Decoder) throws {
+        self.init()
+        let container = try decoder.container(keyedBy: _ModelCodingKey.self)
+        try self.properties.forEach { label, property in
+            let decoder = try container.superDecoder(forKey: .string(label))
+            try property.decode(from: decoder)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: _ModelCodingKey.self)
+        try self.properties.forEach { label, property in
+            let encoder = container.superEncoder(forKey: .string(label))
+            try property.encode(to: encoder)
+        }
+    }
+}
+
+extension Schema {
+    static func key<Field>(for field: KeyPath<Self, Field>) -> String
+        where Field: Filterable
+    {
+        return Self.init()[keyPath: field].key
+    }
+}
+
+extension Schema {
+    var _$id: ID<IDValue> {
+        self.anyID as! ID<IDValue>
+    }
+
+    @available(*, deprecated, message: "use init")
+    static var reference: Self {
+        return self.init()
+    }
+}
+
+extension AnySchema {
+    var anyID: AnyID {
+        guard let id = Mirror(reflecting: self).descendant("_id") else {
+            fatalError("id property must be declared using @ID")
+        }
+        return id as! AnyID
+    }
+}
+
+extension Schema {
+    public func requireID() throws -> IDValue {
+        guard let id = self.id else {
+            throw FluentError.idRequired
+        }
+        return id
+    }
+}

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -45,7 +45,9 @@ extension AnyModel {
             return (label, field)
         }
     }
-    
+}
+
+extension AnySchema {
     var properties: [(String, AnyProperty)] {
         return Mirror(reflecting: self)
             .children


### PR DESCRIPTION
I made a first try at splitting the id and field functionality from the database query functionality of model. Could be interesting, let me know what you think @tanner0101 

Some context: 
The idea here is to split the database related functionality of the `Model` protocol from the property wrappers around fields and the id property. I've done this by wrapping these in a protocol called `Schema` for now. This would be useful when working with third-party RESTful API's for example or in a microservices setup. 