### PR TITLE
Don't eager load on empty result set

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -50,6 +50,7 @@ public final class FluentBenchmarker {
         try self.testPerformance()
         try self.testSoftDeleteWithQuery()
         try self.testDuplicatedUniquePropertyName()
+        try self.testEmptyEagerLoadChildren()
     }
     
     public func testCreate() throws {
@@ -1755,6 +1756,23 @@ public final class FluentBenchmarker {
             Bar()
         ]) {
             //
+        }
+    }
+    
+    // https://github.com/vapor/fluent-kit/issues/117
+    public func testEmptyEagerLoadChildren() throws {
+        try runTest(#function, [
+            GalaxyMigration(),
+            PlanetMigration(),
+            GalaxySeed(),
+            PlanetSeed()
+        ]) {
+            let galaxies = try Galaxy.query(on: self.database)
+                .filter(\.$name == "foo")
+                .with(\.$planets)
+                .all().wait()
+
+            XCTAssertEqual(galaxies.count, 0)
         }
     }
 


### PR DESCRIPTION
Fluent's `QueryBuilder` no longer attempts to run eager loads if `all()` returns zero models. This fixes an issue where attempting to eager load children on a query that returned zero models would result in a syntax error (#117).