### PR TITLE
SQL Enums

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker+Enum.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker+Enum.swift
@@ -1,0 +1,146 @@
+import FluentSQL
+import XCTest
+
+extension FluentBenchmarker {
+    public func testSQLEnums() throws {
+        try runTest(#function, [
+            _PlanetMigration(),
+        ]) {
+            try _Planet(name: "Earth", type: .smallRocky)
+                .save(on: self.database).wait()
+            try _Planet(name: "Jupiter", type: .gasGiant)
+                .save(on: self.database).wait()
+
+            let planets1 = try _Planet.query(on: self.database).sort(\.$name).all().wait()
+            XCTAssertEqual(planets1.map { "\($0.name):\($0.type)" }, [
+                "Earth:smallRocky",
+                "Jupiter:gasGiant"
+            ])
+
+            try _PlanetAddDwarfType().prepare(on: self.database).wait()
+
+            try _Planet(name: "Pluto", type: .dwarf)
+                .save(on: self.database).wait()
+
+            let planets2 = try _Planet.query(on: self.database).sort(\.$name).all().wait()
+            XCTAssertEqual(planets2.map { "\($0.name):\($0.type)" }, [
+                "Earth:smallRocky",
+                "Jupiter:gasGiant",
+                "Pluto:dwarf"
+            ])
+        }
+    }
+}
+
+private enum PlanetType: String, Codable, SQLExpressible {
+    case smallRocky
+    case gasGiant
+    case dwarf
+
+    var sql: SQLExpression {
+        // serializes the value as a literal string in
+        // queries instead of binding the value
+        SQLLiteral.string(self.rawValue)
+    }
+}
+
+private final class _Planet: Model {
+    static let schema = "planets"
+
+    @ID(key: "id")
+    var id: UUID?
+
+    @Field(key: "name")
+    var name: String
+
+    @Field(key: "type")
+    var type: PlanetType
+
+    public init() { }
+
+    init(id: UUID? = nil, name: String, type: PlanetType) {
+        self.id = id
+        self.name = name
+        self.type = type
+    }
+}
+
+private struct _PlanetMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            return database.eventLoop.makeFailedFuture(
+                FluentBenchmarker.Failure("SQL database required")
+            )
+        }
+
+        let planetType: EventLoopFuture<DatabaseSchema.DataType>
+        switch sql.dialect.enumSyntax {
+        case .unsupported:
+            // if the database does not support enums,
+            // just store the enum value as an unchecked string
+            planetType = database.eventLoop.makeSucceededFuture(.string)
+        case .typeName:
+            // if the database supports types, create a new enum type
+            planetType = sql.create(
+                enum: "PLANET_TYPE", cases: "smallRocky", "gasGiant"
+            ).run().map {
+                .sql(.type("PLANET_TYPE"))
+            }
+        case .inline:
+            // use in-line enum data types if supported
+            planetType = database.eventLoop.makeSucceededFuture(
+                .sql(.enum("smallRocky", "gasGiant"))
+            )
+        }
+
+        return planetType.flatMap {
+            database.schema("planets")
+                .field("id", .uuid, .identifier(auto: false))
+                .field("name", .string, .required)
+                .field("type", $0, .required)
+                .create()
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("planets").delete().flatMap {
+            if let sql = database as? SQLDatabase, case .typeName = sql.dialect.enumSyntax {
+                // if the database supports types, drop the type
+                // created by the forward migration
+                return sql.drop(type: "PLANET_TYPE").run()
+            } else {
+                return database.eventLoop.makeSucceededFuture(())
+            }
+        }
+    }
+}
+
+private struct _PlanetAddDwarfType: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let sql = database as? SQLDatabase else {
+            return database.eventLoop.makeFailedFuture(
+                FluentBenchmarker.Failure("SQL database required")
+            )
+        }
+        switch sql.dialect.enumSyntax {
+        case .unsupported:
+            // if the database does not support typed enums,
+            // nothing needs to be done here
+            return database.eventLoop.makeSucceededFuture(())
+        case .typeName:
+            // if the database supports types, add the new enum case
+            return sql.alter(type: "PLANET_TYPE").add(value: "dwarf").run()
+        case .inline:
+            // if the database supports in-line enums, modify the
+            // table schema to add the new enum case
+            return database.schema("planets")
+                .updateField("type", .sql(.enum("smallRocky", "gasGiant", "dwarf")))
+                .update()
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        // not possible to undo
+        return database.eventLoop.makeSucceededFuture(())
+    }
+}

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -53,6 +53,7 @@ public final class FluentBenchmarker {
         try self.testEmptyEagerLoadChildren()
         try self.testUInt8BackedEnum()
         try self.testRange()
+        try self.testSQLEnums()
     }
     
     public func testCreate() throws {
@@ -1875,7 +1876,7 @@ public final class FluentBenchmarker {
         }
     }
     
