### PR TITLE
Grouped SQL Filters

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -121,7 +121,7 @@ public final class FluentBenchmarker {
             checklist.contents.append(", Fizz, Buzz")
             try checklist.save(on: self.database).wait()
 
-            let trash = try Trash.query(on: self.database).filter(\.$contents =~ "Foo").all().wait()
+            let trash = try Trash.query(on: self.database).filter(\.$contents == "Foo, Bar, Baz, Fizz, Buzz").all().wait()
             guard trash.count == 1 else {
                 throw Failure("unexpected trash count: \(trash)")
             }

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -96,17 +96,20 @@ public final class FluentBenchmarker {
         try runTest(#function, [
             GalaxyMigration()
         ]) {
-            let galaxy = Galaxy(name: "Milkey Way")
-            try galaxy.save(on: self.database).wait()
-            galaxy.name = "Milky Way"
-            try galaxy.save(on: self.database).wait()
+            let galaxy1 = Galaxy(name: "Milkey Way")
+            let galaxy2 = Galaxy(name: "Black Eye")
+            try galaxy1.save(on: self.database).wait()
+            try galaxy2.save(on: self.database).wait()
+
+            galaxy1.name = "Andromeda"
+            try galaxy1.save(on: self.database).wait()
             
             // verify
-            let galaxies = try Galaxy.query(on: self.database).filter(\.$name == "Milky Way").all().wait()
+            let galaxies = try Galaxy.query(on: self.database).filter(\.$name == "Andromeda").all().wait()
             guard galaxies.count == 1 else {
                 throw Failure("unexpected galaxy count: \(galaxies)")
             }
-            guard galaxies[0].name == "Milky Way" else {
+            guard galaxies[0].name == "Andromeda" else {
                 throw Failure("unexpected galaxy name")
             }
         }

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -112,14 +112,14 @@ public final class FluentBenchmarker {
                 throw Failure("unexpected galaxy name")
             }
 
-            let checklist = Trash(contents: "Foo, Bar, Baz")
-            let code = Trash(contents: "print(42)")
+            let checklist1 = Trash(contents: "Foo, Bar, Baz")
+            let checklist2 = Trash(contents: "Foo, Bar, Baz")
 
-            try checklist.save(on: self.database).wait()
-            try code.save(on: self.database).wait()
+            try checklist1.save(on: self.database).wait()
+            try checklist2.save(on: self.database).wait()
 
-            checklist.contents.append(", Fizz, Buzz")
-            try checklist.save(on: self.database).wait()
+            checklist1.contents.append(", Fizz, Buzz")
+            try checklist1.save(on: self.database).wait()
 
             let trash = try Trash.query(on: self.database).filter(\.$contents == "Foo, Bar, Baz, Fizz, Buzz").all().wait()
             guard trash.count == 1 else {

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -96,13 +96,11 @@ public final class FluentBenchmarker {
         try runTest(#function, [
             GalaxyMigration()
         ]) {
-            let galaxy1 = Galaxy(name: "Milkey Way")
-            let galaxy2 = Galaxy(name: "Black Eye")
-            try galaxy1.save(on: self.database).wait()
-            try galaxy2.save(on: self.database).wait()
+            let galaxy = Galaxy(name: "Milkey Way")
+            try galaxy.save(on: self.database).wait()
 
-            galaxy1.name = "Andromeda"
-            try galaxy1.save(on: self.database).wait()
+            galaxy.name = "Andromeda"
+            try galaxy.save(on: self.database).wait()
             
             // verify
             let galaxies = try Galaxy.query(on: self.database).filter(\.$name == "Andromeda").all().wait()
@@ -1252,14 +1250,12 @@ public final class FluentBenchmarker {
             struct GalaxyJSON: Codable {
                 var id: Int
                 var name: String
-                var deletedAt: Date?
                 
                 init(from decoder: Decoder) throws {
                     let keyed = try decoder.container(keyedBy: GalaxyKey.self)
                     self.id = try keyed.decode(Int.self, forKey: "id")
                     self.name = try keyed.decode(String.self, forKey: "name")
-                    self.deletedAt = try keyed.decodeIfPresent(Date.self, forKey: "deleted_at")
-                    XCTAssertEqual(keyed.allKeys.count, 3)
+                    XCTAssertEqual(keyed.allKeys.count, 2)
                 }
             }
 

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -115,11 +115,11 @@ public final class FluentBenchmarker {
             let checklist1 = Trash(contents: "Foo, Bar, Baz")
             let checklist2 = Trash(contents: "Foo, Bar, Baz")
 
-            try checklist1.save(on: self.database).wait()
-            try checklist2.save(on: self.database).wait()
+            try checklist1.create(on: self.database).wait()
+            try checklist2.create(on: self.database).wait()
 
             checklist1.contents.append(", Fizz, Buzz")
-            try checklist1.save(on: self.database).wait()
+            try checklist1.update(on: self.database).wait()
 
             let trash = try Trash.query(on: self.database).filter(\.$contents == "Foo, Bar, Baz, Fizz, Buzz").all().wait()
             guard trash.count == 1 else {

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -118,8 +118,8 @@ public final class FluentBenchmarker {
             try checklist1.create(on: self.database).wait()
             try checklist2.create(on: self.database).wait()
 
-            checklist1.contents.append(", Fizz, Buzz")
-            try checklist1.update(on: self.database).wait()
+            let update = Trash(id: checklist1.id, contents: "Foo, Bar, Baz, Fizz, Buzz")
+            try update.update(on: self.database).wait()
 
             let trash = try Trash.query(on: self.database).filter(\.$contents == "Foo, Bar, Baz, Fizz, Buzz").all().wait()
             guard trash.count == 1 else {

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -119,7 +119,7 @@ public final class FluentBenchmarker {
             try checklist1.create(on: self.database).wait()
             try checklist2.create(on: self.database).wait()
 
-            let update = Trash(id: checklist1.id, contents: "Foo, Bar, Baz, Fizz, Buzz", deletedAt: deletedAt)
+            let update = Trash(id: checklist1.id, contents: "Foo, Bar, Baz, Fizz, Buzz")
             try update.update(on: self.database).wait()
 
             let trash = try Trash.query(on: self.database).filter(\.$contents == "Foo, Bar, Baz, Fizz, Buzz").all().wait()

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -112,13 +112,14 @@ public final class FluentBenchmarker {
                 throw Failure("unexpected galaxy name")
             }
 
-            let checklist1 = Trash(contents: "Foo, Bar, Baz")
-            let checklist2 = Trash(contents: "Foo, Bar, Baz")
+            let deletedAt = Date()
+            let checklist1 = Trash(contents: "Foo, Bar, Baz", deletedAt: deletedAt)
+            let checklist2 = Trash(contents: "Foo, Bar, Baz", deletedAt: deletedAt)
 
             try checklist1.create(on: self.database).wait()
             try checklist2.create(on: self.database).wait()
 
-            let update = Trash(id: checklist1.id, contents: "Foo, Bar, Baz, Fizz, Buzz")
+            let update = Trash(id: checklist1.id, contents: "Foo, Bar, Baz, Fizz, Buzz", deletedAt: deletedAt)
             try update.update(on: self.database).wait()
 
             let trash = try Trash.query(on: self.database).filter(\.$contents == "Foo, Bar, Baz, Fizz, Buzz").all().wait()

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -95,12 +95,10 @@ public final class FluentBenchmarker {
     
     public func testUpdate() throws {
         try runTest(#function, [
-            GalaxyMigration(),
-            TrashMigration()
+            GalaxyMigration()
         ]) {
             let galaxy = Galaxy(name: "Milkey Way")
             try galaxy.save(on: self.database).wait()
-
             galaxy.name = "Milky Way"
             try galaxy.save(on: self.database).wait()
             

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -1252,12 +1252,14 @@ public final class FluentBenchmarker {
             struct GalaxyJSON: Codable {
                 var id: Int
                 var name: String
+                var deletedAt: Date?
                 
                 init(from decoder: Decoder) throws {
                     let keyed = try decoder.container(keyedBy: GalaxyKey.self)
                     self.id = try keyed.decode(Int.self, forKey: "id")
                     self.name = try keyed.decode(String.self, forKey: "name")
-                    XCTAssertEqual(keyed.allKeys.count, 2)
+                    self.deletedAt = try keyed.decodeIfPresent(Date.self, forKey: "deleted_at")
+                    XCTAssertEqual(keyed.allKeys.count, 3)
                 }
             }
 

--- a/Sources/FluentBenchmark/Galaxy.swift
+++ b/Sources/FluentBenchmark/Galaxy.swift
@@ -16,6 +16,9 @@ public final class Galaxy: Model {
     @Children(for: \.$galaxy)
     public var planets: [Planet]
 
+    @Timestamp(key: "deleted_at", on: .delete)
+    public var deletedAt: Date?
+
     public init() { }
 
     public init(id: Int? = nil, name: String) {

--- a/Sources/FluentBenchmark/Galaxy.swift
+++ b/Sources/FluentBenchmark/Galaxy.swift
@@ -34,6 +34,7 @@ struct GalaxyMigration: Migration {
         return database.schema("galaxies")
             .field("id", .int, .identifier(auto: true))
             .field("name", .string, .required)
+            .field("deleted_at", .datetime)
             .create()
     }
 

--- a/Sources/FluentBenchmark/Galaxy.swift
+++ b/Sources/FluentBenchmark/Galaxy.swift
@@ -1,4 +1,3 @@
-import struct Foundation.Date
 import FluentKit
 
 public final class Galaxy: Model {
@@ -17,9 +16,6 @@ public final class Galaxy: Model {
     @Children(for: \.$galaxy)
     public var planets: [Planet]
 
-    @Timestamp(key: "deleted_at", on: .delete)
-    public var deletedAt: Date?
-
     public init() { }
 
     public init(id: Int? = nil, name: String) {
@@ -34,7 +30,6 @@ struct GalaxyMigration: Migration {
         return database.schema("galaxies")
             .field("id", .int, .identifier(auto: true))
             .field("name", .string, .required)
-            .field("deleted_at", .datetime)
             .create()
     }
 

--- a/Sources/FluentBenchmark/Galaxy.swift
+++ b/Sources/FluentBenchmark/Galaxy.swift
@@ -1,3 +1,4 @@
+import struct Foundation.Date
 import FluentKit
 
 public final class Galaxy: Model {

--- a/Sources/FluentBenchmark/Trash.swift
+++ b/Sources/FluentBenchmark/Trash.swift
@@ -23,7 +23,7 @@ final class Trash: Model {
 struct TrashMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         return database.schema(Trash.schema)
-            .field("id", .uuid, .identifier(auto: true))
+            .field("id", .uuid, .identifier(auto: false))
             .field("contents", .string, .required)
             .field("deleted_at", .datetime)
             .create()

--- a/Sources/FluentBenchmark/Trash.swift
+++ b/Sources/FluentBenchmark/Trash.swift
@@ -1,11 +1,11 @@
-import struct Foundation.Date
+import Foundation
 import FluentKit
 
 final class Trash: Model {
     static let schema = "trash"
 
     @ID(key: "id")
-    var id: Int?
+    var id: UUID?
 
     @Field(key: "contents")
     var contents: String
@@ -23,7 +23,7 @@ final class Trash: Model {
 struct TrashMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         return database.schema(Trash.schema)
-            .field("id", .int, .identifier(auto: true))
+            .field("id", .uuid, .identifier(auto: true))
             .field("contents", .string, .required)
             .field("deleted_at", .datetime)
             .create()

--- a/Sources/FluentBenchmark/Trash.swift
+++ b/Sources/FluentBenchmark/Trash.swift
@@ -15,12 +15,13 @@ final class Trash: Model {
 
     init() { }
 
-    init(id: UUID? = nil, contents: String) {
+    init(id: UUID? = nil, contents: String, deletedAt: Date? = nil) {
         if let id = id {
             self.id = id
             self._id.exists = true
         }
         self.contents = contents
+        self.deletedAt = deletedAt
     }
 }
 

--- a/Sources/FluentBenchmark/Trash.swift
+++ b/Sources/FluentBenchmark/Trash.swift
@@ -27,14 +27,11 @@ final class Trash: Model {
 
 struct TrashMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
-        let builder = database.schema(Trash.schema)
-            .field("id", .uuid, .identifier(auto: false))
+        return database.schema(Trash.schema)
+            .field("id", .uuid, .identifier(auto: false), .custom("UNIQUE"))
             .field("contents", .string, .required)
             .field("deleted_at", .datetime)
-
-        builder.schema.constraints.append(.unique(fields: [.string("id")]))
-
-        return builder.create()
+            .create()
     }
 
     func revert(on database: Database) -> EventLoopFuture<Void> {

--- a/Sources/FluentBenchmark/Trash.swift
+++ b/Sources/FluentBenchmark/Trash.swift
@@ -1,0 +1,35 @@
+import struct Foundation.Date
+import FluentKit
+
+final class Trash: Model {
+    static let schema = "trash"
+
+    @ID(key: "id")
+    var id: Int?
+
+    @Field(key: "contents")
+    var contents: String
+
+    @Timestamp(key: "deleted_at", on: .delete)
+    var deletedAt: Date?
+
+    init() { }
+
+    init(contents: String) {
+        self.contents = contents
+    }
+}
+
+struct TrashMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        return database.schema(Trash.schema)
+            .field("id", .int, .identifier(auto: true))
+            .field("contents", .string, .required)
+            .field("deleted_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        return database.schema(Trash.schema).delete()
+    }
+}

--- a/Sources/FluentBenchmark/Trash.swift
+++ b/Sources/FluentBenchmark/Trash.swift
@@ -15,7 +15,11 @@ final class Trash: Model {
 
     init() { }
 
-    init(contents: String) {
+    init(id: UUID? = nil, contents: String) {
+        if let id = id {
+            self.id = id
+            self._id.exists = true
+        }
         self.contents = contents
     }
 }

--- a/Sources/FluentBenchmark/Trash.swift
+++ b/Sources/FluentBenchmark/Trash.swift
@@ -26,11 +26,14 @@ final class Trash: Model {
 
 struct TrashMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(Trash.schema)
+        let builder = database.schema(Trash.schema)
             .field("id", .uuid, .identifier(auto: false))
             .field("contents", .string, .required)
             .field("deleted_at", .datetime)
-            .create()
+
+        builder.schema.constraints.append(.unique(fields: [.string("id")]))
+
+        return builder.create()
     }
 
     func revert(on database: Database) -> EventLoopFuture<Void> {

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -77,11 +77,12 @@ public struct SQLQueryConverter {
         guard !filters.isEmpty else {
             return nil
         }
-        
-        return SQLList(
+
+        let list = SQLList(
             items: filters.map(self.filter),
             separator: SQLBinaryOperator.and
         )
+        return SQLGroupExpression(list)
     }
 
     private func sort(_ sort: DatabaseQuery.Sort) -> SQLExpression {
@@ -237,7 +238,7 @@ public struct SQLQueryConverter {
         case .custom(let any):
             return custom(any)
         case .group(let filters, let relation):
-            return SQLList(items: filters.map(self.filter), separator: self.relation(relation))
+            return SQLGroupExpression(SQLList(items: filters.map(self.filter), separator: self.relation(relation)))
         }
     }
     

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -237,8 +237,7 @@ public struct SQLQueryConverter {
         case .custom(let any):
             return custom(any)
         case .group(let filters, let relation):
-            return SQLList(items: filters.map(self.filter), separator: self.relation(relation))
-//            return SQLGroupExpression(SQLList(items: filters.map(self.filter), separator: self.relation(relation)))
+            return SQLGroupExpression(SQLList(items: filters.map(self.filter), separator: self.relation(relation)))
         }
     }
     

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -237,7 +237,13 @@ public struct SQLQueryConverter {
         case .custom(let any):
             return custom(any)
         case .group(let filters, let relation):
-            return SQLGroupExpression(SQLList(items: filters.map(self.filter), separator: self.relation(relation)))
+            // <item> OR <item> OR <item>
+            let expression = SQLList(
+                items: filters.map(self.filter),
+                separator: self.relation(relation)
+            )
+            // ( <expr> )
+            return SQLGroupExpression(expression)
         }
     }
     

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -238,7 +238,8 @@ public struct SQLQueryConverter {
         case .custom(let any):
             return custom(any)
         case .group(let filters, let relation):
-            return SQLGroupExpression(SQLList(items: filters.map(self.filter), separator: self.relation(relation)))
+            return SQLList(items: filters.map(self.filter), separator: self.relation(relation))
+//            return SQLGroupExpression(SQLList(items: filters.map(self.filter), separator: self.relation(relation)))
         }
     }
     

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -78,11 +78,10 @@ public struct SQLQueryConverter {
             return nil
         }
 
-        let list = SQLList(
+        return SQLList(
             items: filters.map(self.filter),
             separator: SQLBinaryOperator.and
         )
-        return list
     }
 
     private func sort(_ sort: DatabaseQuery.Sort) -> SQLExpression {

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -82,7 +82,7 @@ public struct SQLQueryConverter {
             items: filters.map(self.filter),
             separator: SQLBinaryOperator.and
         )
-        return SQLGroupExpression(list)
+        return list
     }
 
     private func sort(_ sort: DatabaseQuery.Sort) -> SQLExpression {


### PR DESCRIPTION
When a FluentKit query is converted to a SQL query, the predicates in the `WHERE` clause need to be grouped in parentheses.