### PR TITLE
Added Model.hasChanges Property

### DIFF
--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -108,6 +108,12 @@ private struct ContainerEncoder: Encoder, SingleValueEncodingContainer {
 }
 
 extension Model {
+
+    /// Indicates whether the model has fields that have been set, but the model has not yet been saved to the database.
+    public var hasChanges: Bool {
+        return !self.input.isEmpty
+    }
+
     public static func key<Field>(for field: KeyPath<Self, Field>) -> String
         where Field: FieldRepresentable
     {


### PR DESCRIPTION
Adds a `.hasChanges` computed property to the `Model` protocol, which can be used to check if there are any fields that have had their values set, but the model has not yet been saved to the database.