### PR TITLE
Feature/103/first or create

### DIFF
--- a/Sources/FluentKit/Error.swift
+++ b/Sources/FluentKit/Error.swift
@@ -28,4 +28,9 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
     public var errorDescription: String? {
         return self.description
     }
+
+    public var isNoResults: Bool {
+        guard case .noResults = self else { return false }
+        return true
+    }
 }

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -607,6 +607,23 @@ public final class QueryBuilder<Model>
             .map { $0.first }
     }
     
+    public func first(
+        orCreate newModel: @escaping @autoclosure () -> Model
+    ) -> EventLoopFuture<Model> {
+        return self.first().flatMapThrowing { res in
+            guard let res = res else {
+                throw FluentError.noResults
+            }
+            return res
+        }.flatMapError { _ in
+            let model = newModel()
+
+            return model
+                .save(on: self.database)
+                .map { model }
+        }
+    }
+    
     public func all() -> EventLoopFuture<[Model]> {
         var models: [Result<Model, Error>] = []
         return self.all { model in

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -606,22 +606,46 @@ public final class QueryBuilder<Model>
             .all()
             .map { $0.first }
     }
-    
+
+    /// Retrieve the first result matching the current query or create a new record
+    /// if no results are found.
+    ///
+    /// Example usage:
+    ///
+    ///     User.query(on: database)
+    ///         .filter(\.$name == "Jon")
+    ///         .first(orCreate: User(name: "Jon"))
+    ///
     public func first(
         orCreate newModel: @escaping @autoclosure () -> Model
     ) -> EventLoopFuture<Model> {
-        return self.first().flatMapThrowing { res in
+        let promise = self.database.eventLoop.makePromise(of: Model.self)
+
+        let existingModel: EventLoopFuture<Model> = self.first().flatMapThrowing { res in
             guard let res = res else {
                 throw FluentError.noResults
             }
             return res
-        }.flatMapError { _ in
-            let model = newModel()
-
-            return model
-                .save(on: self.database)
-                .map { model }
         }
+
+        existingModel.cascadeSuccess(to: promise)
+
+        // we only handle failure of .noResults by going
+        // and creating a new model. Other failures get
+        // propagated.
+        existingModel.whenFailure { error in
+            guard let fluentError = error as? FluentError,
+                fluentError.isNoResults else {
+                    promise.fail(error)
+                    return
+            }
+            let model = newModel()
+            model.create(on: self.database)
+                .map { model }
+                .cascade(to: promise)
+        }
+
+        return promise.futureResult
     }
     
     public func all() -> EventLoopFuture<[Model]> {

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -1,0 +1,174 @@
+import NIO
+@testable import FluentKit
+@testable import FluentBenchmark
+import XCTest
+import Foundation
+import FluentSQL
+
+final class QueryBuilderTests: XCTestCase {
+    func testFirstOrCreateFindsResult() throws {
+        let planet = Planet3(id: 1, name: "Nupeter", galaxyID: 10)
+        // first and only result contains existing row
+        let db = DummyDatabase(mockResults: [[
+            DummyRow(dummyDecodedFields: [
+                "id": try planet.requireID(),
+                "name": planet.name,
+                "galaxy_id": planet.$galaxy.id
+            ])
+        ]])
+
+        let retrievedPlanet = try Planet3.query(on: db).first(orCreate: planet).wait()
+
+        XCTAssertEqual(retrievedPlanet.name, planet.name)
+        XCTAssertEqual(try retrievedPlanet.requireID(), try planet.requireID())
+    }
+
+    func testFirstOrCreateCreatesResult() throws {
+        let planet = Planet3(id: 1, name: "Nupeter", galaxyID: 10)
+        // first result is empty, second result contains created row
+        let db = DummyDatabase(mockResults: [[], [
+            DummyRow(dummyDecodedFields: [
+                "id": try planet.requireID(),
+                "name": planet.name,
+                "galaxy_id": planet.$galaxy.id
+            ])
+        ]])
+
+        let retrievedPlanet = try Planet3.query(on: db).first(orCreate: planet).wait()
+
+        XCTAssertEqual(retrievedPlanet.name, planet.name)
+        XCTAssertEqual(try retrievedPlanet.requireID(), try planet.requireID())
+    }
+
+    func testFirstOrCreatePropagatesError() throws {
+        // pretend a query results in a field of the wrong type
+        let planet = Planet3(id: 1, name: "Nupeter", galaxyID: 10)
+        let db = DummyDatabase(mockResults: [[
+            DummyRow(dummyDecodedFields: [
+                "id": "hello", // wrong type here
+                "name": planet.name,
+                "galaxy_id": planet.$galaxy.id
+            ])
+        ]])
+
+        XCTAssertThrowsError(try Planet3.query(on: db).first(orCreate: planet).wait())
+    }
+}
+
+/// Lets you determine the row results for each query.
+///
+/// Initialize with an array or arrays, each inner array
+/// containing all the rows for a certain query result. Each
+/// new query will produce the next inner-array of results.
+///
+/// You can specify an empty result-set (as is correct for
+/// some queries and useful for other tests) with an empty
+/// inner-array.
+///
+/// Examples:
+///
+/// Return an empty result for all queries:
+///
+///     DummyDatabase(mockResults: [[]])
+///
+/// Return an empty result for first query, and a single result
+/// for the second query (perhaps a query to find a record with
+/// no results followed by a successful query to create the record):
+///
+///     DummyDatabase(mockResults: [
+///         [],
+///         [
+///             DummyRow(dummyDecodedFields: ["id": 1, "name": "Boise"])
+///         ]
+///     ])
+fileprivate class DummyDatabase: Database {
+
+    typealias MockResult = [DatabaseRow]
+
+    let mockResults: [MockResult]
+    var resultIdx: Int = 0
+
+    public var dialect: SQLDialect {
+        DummyDatabaseDialect()
+    }
+    public var context: DatabaseContext
+
+    public init(
+        mockResults: [MockResult],
+        context: DatabaseContext = .init(
+            configuration: .init(),
+            logger: .init(label: "test"),
+            eventLoop: EmbeddedEventLoop()
+        )
+    ) {
+        self.context = context
+        self.mockResults = mockResults
+    }
+
+    public func execute(query: DatabaseQuery, onRow: @escaping (DatabaseRow) -> ()) -> EventLoopFuture<Void> {
+        defer { resultIdx = (resultIdx + 1) % mockResults.count }
+
+        for row in mockResults[resultIdx] {
+            onRow(row)
+        }
+        return self.eventLoop.makeSucceededFuture(())
+    }
+
+    public func withConnection<T>(_ closure: (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        closure(self)
+    }
+
+    public func execute(schema: DatabaseSchema) -> EventLoopFuture<Void> {
+        self.eventLoop.makeSucceededFuture(())
+    }
+}
+
+fileprivate enum DummyDecodeError: Error {
+    case wrongType
+}
+
+fileprivate struct DummyRow: DatabaseRow {
+    func decode<T>(field: String, as type: T.Type, for database: Database) throws -> T
+        where T: Decodable
+    {
+        if let res = dummyDecodedFields[field] as? T {
+            return res
+        }
+        throw DummyDecodeError.wrongType
+    }
+
+    func contains(field: String) -> Bool {
+        return true
+    }
+
+    var description: String {
+        return "<dummy>"
+    }
+
+    let dummyDecodedFields: [String: Any]
+}
+
+/// Same as FluentBenchmark.Planet except the ID is user generated.
+fileprivate final class Planet3: Model {
+    static let schema = "planets"
+
+    @ID(key: "id", generatedBy: .user)
+    var id: Int?
+
+    @Field(key: "name")
+    var name: String
+
+    @Parent(key: "galaxy_id")
+    public var galaxy: Galaxy
+
+    @Siblings(through: PlanetTag.self, from: \.$planet, to: \.$tag)
+    public var tags: [Tag]
+
+    init() { }
+
+    public init(id: Int? = nil, name: String, galaxyID: Galaxy.IDValue) {
+        self.id = id
+        self.name = name
+        self.$galaxy.id = galaxyID
+    }
+}

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -7,20 +7,21 @@ import FluentSQL
 
 final class QueryBuilderTests: XCTestCase {
     func testFirstOrCreateFindsResult() throws {
-        let planet = Planet3(id: 1, name: "Nupeter", galaxyID: 10)
+        let existingPlanet = Planet3(id: 1, name: "Nupeter", galaxyID: 10)
+        let newPlanet = Planet3(id: 2, name: "Marzipan", galaxyID: 10)
         // first and only result contains existing row
         let db = DummyDatabase(mockResults: [[
             DummyRow(dummyDecodedFields: [
-                "id": try planet.requireID(),
-                "name": planet.name,
-                "galaxy_id": planet.$galaxy.id
+                "id": try existingPlanet.requireID(),
+                "name": existingPlanet.name,
+                "galaxy_id": existingPlanet.$galaxy.id
             ])
         ]])
 
-        let retrievedPlanet = try Planet3.query(on: db).first(orCreate: planet).wait()
+        let retrievedPlanet = try Planet3.query(on: db).first(orCreate: newPlanet).wait()
 
-        XCTAssertEqual(retrievedPlanet.name, planet.name)
-        XCTAssertEqual(try retrievedPlanet.requireID(), try planet.requireID())
+        XCTAssertEqual(retrievedPlanet.name, existingPlanet.name)
+        XCTAssertEqual(try retrievedPlanet.requireID(), try existingPlanet.requireID())
     }
 
     func testFirstOrCreateCreatesResult() throws {


### PR DESCRIPTION
Closes https://github.com/vapor/fluent-kit/issues/103

Adds a `first(orCreate:)` method to `QueryBuilder`.

I was a bit disappointed with how large the implementation ended up being, but this is what I came up with to support the case where an error other than `.notFound` is thrown and should not be covered up by an attempt to create a new resource. I can imagine a nice extension or two on `EventLoopFuture` that would really clean the implementation up, but did not think it was worth it for this one additional helper function. Curious if anyone else pictures a clearly better implementation!

I added a new DummyDatabase so I could write tests for this function -- no worries if you want that ripped out or changed as I have no idea what the big picture for testing this library looks like.