-    private func runTest(_ name: String, _ migrations: [Migration], _ test: () throws -> ()) throws {
+    internal func runTest(_ name: String, _ migrations: [Migration], _ test: () throws -> ()) throws {
         self.log("Running \(name)...")
         for migration in migrations {
             do {

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -99,6 +99,7 @@ public struct DatabaseSchema {
     public var action: Action
     public var schema: String
     public var createFields: [FieldDefinition]
+    public var updateFields: [FieldDefinition]
     public var deleteFields: [FieldName]
     public var constraints: [Constraint]
     
@@ -106,6 +107,7 @@ public struct DatabaseSchema {
         self.action = .create
         self.schema = schema
         self.createFields = []
+        self.updateFields = []
         self.deleteFields = []
         self.constraints = []
     }

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -55,6 +55,25 @@ public final class SchemaBuilder {
         ))
         return self
     }
+
+
+
+    public func updateField(
+        _ name: String,
+        _ dataType: DatabaseSchema.DataType,
+        _ constraints: DatabaseSchema.FieldConstraint...
+    ) -> Self {
+        return self.updateField(.definition(
+            name: .string(name),
+            dataType: dataType,
+            constraints: constraints
+        ))
+    }
+
+    public func updateField(_ field: DatabaseSchema.FieldDefinition) -> Self {
+        self.schema.updateFields.append(field)
+        return self
+    }
     
     public func deleteField(_ name: String) -> Self {
         return self.deleteField(.string(name))

--- a/Sources/FluentSQL/DatabaseSchema+SQL.swift
+++ b/Sources/FluentSQL/DatabaseSchema+SQL.swift
@@ -1,0 +1,5 @@
+extension DatabaseSchema.DataType {
+    public static func sql(_ dataType: SQLDataType) -> Self {
+        .custom(dataType)
+    }
+}

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -279,7 +279,11 @@ public struct SQLQueryConverter {
     private func value(_ value: DatabaseQuery.Value) -> SQLExpression {
         switch value {
         case .bind(let encodable):
-            return SQLBind(encodable)
+            if let expressible = encodable as? SQLExpressible {
+                return expressible.sql
+            } else {
+                return SQLBind(encodable)
+            }
         case .null:
             return SQLLiteral.null
         case .array(let values):

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -24,7 +24,8 @@ public struct SQLSchemaConverter {
 
     private func update(_ schema: DatabaseSchema) -> SQLExpression {
         var update = SQLAlterTable(name: self.name(schema.schema))
-        update.columns = schema.createFields.map(self.fieldDefinition)
+        update.addColumns = schema.createFields.map(self.fieldDefinition)
+        update.modifyColumns = schema.updateFields.map(self.fieldDefinition)
         return update
     }
     


### PR DESCRIPTION
Adds support for storing Swift enums as native SQL enums. Using native SQL enums requires casting `database` to `SQLDatabase` in migrations and using the `.sql` prefixed data types.