### PR TITLE
Model middleware

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -889,10 +889,10 @@ public final class FluentBenchmarker {
                 }
             }
             
-            func delete(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
+            func delete(model: User, force: Bool, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "G"
                 
-                return next.handle(.softDelete, model, on: db).flatMap {
+                return next.handle(.delete(force), model, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didDelete"))
                 }
             }

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -860,7 +860,7 @@ public final class FluentBenchmarker {
             func create(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "B"
                 
-                return next.handle(.create, model, on: db).flatMap {
+                return next.create(model, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didCreate"))
                 }
             }
@@ -868,7 +868,7 @@ public final class FluentBenchmarker {
             func update(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "D"
                 
-                return next.handle(.update, model, on: db).flatMap {
+                return next.update(model, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didUpdate"))
                 }
             }
@@ -876,7 +876,7 @@ public final class FluentBenchmarker {
             func softDelete(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "E"
                 
-                return next.handle(.softDelete, model, on: db).flatMap {
+                return next.softDelete(model, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didSoftDelete"))
                 }
             }
@@ -884,7 +884,7 @@ public final class FluentBenchmarker {
             func restore(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "F"
                 
-                return next.handle(.restore, model , on: db).flatMap {
+                return next.restore(model , on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didRestore"))
                 }
             }
@@ -892,7 +892,7 @@ public final class FluentBenchmarker {
             func delete(model: User, force: Bool, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "G"
                 
-                return next.handle(.delete(force), model, on: db).flatMap {
+                return next.delete(model, force: force, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didDelete"))
                 }
             }

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -860,7 +860,7 @@ public final class FluentBenchmarker {
             func create(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "B"
                 
-                return next.handle(event: .create, model: model, on: db).flatMap {
+                return next.handle(.create, model, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didCreate"))
                 }
             }
@@ -868,7 +868,7 @@ public final class FluentBenchmarker {
             func update(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "D"
                 
-                return next.handle(event: .update, model: model, on: db).flatMap {
+                return next.handle(.update, model, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didUpdate"))
                 }
             }
@@ -876,7 +876,7 @@ public final class FluentBenchmarker {
             func softDelete(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "E"
                 
-                return next.handle(event: .softDelete, model: model, on: db).flatMap {
+                return next.handle(.softDelete, model, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didSoftDelete"))
                 }
             }
@@ -884,7 +884,7 @@ public final class FluentBenchmarker {
             func restore(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "F"
                 
-                return next.handle(event: .restore, model: model , on: db).flatMap {
+                return next.handle(.restore, model , on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didRestore"))
                 }
             }
@@ -892,7 +892,7 @@ public final class FluentBenchmarker {
             func delete(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
                 model.name = "G"
                 
-                return next.handle(event: .softDelete, model: model, on: db).flatMap {
+                return next.handle(.softDelete, model, on: db).flatMap {
                     return db.eventLoop.makeFailedFuture(TestError(string: "didDelete"))
                 }
             }

--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -3,13 +3,30 @@ public enum EventLoopPreference {
     case delegate(on: EventLoop)
 }
 
+public class DatabaseContext {
+    internal var middleware: [AnyModelMiddleware]
+    
+    init() {
+        self.middleware = []
+    }
+    
+    public func use(middleware: AnyModelMiddleware) {
+        self.middleware.append(middleware)
+    }
+}
+
 public protocol Database {
     var driver: DatabaseDriver { get }
     var logger: Logger { get }
     var eventLoopPreference: EventLoopPreference { get }
+    var context: DatabaseContext { get }
 }
 
 private struct DriverOverrideDatabase: Database {
+    var context: DatabaseContext {
+        return self.base.context
+    }
+    
     var logger: Logger {
         return self.base.logger
     }
@@ -18,7 +35,7 @@ private struct DriverOverrideDatabase: Database {
         return self.base.eventLoopPreference
     }
     
-    let base: Database
+    var base: Database
     let driver: DatabaseDriver
     
     init(base: Database, driver: DatabaseDriver) {

--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -35,7 +35,7 @@ private struct DriverOverrideDatabase: Database {
         return self.base.eventLoopPreference
     }
     
-    var base: Database
+    let base: Database
     let driver: DatabaseDriver
     
     init(base: Database, driver: DatabaseDriver) {

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -14,7 +14,7 @@ public final class Databases {
         as id: DatabaseID,
         isDefault: Bool = true
     ) {
-        let db = BasicDatabase(driver: driver, logger: logger)
+        let db = BasicDatabase(context: DatabaseContext(), driver: driver, logger: logger)
         self.storage[id] = db
         if isDefault {
             self._default = db
@@ -37,6 +37,8 @@ public final class Databases {
 }
 
 private struct BasicDatabase: Database {
+    var context: DatabaseContext
+    
     var eventLoopPreference: EventLoopPreference {
         return .indifferent
     }

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -14,7 +14,7 @@ public final class Databases {
         as id: DatabaseID,
         isDefault: Bool = true
     ) {
-        let db = BasicDatabase(context: DatabaseContext(), driver: driver, logger: logger)
+        let db = BasicDatabase(driver: driver, logger: logger, context: DatabaseContext())
         self.storage[id] = db
         if isDefault {
             self._default = db
@@ -37,12 +37,11 @@ public final class Databases {
 }
 
 private struct BasicDatabase: Database {
-    var context: DatabaseContext
-    
     var eventLoopPreference: EventLoopPreference {
         return .indifferent
     }
 
     let driver: DatabaseDriver
     let logger: Logger
+    let context: DatabaseContext
 }

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -6,96 +6,101 @@ extension Model {
             return self.create(on: database)
         }
     }
-
+    
     public func create(on database: Database) -> EventLoopFuture<Void> {
+        let responder = BasicModelResponder { (_, _, db) in self._create(on: db) }
+        return database.context.middleware.makeResponder(chainingTo: responder)
+            .handle(event: .create, model: self, on: database)
+    }
+    
+    private func _create(on database: Database) -> EventLoopFuture<Void> {
         self.touchTimestamps(.create, .update)
         precondition(!self._$id.exists)
-        return self.willCreate(on: database).flatMap {
-            self._$id.generate()
-            let promise = database.eventLoop.makePromise(of: DatabaseOutput.self)
-            Self.query(on: database)
-                .set(self.input)
-                .action(.create)
-                .run { promise.succeed($0) }
-                .cascadeFailure(to: promise)
-            return promise.futureResult.flatMapThrowing { output in
-                var input = self.input
-                if self._$id.generator == .database {
-                    let id = try output.decode("fluentID", as: Self.IDValue.self)
-                    input[Self.key(for: \._$id)] = .bind(id)
-                }
-                try self.output(from: SavedInput(input).output(for: database))
+        self._$id.generate()
+        let promise = database.eventLoop.makePromise(of: DatabaseOutput.self)
+        Self.query(on: database)
+            .set(self.input)
+            .action(.create)
+            .run { promise.succeed($0) }
+            .cascadeFailure(to: promise)
+        return promise.futureResult.flatMapThrowing { output in
+            var input = self.input
+            if self._$id.generator == .database {
+                let id = try output.decode("fluentID", as: Self.IDValue.self)
+                input[Self.key(for: \._$id)] = .bind(id)
             }
-        }.flatMap {
-            return self.didCreate(on: database)
+            try self.output(from: SavedInput(input).output(for: database))
         }
     }
-
+    
     public func update(on database: Database) -> EventLoopFuture<Void> {
+        let responder = BasicModelResponder { (_, _, db) in self._update(on: db) }
+        return database.context.middleware.makeResponder(chainingTo: responder)
+            .handle(event: .update, model: self, on: database)
+    }
+    
+    private func _update(on database: Database) -> EventLoopFuture<Void> {
         self.touchTimestamps(.update)
         precondition(self._$id.exists)
-
-        return self.willUpdate(on: database).flatMap {
-            let input = self.input
-            return Self.query(on: database)
-                .filter(\._$id == self.id!)
-                .set(input)
-                .action(.update)
-                .run()
-                .flatMapThrowing {
-                    try self.output(from: SavedInput(input).output(for: database))
-                }
-        }.flatMap {
-            return self.didUpdate(on: database)
+        let input = self.input
+        return Self.query(on: database)
+            .filter(\._$id == self.id!)
+            .set(input)
+            .action(.update)
+            .run()
+            .flatMapThrowing {
+                try self.output(from: SavedInput(input).output(for: database))
         }
     }
-
+    
     public func delete(force: Bool = false, on database: Database) -> EventLoopFuture<Void> {
         if !force, let timestamp = self.timestamps.filter({ $0.1.trigger == .delete }).first {
             timestamp.1.touch()
-            return self.willSoftDelete(on: database).flatMap {
-                return self.update(on: database)
-            }.flatMap {
-                return self.didSoftDelete(on: database)
-            }
+            let responder = BasicModelResponder { (_, _, db) in self._update(on: db) }
+            return database.context.middleware.makeResponder(chainingTo: responder)
+                .handle(event: .softDelete, model: self, on: database)
         } else {
-            return self.willDelete(on: database).flatMap {
-                let query = Self.query(on: database)
-                if force {
-                    _ = query.withDeleted()
-                }
-                return query
-                    .filter(\._$id == self.id!)
-                    .action(.delete)
-                    .run()
-                    .map {
-                        self._$id.exists = false
-                    }
-            }.flatMap {
-                return self.didDelete(on: database)
-            }
+            let responder = BasicModelResponder { (_, _, db) in self._delete(force: force, on: db) }
+            return database.context.middleware.makeResponder(chainingTo: responder)
+                .handle(event: .delete, model: self, on: database)
         }
     }
-
+    
+    private func _delete(force: Bool = false, on database: Database) -> EventLoopFuture<Void> {
+        let query = Self.query(on: database)
+        if force {
+            _ = query.withDeleted()
+        }
+        return query
+            .filter(\._$id == self.id!)
+            .action(.delete)
+            .run()
+            .map {
+                self._$id.exists = false
+        }
+    }
+    
     public func restore(on database: Database) -> EventLoopFuture<Void> {
+        let responder = BasicModelResponder { (_, _, db) in self._restore(on: db) }
+        return database.context.middleware.makeResponder(chainingTo: responder)
+            .handle(event: .restore, model: self, on: database)
+    }
+    
+    private func _restore(on database: Database) -> EventLoopFuture<Void> {
         guard let timestamp = self.timestamps.filter({ $0.1.trigger == .delete }).first else {
             fatalError("no delete timestamp on this model")
         }
         timestamp.1.touch(date: nil)
         precondition(self._$id.exists)
-        return self.willRestore(on: database).flatMap {
-            return Self.query(on: database)
-                .withDeleted()
-                .filter(\._$id == self.id!)
-                .set(self.input)
-                .action(.update)
-                .run()
-                .flatMapThrowing {
-                    try self.output(from: SavedInput(self.input).output(for: database))
-                    self._$id.exists = true
-                }
-        }.flatMap {
-            return self.didRestore(on: database)
+        return Self.query(on: database)
+            .withDeleted()
+            .filter(\._$id == self.id!)
+            .set(self.input)
+            .action(.update)
+            .run()
+            .flatMapThrowing {
+                try self.output(from: SavedInput(self.input).output(for: database))
+                self._$id.exists = true
         }
     }
 }
@@ -106,28 +111,20 @@ extension Array where Element: FluentKit.Model {
         self.forEach { model in
             precondition(!model._$id.exists)
         }
-        return EventLoopFuture<Void>.andAllSucceed(
-            self.map { $0.willCreate(on: database) },
-            on: database.eventLoop
-        ).flatMap {
-            self.forEach {
-                $0._$id.generate()
-                $0.touchTimestamps(.create)
-                $0.touchTimestamps(.update)
-            }
-            builder.set(self.map { $0.input })
-            builder.query.action = .create
-            var it = self.makeIterator()
-            return builder.run { created in
-                let next = it.next()!
-                next._$id.exists = true
-            }
-        }.flatMap {
-            return EventLoopFuture<Void>.andAllSucceed(
-                self.map { $0.didCreate(on: database) },
-                on: database.eventLoop
-            )
+        
+        self.forEach {
+            $0._$id.generate()
+            $0.touchTimestamps(.create)
+            $0.touchTimestamps(.update)
         }
+        builder.set(self.map { $0.input })
+        builder.query.action = .create
+        var it = self.makeIterator()
+        return builder.run { created in
+            let next = it.next()!
+            next._$id.exists = true
+        }
+        
     }
 }
 
@@ -136,15 +133,15 @@ extension Array where Element: FluentKit.Model {
 
 private struct SavedInput: DatabaseRow {
     var input: [String: DatabaseQuery.Value]
-
+    
     init(_ input: [String: DatabaseQuery.Value]) {
         self.input = input
     }
-
+    
     func contains(field: String) -> Bool {
         return self.input[field] != nil
     }
-
+    
     func decode<T>(field: String, as type: T.Type, for database: Database) throws -> T where T : Decodable {
         if let value = self.input[field] {
             // not in output, get from saved input
@@ -158,7 +155,7 @@ private struct SavedInput: DatabaseRow {
             throw FluentError.missingField(name: field)
         }
     }
-
+    
     var description: String {
         return self.input.description
     }

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -57,7 +57,7 @@ extension Model {
         if !force, let timestamp = self.timestamps.filter({ $0.1.trigger == .delete }).first {
             timestamp.1.touch()
             return database.context.middleware.chainingTo { event, model, db in
-                self.update(on: db)
+                self._update(on: db)
             }.handle(event: .softDelete, model: self, on: database)
         } else {
             return database.context.middleware.chainingTo { event, model, db in

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -10,7 +10,7 @@ extension Model {
     public func create(on database: Database) -> EventLoopFuture<Void> {
         return database.context.middleware.chainingTo { event, model, db in
             self._create(on: db)
-        }.handle(event: .create, model: self, on: database)
+        }.handle(.create, self, on: database)
     }
     
     private func _create(on database: Database) -> EventLoopFuture<Void> {
@@ -36,7 +36,7 @@ extension Model {
     public func update(on database: Database) -> EventLoopFuture<Void> {
         return database.context.middleware.chainingTo { event, model, db in
             self._update(on: db)
-        }.handle(event: .update, model: self, on: database)
+        }.handle(.update, self, on: database)
     }
     
     private func _update(on database: Database) -> EventLoopFuture<Void> {
@@ -58,11 +58,11 @@ extension Model {
             timestamp.1.touch()
             return database.context.middleware.chainingTo { event, model, db in
                 self._update(on: db)
-            }.handle(event: .softDelete, model: self, on: database)
+            }.handle(.softDelete, self, on: database)
         } else {
             return database.context.middleware.chainingTo { event, model, db in
                 self._delete(force: force, on: db)
-            }.handle(event: .delete, model: self, on: database)
+            }.handle(.delete, self, on: database)
         }
     }
     
@@ -83,7 +83,7 @@ extension Model {
     public func restore(on database: Database) -> EventLoopFuture<Void> {
         return database.context.middleware.chainingTo { event, model, db in
             self._restore(on: db)
-        }.handle(event: .restore, model: self, on: database)
+        }.handle(.restore, self, on: database)
     }
     
     private func _restore(on database: Database) -> EventLoopFuture<Void> {

--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -12,23 +12,6 @@ public protocol Model: AnyModel {
     associatedtype IDValue: Codable, Hashable
 
     var id: IDValue? { get set }
-
-    // MARK: Lifecycle
-
-    func willCreate(on database: Database) -> EventLoopFuture<Void>
-    func didCreate(on database: Database) -> EventLoopFuture<Void>
-
-    func willUpdate(on database: Database) -> EventLoopFuture<Void>
-    func didUpdate(on database: Database) -> EventLoopFuture<Void>
-
-    func willDelete(on database: Database) -> EventLoopFuture<Void>
-    func didDelete(on database: Database) -> EventLoopFuture<Void>
-
-    func willRestore(on database: Database) -> EventLoopFuture<Void>
-    func didRestore(on database: Database) -> EventLoopFuture<Void>
-
-    func willSoftDelete(on database: Database) -> EventLoopFuture<Void>
-    func didSoftDelete(on database: Database) -> EventLoopFuture<Void>
 }
 
 extension AnyModel {
@@ -283,42 +266,5 @@ extension Model {
         return Self.query(on: database)
             .filter(\._$id == id)
             .first()
-    }
-}
-
-extension Model {
-    public func willCreate(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-    public func didCreate(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-
-    public func willUpdate(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-    public func didUpdate(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-
-    public func willDelete(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-    public func didDelete(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-
-    public func willRestore(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-    public func didRestore(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-
-    public func willSoftDelete(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
-    }
-    public func didSoftDelete(on database: Database) -> EventLoopFuture<Void> {
-        return database.eventLoop.makeSucceededFuture(())
     }
 }

--- a/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
@@ -1,5 +1,5 @@
 public protocol AnyModelMiddleware {
-    func handle(event: ModelEvent, model: AnyModel, on db: Database, chainingTo next: AnyModelResponder) -> EventLoopFuture<Void>
+    func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database, chainingTo next: AnyModelResponder) -> EventLoopFuture<Void>
 }
 
 public protocol ModelMiddleware: AnyModelMiddleware {
@@ -13,9 +13,9 @@ public protocol ModelMiddleware: AnyModelMiddleware {
 }
 
 extension ModelMiddleware {
-    public func handle(event: ModelEvent, model: AnyModel, on db: Database, chainingTo next: AnyModelResponder) -> EventLoopFuture<Void> {
+    public func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database, chainingTo next: AnyModelResponder) -> EventLoopFuture<Void> {
         guard let modelType = model as? Model else {
-            return next.handle(event: event, model: model, on: db)
+            return next.handle(event, model, on: db)
         }
         
         switch event {
@@ -33,23 +33,23 @@ extension ModelMiddleware {
     }
     
     public func create(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(event: .create, model: model, on: db)
+        return next.handle(.create, model, on: db)
     }
     
     public func update(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(event: .update, model: model, on: db)
+        return next.handle(.update, model, on: db)
     }
     
     public func delete(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(event: .delete, model: model, on: db)
+        return next.handle(.delete, model, on: db)
     }
     
     public func softDelete(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(event: .softDelete, model: model, on: db)
+        return next.handle(.softDelete, model, on: db)
     }
     
     public func restore(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(event: .restore, model: model, on: db)
+        return next.handle(.restore, model, on: db)
     }
 }
 
@@ -73,8 +73,8 @@ private struct ModelMiddlewareResponder: AnyModelResponder {
     var middleware: AnyModelMiddleware
     var responder: AnyModelResponder
     
-    func handle(event: ModelEvent, model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
-        return self.middleware.handle(event: event, model: model, on: db, chainingTo: responder)
+    func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+        return self.middleware.handle(event, model, on: db, chainingTo: responder)
     }
 }
 

--- a/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
@@ -31,6 +31,26 @@ extension ModelMiddleware {
             return self.restore(model: modelType, on: db, next: next)
         }
     }
+    
+    public func create(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
+        return next.handle(event: .create, model: model, on: db)
+    }
+    
+    public func update(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
+        return next.handle(event: .update, model: model, on: db)
+    }
+    
+    public func delete(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
+        return next.handle(event: .delete, model: model, on: db)
+    }
+    
+    public func softDelete(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
+        return next.handle(event: .softDelete, model: model, on: db)
+    }
+    
+    public func restore(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
+        return next.handle(event: .restore, model: model, on: db)
+    }
 }
 
 extension AnyModelMiddleware {

--- a/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
@@ -1,0 +1,67 @@
+public protocol AnyModelMiddleware {
+    func handle(event: ModelEvent, model: AnyModel, on db: Database, chainingTo next: AnyModelResponder) -> EventLoopFuture<Void>
+}
+
+public protocol ModelMiddleware: AnyModelMiddleware {
+    associatedtype Model: FluentKit.Model
+    
+    func create(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void>
+    func update(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void>
+    func delete(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void>
+    func softDelete(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void>
+    func restore(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void>
+}
+
+extension ModelMiddleware {
+    public func handle(event: ModelEvent, model: AnyModel, on db: Database, chainingTo next: AnyModelResponder) -> EventLoopFuture<Void> {
+        guard let modelType = model as? Model else {
+            return next.handle(event: event, model: model, on: db)
+        }
+        
+        switch event {
+        case .create:
+            return self.create(model: modelType, on: db, next: next)
+        case .update:
+            return self.update(model: modelType, on: db, next: next)
+        case .delete:
+            return self.delete(model: modelType, on: db, next: next)
+        case .softDelete:
+            return self.softDelete(model: modelType, on: db, next: next)
+        case .restore:
+            return self.restore(model: modelType, on: db, next: next)
+        }
+    }
+}
+
+extension AnyModelMiddleware {
+    func makeResponder(chainingTo responder: AnyModelResponder) -> AnyModelResponder {
+        return ModelMiddlewareResponder(middleware: self, responder: responder)
+    }
+}
+
+extension Array where Element == AnyModelMiddleware {
+    public func makeResponder(chainingTo responder: AnyModelResponder) -> AnyModelResponder {
+        var responder = responder
+        for middleware in reversed() {
+            responder = middleware.makeResponder(chainingTo: responder)
+        }
+        return responder
+    }
+}
+
+private struct ModelMiddlewareResponder: AnyModelResponder {
+    var middleware: AnyModelMiddleware
+    var responder: AnyModelResponder
+    
+    func handle(event: ModelEvent, model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+        return self.middleware.handle(event: event, model: model, on: db, chainingTo: responder)
+    }
+}
+
+public enum ModelEvent {
+    case create
+    case update
+    case delete
+    case restore
+    case softDelete
+}

--- a/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
@@ -40,8 +40,8 @@ extension AnyModelMiddleware {
 }
 
 extension Array where Element == AnyModelMiddleware {
-    public func makeResponder(chainingTo responder: AnyModelResponder) -> AnyModelResponder {
-        var responder = responder
+    internal func chainingTo(closure: @escaping BasicModelResponderClosure) -> AnyModelResponder {
+        var responder: AnyModelResponder = BasicModelResponder(handle: closure)
         for middleware in reversed() {
             responder = middleware.makeResponder(chainingTo: responder)
         }

--- a/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelMiddleware.swift
@@ -20,36 +20,36 @@ extension ModelMiddleware {
         
         switch event {
         case .create:
-            return self.create(model: modelType, on: db, next: next)
+            return create(model: modelType, on: db, next: next)
         case .update:
-            return self.update(model: modelType, on: db, next: next)
+            return update(model: modelType, on: db, next: next)
         case .delete(let force):
-            return self.delete(model: modelType, force: force, on: db, next: next)
+            return delete(model: modelType, force: force, on: db, next: next)
         case .softDelete:
-            return self.softDelete(model: modelType, on: db, next: next)
+            return softDelete(model: modelType, on: db, next: next)
         case .restore:
-            return self.restore(model: modelType, on: db, next: next)
+            return restore(model: modelType, on: db, next: next)
         }
     }
     
     public func create(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(.create, model, on: db)
+        return next.create(model, on: db)
     }
     
     public func update(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(.update, model, on: db)
+        return next.update(model, on: db)
     }
     
     public func delete(model: Model, force: Bool, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(.delete(force), model, on: db)
+        return next.delete(model, force: force, on: db)
     }
     
     public func softDelete(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(.softDelete, model, on: db)
+        return next.softDelete(model, on: db)
     }
     
     public func restore(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
-        return next.handle(.restore, model, on: db)
+        return next.restore(model, on: db)
     }
 }
 
@@ -61,7 +61,7 @@ extension AnyModelMiddleware {
 
 extension Array where Element == AnyModelMiddleware {
     internal func chainingTo<Model>(_ type: Model.Type, closure: @escaping (ModelEvent, Model, Database) throws -> EventLoopFuture<Void>) -> AnyModelResponder where Model: FluentKit.Model {
-        var responder: AnyModelResponder = ModelResponder(handle: closure)
+        var responder: AnyModelResponder = BasicModelResponder(handle: closure)
         for middleware in reversed() {
             responder = middleware.makeResponder(chainingTo: responder)
         }

--- a/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
@@ -1,5 +1,5 @@
 public protocol AnyModelResponder {
-    func handle(event: ModelEvent, model: AnyModel, on db: Database) -> EventLoopFuture<Void>
+    func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void>
 }
 
 internal typealias BasicModelResponderClosure = (ModelEvent, AnyModel, Database) throws -> EventLoopFuture<Void>
@@ -7,7 +7,7 @@ internal typealias BasicModelResponderClosure = (ModelEvent, AnyModel, Database)
 internal struct BasicModelResponder: AnyModelResponder {
     private let _handle: BasicModelResponderClosure
     
-    public func handle(event: ModelEvent, model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+    public func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
         do {
             return try _handle(event, model, db)
         } catch {

--- a/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
@@ -2,8 +2,10 @@ public protocol AnyModelResponder {
     func handle(event: ModelEvent, model: AnyModel, on db: Database) -> EventLoopFuture<Void>
 }
 
-public struct BasicModelResponder: AnyModelResponder {
-    private let _handle: (ModelEvent, AnyModel, Database) throws -> EventLoopFuture<Void>
+internal typealias BasicModelResponderClosure = (ModelEvent, AnyModel, Database) throws -> EventLoopFuture<Void>
+
+internal struct BasicModelResponder: AnyModelResponder {
+    private let _handle: BasicModelResponderClosure
     
     public func handle(event: ModelEvent, model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
         do {
@@ -13,7 +15,7 @@ public struct BasicModelResponder: AnyModelResponder {
         }
     }
     
-    init(handle: @escaping (ModelEvent, AnyModel, Database) throws -> EventLoopFuture<Void>) {
+    init(handle: @escaping BasicModelResponderClosure) {
         self._handle = handle
     }
 }

--- a/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
@@ -1,0 +1,19 @@
+public protocol AnyModelResponder {
+    func handle(event: ModelEvent, model: AnyModel, on db: Database) -> EventLoopFuture<Void>
+}
+
+public struct BasicModelResponder: AnyModelResponder {
+    private let _handle: (ModelEvent, AnyModel, Database) throws -> EventLoopFuture<Void>
+    
+    public func handle(event: ModelEvent, model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+        do {
+            return try _handle(event, model, db)
+        } catch {
+            return db.eventLoop.makeFailedFuture(error)
+        }
+    }
+    
+    init(handle: @escaping (ModelEvent, AnyModel, Database) throws -> EventLoopFuture<Void>) {
+        self._handle = handle
+    }
+}

--- a/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
@@ -2,20 +2,23 @@ public protocol AnyModelResponder {
     func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void>
 }
 
-internal typealias BasicModelResponderClosure = (ModelEvent, AnyModel, Database) throws -> EventLoopFuture<Void>
-
-internal struct BasicModelResponder: AnyModelResponder {
-    private let _handle: BasicModelResponderClosure
+internal struct ModelResponder<Model>: AnyModelResponder where Model: FluentKit.Model {
+    private let _handle: (ModelEvent, Model, Database) throws -> EventLoopFuture<Void>
     
-    public func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+    func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+        guard let modelType = model as? Model else {
+            fatalError("Could not convert type AnyModel to \(Model.self)")
+        }
+        
         do {
-            return try _handle(event, model, db)
+            return try _handle(event, modelType, db)
         } catch {
             return db.eventLoop.makeFailedFuture(error)
         }
     }
     
-    init(handle: @escaping BasicModelResponderClosure) {
+    init(handle: @escaping (ModelEvent, Model, Database) throws -> EventLoopFuture<Void>) {
         self._handle = handle
     }
 }
+

--- a/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
+++ b/Sources/FluentKit/ModelMiddleware/ModelResponder.swift
@@ -2,10 +2,32 @@ public protocol AnyModelResponder {
     func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void>
 }
 
-internal struct ModelResponder<Model>: AnyModelResponder where Model: FluentKit.Model {
+extension AnyModelResponder {
+    public func create(_ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+        return handle(.create, model, on: db)
+    }
+    
+    public func update(_ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+        return handle(.update, model, on: db)
+    }
+    
+    public func restore(_ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+        return handle(.restore, model, on: db)
+    }
+    
+    public func softDelete(_ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+        return handle(.softDelete, model, on: db)
+    }
+    
+    public func delete(_ model: AnyModel, force: Bool, on db: Database) -> EventLoopFuture<Void> {
+        return handle(.delete(force), model, on: db)
+    }
+}
+
+internal struct BasicModelResponder<Model>: AnyModelResponder where Model: FluentKit.Model {
     private let _handle: (ModelEvent, Model, Database) throws -> EventLoopFuture<Void>
     
-    func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
+    internal func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
         guard let modelType = model as? Model else {
             fatalError("Could not convert type AnyModel to \(Model.self)")
         }


### PR DESCRIPTION
This draft PR is about the idea of using model middleware instead of the current lifecycle hooks. 

This, for example, solves the issue for Vapor where you aren't able to use services inside your lifecycle hooks since you have no access to a container. These can now be injected into the Middleware class.

Feedback and contributions would be greatly appreciated, as I am sure this PR could be improved and optimized in terms of type safety or functionality. 

This is type of functionality I have so far: (along with the other Lifecycle methods)

```swift
struct TodoMiddleware: ModelMiddleware {
    func create(model: Todo, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
        // This code runs before creation. "willCreate"
        model.title = "Modified title"
        
        return next.handle(event: .create, model: model, on: db).flatMap {
            // This runs after creation: "didCreate"
            print("Created Todo with ID: \(try! model.requireID())")
            return db.eventLoop.makeSucceededFuture(())
        }
    }
}
```

Middlewares are added on a `DatabaseContext` class on a `Database` object:
`database.context.use(TodoMiddleware())`

I am not sure this is the best approach in terms of storage/naming, so any ideas here would be great!

This implementation is based on Vapor's `Middleware`, so they are very similar.
