### PR TITLE
Pagination and Range

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -52,6 +52,7 @@ public final class FluentBenchmarker {
         try self.testDuplicatedUniquePropertyName()
         try self.testEmptyEagerLoadChildren()
         try self.testUInt8BackedEnum()
+        try self.testRange()
     }
     
     public func testCreate() throws {
@@ -1818,6 +1819,45 @@ public final class FluentBenchmarker {
             
             let fetched = try Foo.find(foo.id, on: self.database).wait()
             XCTAssertEqual(fetched?.bar, .baz)
+        }
+    }
+
+    public func testRange() throws {
+        try runTest(#function, [
+            GalaxyMigration(),
+            PlanetMigration(),
+            GalaxySeed(),
+            PlanetSeed()
+        ]) {
+            do {
+                let planets = try Planet.query(on: self.database)
+                    .range(2..<5)
+                    .sort(\.$name)
+                    .all().wait()
+                XCTAssertEqual(planets.count, 3)
+                XCTAssertEqual(planets[0].name, "Mars")
+            }
+            do {
+                let planets = try Planet.query(on: self.database)
+                    .range(...5)
+                    .sort(\.$name)
+                    .all().wait()
+                XCTAssertEqual(planets.count, 6)
+            }
+            do {
+                let planets = try Planet.query(on: self.database)
+                    .range(..<5)
+                    .sort(\.$name)
+                    .all().wait()
+                XCTAssertEqual(planets.count, 5)
+            }
+            do {
+                let planets = try Planet.query(on: self.database)
+                    .range(..<5)
+                    .sort(\.$name)
+                    .all().wait()
+                XCTAssertEqual(planets.count, 5)
+            }
         }
     }
 

