### PR TITLE
@Parent.get id fix

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -38,6 +38,7 @@ public final class FluentBenchmarker {
         try self.testUUIDModel()
         try self.testNewModelDecode()
         try self.testSiblingsAttach()
+        try self.testParentGet()
     }
     
     public func testCreate() throws {
@@ -1133,6 +1134,32 @@ public final class FluentBenchmarker {
                 case "Jupiter":
                     XCTAssertEqual(planet.galaxy.name, "Milky Way")
                     XCTAssertEqual(planet.tags.map { $0.name }, ["Gas Giant"])
+                default: break
+                }
+            }
+        }
+    }
+
+    public func testParentGet() throws {
+        // seeded db
+        try runTest(#function, [
+            GalaxyMigration(),
+            GalaxySeed(),
+            PlanetMigration(),
+            PlanetSeed(),
+        ]) {
+            let planets = try Planet.query(on: self.database)
+                .all().wait()
+
+            for planet in planets {
+                let galaxy = try planet.$galaxy.get(on: self.database).wait()
+                switch planet.name {
+                case "Earth":
+                    XCTAssertEqual(galaxy.name, "Milky Way")
+                case "PA-99-N2":
+                    XCTAssertEqual(galaxy.name, "Andromeda")
+                case "Jupiter":
+                    XCTAssertEqual(galaxy.name, "Milky Way")
                 default: break
                 }
             }

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -42,7 +42,7 @@ public final class Parent<To>: AnyField, AnyEagerLoadable
 
     public func query(on database: Database) -> QueryBuilder<To> {
         return To.query(on: database)
-            .filter(self.key, .equal, self.id)
+            .filter(\._$id == self.id)
     }
 
     public func get(on database: Database) -> EventLoopFuture<To> {


### PR DESCRIPTION
Fixes a bug that caused `@Parent.get` to use the incorrect key when generating a query builder for the related parent. This affected both `@Parent.query` and `@Parent.get`. 