### PR TITLE
DatabaseSchema.DataType.Enum not accessible

### DIFF
--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -61,8 +61,8 @@ public struct DatabaseSchema {
         case bool
         
         public struct Enum {
-            var name: String
-            var cases: [String]
+            public var name: String
+            public var cases: [String]
         }
         case `enum`(Enum)
         case string


### PR DESCRIPTION
In order for a driver to implement the `DataType.Enum` constraint, `name` and `cases` must be publicly accessible.