--- a/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
@@ -8,19 +8,18 @@ extension QueryBuilder {
     public func paginate(
         _ request: PageRequest
     ) -> EventLoopFuture<Page<Model>> {
-        self.count()
-            .flatMap {
-                self.copy().range(request.start..<request.end).all().and(value: $0)
-            }.map { (models, total) in
-                Page(
-                    items: models,
-                    metadata: .init(
-                        page: request.page,
-                        per: request.per,
-                        total: total
-                    )
+        let count = self.count()
+        let items = self.copy().range(request.start..<request.end).all()
+        return items.and(count).map { (models, total) in
+            Page(
+                items: models,
+                metadata: .init(
+                    page: request.page,
+                    per: request.per,
+                    total: total
                 )
-            }
+            )
+        }
     }
 }
 

--- a/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
@@ -1,0 +1,73 @@
+public struct PageMetadata: Codable {
+    public let page: Int
+    public let per: Int
+    public let total: Int
+}
+
+public struct Page<T>: Codable where T: Codable {
+    public let items: [T]
+    public let metadata: PageMetadata
+
+    public init(items: [T], metadata: PageMetadata) {
+        self.items = items
+        self.metadata = metadata
+    }
+
+    public func map<U>(_ transform: (T) throws -> (U)) rethrows -> Page<U>
+        where U: Codable
+    {
+        try .init(
+            items: self.items.map(transform),
+            metadata: self.metadata
+        )
+    }
+}
+
+public struct PageRequest: Decodable {
+    public let page: Int
+    public let per: Int
+
+    enum CodingKeys: String, CodingKey {
+        case page = "page"
+        case per = "per"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.page = try container.decodeIfPresent(Int.self, forKey: .page) ?? 1
+        self.per = try container.decodeIfPresent(Int.self, forKey: .per) ?? 10
+    }
+
+    public init(page: Int, per: Int) {
+        self.page = page
+        self.per = per
+    }
+
+    var start: Int {
+        (self.page - 1) * self.per
+    }
+
+    var end: Int {
+        self.page * self.per
+    }
+}
+
+extension QueryBuilder {
+    public func paginate(
+        _ request: PageRequest
+    ) -> EventLoopFuture<Page<Model>> {
+        self.count()
+            .flatMap {
+                self.range(request.start..<request.end).all().and(value: $0)
+            }.map { (models, total) in
+                Page(
+                    items: models,
+                    metadata: .init(
+                        page: request.page,
+                        per: request.per,
+                        total: total
+                    )
+                )
+            }
+    }
+}

--- a/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
@@ -1,18 +1,44 @@
-public struct PageMetadata: Codable {
-    public let page: Int
-    public let per: Int
-    public let total: Int
+extension QueryBuilder {
+    /// Returns a single `Page` out of the complete result set according to the supplied `PageRequest`.
+    ///
+    /// This method will first `count()` the result set, then request a subset of the results using `range()` and `all()`.
+    /// - Parameters:
+    ///     - request: Describes which page should be fetched.
+    /// - Returns: A single `Page` of the result set containing the requested items and page metadata.
+    public func paginate(
+        _ request: PageRequest
+    ) -> EventLoopFuture<Page<Model>> {
+        self.count()
+            .flatMap {
+                self.copy().range(request.start..<request.end).all().and(value: $0)
+            }.map { (models, total) in
+                Page(
+                    items: models,
+                    metadata: .init(
+                        page: request.page,
+                        per: request.per,
+                        total: total
+                    )
+                )
+            }
+    }
 }
 
+/// A single section of a larger, traversable result set.
 public struct Page<T>: Codable where T: Codable {
+    /// The page's items. Usually models.
     public let items: [T]
+
+    /// Metadata containing information about current page, items per page, and total items.
     public let metadata: PageMetadata
 
+    /// Creates a new `Page`.
     public init(items: [T], metadata: PageMetadata) {
         self.items = items
         self.metadata = metadata
     }
 
+    /// Maps a page's items to a different type using the supplied closure.
     public func map<U>(_ transform: (T) throws -> (U)) rethrows -> Page<U>
         where U: Codable
     {
@@ -23,8 +49,24 @@ public struct Page<T>: Codable where T: Codable {
     }
 }
 
-public struct PageRequest: Decodable {
+/// Metadata for a given `Page`.
+public struct PageMetadata: Codable {
+    /// Current page number. Starts at `1`.
     public let page: Int
+
+    /// Max items per page.
+    public let per: Int
+
+    /// Total number of items available.
+    public let total: Int
+}
+
+/// Represents information needed to generate a `Page` from the full result set.
+public struct PageRequest: Decodable {
+    /// Page number to request. Starts at `1`.
+    public let page: Int
+
+    /// Max items per page.
     public let per: Int
 
     enum CodingKeys: String, CodingKey {
@@ -32,12 +74,17 @@ public struct PageRequest: Decodable {
         case per = "per"
     }
 
+    /// `Decodable` conformance.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.page = try container.decodeIfPresent(Int.self, forKey: .page) ?? 1
         self.per = try container.decodeIfPresent(Int.self, forKey: .per) ?? 10
     }
 
+    /// Crates a new `PageRequest`
+    /// - Parameters:
+    ///   - page: Page number to request. Starts at `1`.
+    ///   - per: Max items per page.
     public init(page: Int, per: Int) {
         self.page = page
         self.per = per
@@ -49,25 +96,5 @@ public struct PageRequest: Decodable {
 
     var end: Int {
         self.page * self.per
-    }
-}
-
-extension QueryBuilder {
-    public func paginate(
-        _ request: PageRequest
-    ) -> EventLoopFuture<Page<Model>> {
-        self.count()
-            .flatMap {
-                self.range(request.start..<request.end).all().and(value: $0)
-            }.map { (models, total) in
-                Page(
-                    items: models,
-                    metadata: .init(
-                        page: request.page,
-                        per: request.per,
-                        total: total
-                    )
-                )
-            }
     }
 }

--- a/Sources/FluentKit/Query/QueryBuilder+Range.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Range.swift
@@ -1,0 +1,62 @@
+extension QueryBuilder {
+    // MARK: Range
+
+    /// Limits the results of this query to the specified range.
+    ///
+    ///     query.range(2..<5) // returns at most 3 results, offset by 2
+    ///
+    /// - returns: Query builder for chaining.
+    public func range(_ range: Range<Int>) -> Self {
+        return self.range(lower: range.lowerBound, upper: range.upperBound - 1)
+    }
+
+    /// Limits the results of this query to the specified range.
+    ///
+    ///     query.range(...5) // returns at most 6 results
+    ///
+    /// - returns: Query builder for chaining.
+    public func range(_ range: PartialRangeThrough<Int>) -> Self {
+        return self.range(upper: range.upperBound)
+    }
+
+    /// Limits the results of this query to the specified range.
+    ///
+    ///     query.range(..<5) // returns at most 5 results
+    ///
+    /// - returns: Query builder for chaining.
+    public func range(_ range: PartialRangeUpTo<Int>) -> Self {
+        return self.range(upper: range.upperBound - 1)
+    }
+
+    /// Limits the results of this query to the specified range.
+    ///
+    ///     query.range(5...) // offsets the result by 5
+    ///
+    /// - returns: Query builder for chaining.
+    public func range(_ range: PartialRangeFrom<Int>) -> Self {
+        return self.range(lower: range.lowerBound)
+    }
+
+    /// Limits the results of this query to the specified range.
+    ///
+    ///     query.range(2..<5) // returns at most 3 results, offset by 2
+    ///
+    /// - returns: Query builder for chaining.
+    public func range(_ range: ClosedRange<Int>) -> Self {
+        return self.range(lower: range.lowerBound, upper: range.upperBound)
+    }
+
+    /// Limits the results of this query to the specified range.
+    ///
+    /// - parameters:
+    ///     - lower: Amount to offset the query by.
+    ///     - upper: `upper` - `lower` = maximum results.
+    /// - returns: Query builder for chaining.
+    public func range(lower: Int = 0, upper: Int? = nil) -> Self {
+        self.query.offsets.append(.count(lower))
+        upper.flatMap {
+            self.query.limits.append(.count(($0 - lower) + 1))
+        }
+        return self
+    }
+}

--- a/Sources/FluentKit/Query/QueryBuilder+Range.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Range.swift
@@ -54,8 +54,8 @@ extension QueryBuilder {
     /// - returns: Query builder for chaining.
     public func range(lower: Int = 0, upper: Int? = nil) -> Self {
         self.query.offsets.append(.count(lower))
-        upper.flatMap {
-            self.query.limits.append(.count(($0 - lower) + 1))
+        upper.flatMap { upper in
+            self.query.limits.append(.count((upper - lower) + 1))
         }
         return self
     }

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -25,6 +25,30 @@ public final class QueryBuilder<Model>
         self.joinedModels = []
     }
 
+    private init(
+        query: DatabaseQuery,
+        database: Database,
+        eagerLoads: EagerLoads,
+        includeDeleted: Bool,
+        joinedModels: [AnyModel]
+    ) {
+        self.query = query
+        self.database = database
+        self.eagerLoads = eagerLoads
+        self.includeDeleted = includeDeleted
+        self.joinedModels = joinedModels
+    }
+
+    public func copy() -> QueryBuilder<Model> {
+        .init(
+            query: self.query,
+            database: self.database,
+            eagerLoads: self.eagerLoads,
+            includeDeleted: self.includeDeleted,
+            joinedModels: self.joinedModels
+        )
+    }
+
     // MARK: Eager Load
 
     @discardableResult
@@ -550,7 +574,8 @@ public final class QueryBuilder<Model>
     ) -> EventLoopFuture<Result>
         where Result: Codable
     {
-        self.query.fields = [.aggregate(.fields(
+        let copy = self.copy()
+        copy.query.fields = [.aggregate(.fields(
             method: method,
             fields: [.field(
                 path: [fieldName],
@@ -559,7 +584,7 @@ public final class QueryBuilder<Model>
             ]
         ))]
         
-        return self.first().flatMapThrowing { res in
+        return copy.first().flatMapThrowing { res in
             guard let res = res else {
                 throw FluentError.noResults
             }


### PR DESCRIPTION
Adds `paginate` method to `QueryBuilder` which returns a `Page` of models. `Page` includes the array of models and a `PageMetadata` struct including information on current page, items per page, and total number of items. 

Fluent adds a `paginate(for:Request)` method that automatically decodes the `PageRequest` from the Request's query string.

```swift
struct TodoController {
    func index(req: Request) throws -> EventLoopFuture<Page<Todo>> {
        Todo.query(on: req.db).paginate(for: req)
    }
}
```

`Page` can also `map` its items to different types.

```swift
let todos = Todo.query(on: req.db).paginate(for: req).map { page in
    page.map(Todo.Public.init)
}
print(todos) // ELFuture<Page<Todo.Public>>
```

In addition to pagination, `QueryBuilder` now supports `range` methods accepting Swift's `Range` literals.

```swift
query.range(2..<5) // returns at most 3 results, offset by 2
query.range(..<5) // returns at most 5 results
```