### PR TITLE
modified schema setup proposal for migrations

### DIFF
--- a/Sources/FluentBenchmark/Planet.swift
+++ b/Sources/FluentBenchmark/Planet.swift
@@ -24,9 +24,11 @@ final class Planet: Model {
     }
 }
 
-struct PlanetMigration: Migration {
+struct PlanetMigration: GenericMigration {
+    typealias MigrationModel = Planet
+    
     func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("planets")
+        return schema(for: database)
             .field("id", .int, .identifier(auto: true))
             .field("name", .string, .required)
             .field("galaxy_id", .int, .required)
@@ -34,7 +36,7 @@ struct PlanetMigration: Migration {
     }
 
     func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("planets").delete()
+        return schema(for: database).delete()
     }
 }
 

--- a/Sources/FluentKit/Migration/Migration.swift
+++ b/Sources/FluentKit/Migration/Migration.swift
@@ -11,6 +11,16 @@ extension Migration {
     
 }
 
+public protocol GenericMigration: Migration {
+    associatedtype MigrationModel: Model
+}
+
+extension GenericMigration {
+    public func schema(for database: Database) -> SchemaBuilder {
+        database.schema(MigrationModel.schema)
+    }
+}
+
 //extension Model {
 //    public static func autoMigration() -> Migration {
 //        return AutoMigration<Self>()

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -112,4 +112,9 @@ public struct DatabaseSchema {
         self.deleteFields = []
         self.constraints = []
     }
+    
+    public init<M>(model: M.Type) where M: Model {
+        self.init(schema: model.schema)
+    }
+    
 }

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -4,6 +4,10 @@ extension Database {
     public func schema(_ schema: String) -> SchemaBuilder {
         return .init(database: self, schema: schema)
     }
+    
+    public func schema<M>(_ model: M.Type) -> SchemaBuilder where M: Model {
+        return .init(database: self, schema: model.schema)
+    }
 }
 
 public final class SchemaBuilder {


### PR DESCRIPTION
I would like to remove the need to hard code schema strings in three places when using migrations (Model x1, Migration 2x)
https://github.com/vapor/api-template/blob/946c8cc967e522b39f4b26979e9b52a40c1c6ca2/Sources/App/Migrations/CreateTodo.swift#L5

The `GenericMigration` is there just temporarily to show what I am trying to achieve. I just couldn't come up with a better name.
