### PR TITLE
fix fatalError when two children have same key

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -45,6 +45,7 @@ public final class FluentBenchmarker {
         try self.testOptionalParent()
         try self.testFieldFilter()
         try self.testJoinedFieldFilter()
+        try self.testSameChildrenFromKey()
     }
     
     public func testCreate() throws {
@@ -1411,6 +1412,136 @@ public final class FluentBenchmarker {
                 .all()
                 .wait()
             XCTAssertEqual(averageSchools.count, 1)
+        }
+    }
+    
+    public func testSameChildrenFromKey() throws {
+        final class Foo: Model {
+            static let schema = "foos"
+
+            struct _Migration: Migration {
+                func prepare(on database: Database) -> EventLoopFuture<Void> {
+                    return database.schema("foos")
+                        .field("id", .int, .identifier(auto: true))
+                        .field("name", .string, .required)
+                        .create()
+                }
+
+                func revert(on database: Database) -> EventLoopFuture<Void> {
+                    return database.schema("foos").delete()
+                }
+            }
+            
+            @ID(key: "id")
+            var id: Int?
+
+            @Field(key: "name")
+            var name: String
+            
+            @Children(for: \.$foo)
+            var bars: [Bar]
+            
+            @Children(for: \.$foo)
+            var bazs: [Baz]
+
+            init() { }
+
+            init(id: Int? = nil, name: String) {
+                self.id = id
+                self.name = name
+            }
+        }
+        
+        final class Bar: Model {
+            static let schema = "bars"
+        
+            struct _Migration: Migration {
+                func prepare(on database: Database) -> EventLoopFuture<Void> {
+                    return database.schema("bars")
+                        .field("id", .int, .identifier(auto: true))
+                        .field("bar", .int, .required)
+                        .field("foo_id", .int, .required)
+                        .create()
+                }
+
+                func revert(on database: Database) -> EventLoopFuture<Void> {
+                    return database.schema("bars").delete()
+                }
+            }
+            
+            @ID(key: "id")
+            var id: Int?
+
+            @Field(key: "bar")
+            var bar: Int
+            
+            @Parent(key: "foo_id")
+            var foo: Foo
+            
+            init() { }
+
+            init(id: Int? = nil, bar: Int, fooID: Int) {
+                self.id = id
+                self.bar = bar
+                self.$foo.id = fooID
+            }
+        }
+        
+        final class Baz: Model {
+            static let schema = "bazs"
+        
+            struct _Migration: Migration {
+                func prepare(on database: Database) -> EventLoopFuture<Void> {
+                    return database.schema("bazs")
+                        .field("id", .int, .identifier(auto: true))
+                        .field("baz", .double, .required)
+                        .field("foo_id", .int, .required)
+                        .create()
+                }
+
+                func revert(on database: Database) -> EventLoopFuture<Void> {
+                    return database.schema("bazs").delete()
+                }
+            }
+            
+            @ID(key: "id")
+            var id: Int?
+
+            @Field(key: "baz")
+            var baz: Double
+            
+            @Parent(key: "foo_id")
+            var foo: Foo
+            
+            init() { }
+
+            init(id: Int? = nil, baz: Double, fooID: Int) {
+                self.id = id
+                self.baz = baz
+                self.$foo.id = fooID
+            }
+        }
+        try runTest(#function, [
+            Foo._Migration(),
+            Bar._Migration(),
+            Baz._Migration()
+        ]) {
+            let foo = Foo(name: "a")
+            try foo.save(on: self.database).wait()
+            let bar = Bar(bar: 42, fooID: foo.id!)
+            try bar.save(on: self.database).wait()
+            let baz = Baz(baz: 3.14, fooID: foo.id!)
+            try baz.save(on: self.database).wait()
+            
+            let foos = try Foo.query(on: self.database)
+                .with(\.$bars)
+                .with(\.$bazs)
+                .all().wait()
+            
+            for foo in foos {
+                XCTAssertEqual(foo.bars[0].bar, 42)
+                XCTAssertEqual(foo.bazs[0].baz, 3.14)
+            }
         }
     }
 

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -93,9 +93,9 @@ extension Children: AnyEagerLoadable {
         let ref = To()
         switch self.parentKey {
         case .optional(let optional):
-            return "c:" + ref[keyPath: optional].key
+            return "c:\(To.schema):\(ref[keyPath: optional].key)"
         case .required(let required):
-            return "c:" + ref[keyPath: required].key
+            return "c:\(To.schema):\(ref[keyPath: required].key)"
         }
     }
 


### PR DESCRIPTION
Fixes a fatalError that could occur if two children relations point to a parent relation with the same key. 