### PR TITLE
@Children serialization fix

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -1166,6 +1166,23 @@ public final class FluentBenchmarker {
         }
     }
 
+    public func testParentSerialization() throws {
+        // seeded db
+        try runTest(#function, [
+            GalaxyMigration(),
+            GalaxySeed(),
+            PlanetMigration(),
+            PlanetSeed(),
+        ]) {
+            let galaxies = try Galaxy.query(on: self.database)
+                .all().wait()
+
+            let json = try JSONEncoder().encode(galaxies)
+            let string = String(decoding: json, as: UTF8.self)
+            print(string)
+        }
+    }
+
     // MARK: Utilities
     
     struct Failure: Error {

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -1211,6 +1211,7 @@ public final class FluentBenchmarker {
 
             let encoded = try JSONEncoder().encode(galaxies)
             print(String(decoding: encoded, as: UTF8.self))
+            
             let decoded = try JSONDecoder().decode([GalaxyJSON].self, from: encoded)
             XCTAssertEqual(galaxies.map { $0.id }, decoded.map { $0.id })
             XCTAssertEqual(galaxies.map { $0.name }, decoded.map { $0.name })


### PR DESCRIPTION
Non-eagerload `@Children` relations were serializing as an empty container. This PR introduces a lazy encoder/decoder wrapper that ensures empty containers will not be created where serialization is not desired. 