### PR TITLE
Don't generate bad SQL for `[].create(on: db)`

### DIFF
--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -122,6 +122,12 @@ extension Model {
 
 extension Array where Element: FluentKit.Model {
     public func create(on database: Database) -> EventLoopFuture<Void> {
+        guard self.count > 0 else {
+            // Is it valid to try to create zero models? For now we call it
+            // successful without doing anything.
+            return database.eventLoop.makeSucceededFuture(())
+        }
+        
         let builder = Element.query(on: database)
         self.forEach { model in
             precondition(!model._$id.exists)

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -207,6 +207,13 @@ final class FluentKitTests: XCTestCase {
             print(error)
         }
     }
+    
+    func testCreateEmptyModelArrayDoesntQuery() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        try [Planet2]().create(on: db).wait()
+        XCTAssertEqual(db.sqlSerializers.count, 0)
+    }
+    
 }
 
 final class Planet2: Model {

--- a/Tests/FluentKitTests/XCTestManifests.swift
+++ b/Tests/FluentKitTests/XCTestManifests.swift
@@ -6,6 +6,11 @@ extension FluentKitTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__FluentKitTests = [
+        ("testCreateEmptyModelArrayDoesntQuery", testCreateEmptyModelArrayDoesntQuery),
+        ("testDecodeMissingRequired", testDecodeMissingRequired),
+        ("testDecodeWithID", testDecodeWithID),
+        ("testDecodeWithOptional", testDecodeWithOptional),
+        ("testDecodeWithoutID", testDecodeWithoutID),
         ("testForeignKeyFieldConstraint", testForeignKeyFieldConstraint),
         ("testForeignKeyTableConstraint", testForeignKeyTableConstraint),
         ("testGalaxyPlanetNames", testGalaxyPlanetNames),


### PR DESCRIPTION
When the CRUD method `create(on:)` is invoked on an empty `Array`, the result is usually a syntactically invalid SQL query (e.g. `INSERT INTO relation (field1, field2, field3) VALUES ` for MySQL, similar for Postgres). This PR changes the behavior so that such an invocation immediately returns success without doing anything.

Why success?

- What error would we throw? What exactly failed?
- Success seems to be the more intuitive result; consider a RESTful service which considers an empty input array to be valid. If an error was thrown for this case, all such services would have to manually check for that condition. Those who want to error should still be checking for it anyway, since user input is never to be trusted.

One counterargument is that doing it this way hides failures caused by an invalid database connection or bad model type that would otherwise be caught. However, it seems like these kinds of problems will end up being caught anyway, just at a different time.