### PR TITLE
Duplicate constraint name fix

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -49,6 +49,7 @@ public final class FluentBenchmarker {
         try self.testArray()
         try self.testPerformance()
         try self.testSoftDeleteWithQuery()
+        try self.testDuplicatedUniquePropertyName()
     }
     
     public func testCreate() throws {
@@ -1720,6 +1721,40 @@ public final class FluentBenchmarker {
                 .filter(\.$contents == "c")
                 .all().wait()
             XCTAssertEqual(trash.count, 0)
+        }
+    }
+
+    // https://github.com/vapor/fluent-kit/issues/112
+    public func testDuplicatedUniquePropertyName() throws {
+        struct Foo: Migration {
+            func prepare(on database: Database) -> EventLoopFuture<Void> {
+                database.schema("foos")
+                    .field("name", .string)
+                    .unique(on: "name")
+                    .create()
+            }
+
+            func revert(on database: Database) -> EventLoopFuture<Void> {
+                database.schema("foos").delete()
+            }
+        }
+        struct Bar: Migration {
+            func prepare(on database: Database) -> EventLoopFuture<Void> {
+                database.schema("bars")
+                    .field("name", .string)
+                    .unique(on: "name")
+                    .create()
+            }
+
+            func revert(on database: Database) -> EventLoopFuture<Void> {
+                database.schema("bars").delete()
+            }
+        }
+        try runTest(#function, [
+            Foo(),
+            Bar()
+        ]) {
+            //
         }
     }
 

--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -108,7 +108,7 @@ private struct ContainerEncoder: Encoder, SingleValueEncodingContainer {
 }
 
 extension Model {
-    static func key<Field>(for field: KeyPath<Self, Field>) -> String
+    public static func key<Field>(for field: KeyPath<Self, Field>) -> String
         where Field: FieldRepresentable
     {
         return Self.init()[keyPath: field].field.key

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -53,7 +53,7 @@ public struct SQLSchemaConverter {
                 case .custom:
                     return ""
                 case .string(let name):
-                    return name
+                    return "\(table).\(name)"
                 }
             }.joined(separator: "+")
         }
@@ -63,7 +63,7 @@ public struct SQLSchemaConverter {
             let name = identifier(fields)
             return SQLConstraint(
                 algorithm: SQLTableConstraintAlgorithm.unique(columns: fields.map(self.fieldName)),
-                name: SQLIdentifier("uq:\(table).\(name)")
+                name: SQLIdentifier("uq:\(name)")
             )
         case .foreignKey(fields: let fields, foreignSchema: let parent, foreignFields: let parentFields, onDelete: let onDelete, onUpdate: let onUpdate):
             let name = identifier(fields + parentFields)

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -125,7 +125,7 @@ final class FluentKitTests: XCTestCase {
             .create()
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("id" BIGINT, CONSTRAINT "uq:id" UNIQUE ("id"))"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("id" BIGINT, CONSTRAINT "uq:planets.id" UNIQUE ("id"))"#)
         db.reset()
 
         try db.schema("planets")
@@ -135,7 +135,7 @@ final class FluentKitTests: XCTestCase {
             .create()
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("id" BIGINT, "name" TEXT, CONSTRAINT "uq:id+name" UNIQUE ("id", "name"))"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("id" BIGINT, "name" TEXT, CONSTRAINT "uq:planets.id+planets.name" UNIQUE ("id", "name"))"#)
     }
 
     func testForeignKeyTableConstraint() throws {

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -146,7 +146,7 @@ final class FluentKitTests: XCTestCase {
             .create()
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:galaxy_id+id" FOREIGN KEY ("galaxy_id") REFERENCES "galaxies" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:planets.galaxy_id+planets.id" FOREIGN KEY ("galaxy_id") REFERENCES "galaxies" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)"#)
         db.reset()
 
         try db.schema("planets")
@@ -160,7 +160,7 @@ final class FluentKitTests: XCTestCase {
             .create()
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:galaxy_id+id" FOREIGN KEY ("galaxy_id") REFERENCES "galaxies" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:planets.galaxy_id+planets.id" FOREIGN KEY ("galaxy_id") REFERENCES "galaxies" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)"#)
     }
     
     func testDecodeWithoutID() throws {


### PR DESCRIPTION
- Constraint names (unique and foreign key) now include the table name (#112, #113)

- Publicized `Model.key(for:)` method for getting field key strings statically (#113)
