### PR TITLE
Fix ID.Generator.random Overwrite

### DIFF
--- a/Sources/FluentBenchmark/Exports.swift
+++ b/Sources/FluentBenchmark/Exports.swift
@@ -1,1 +1,2 @@
 @_exported import FluentKit
+@_exported import XCTest

--- a/Sources/FluentBenchmark/FluentBenchmarker+customID.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker+customID.swift
@@ -1,0 +1,43 @@
+extension FluentBenchmarker {
+    // https://github.com/vapor/fluent-kit/issues/132
+    public func testCustomID() throws {
+        try runTest(#function, [
+            CreateFoo(),
+        ]) {
+            let random = Foo()
+            try random.save(on: self.database).wait()
+            XCTAssertNotNil(random.id)
+
+            let uuid = UUID()
+            let custom = Foo(id: uuid)
+            try custom.save(on: self.database).wait()
+            XCTAssertEqual(custom.id, uuid)
+        }
+    }
+}
+
+
+private final class Foo: Model {
+    static let schema = "foos"
+
+    @ID(key: "id")
+    var id: UUID?
+
+    init() { }
+
+    init(id: UUID? = nil) {
+        self.id = id
+    }
+}
+
+private struct CreateFoo: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("foos")
+            .field("id", .uuid, .identifier(auto: false))
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("foos").delete()
+    }
+}

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -53,6 +53,7 @@ public final class FluentBenchmarker {
         try self.testEmptyEagerLoadChildren()
         try self.testUInt8BackedEnum()
         try self.testRange()
+        try self.testCustomID()
     }
     
     public func testCreate() throws {
@@ -1875,7 +1876,7 @@ public final class FluentBenchmarker {
         }
     }
     
-    private func runTest(_ name: String, _ migrations: [Migration], _ test: () throws -> ()) throws {
+    internal func runTest(_ name: String, _ migrations: [Migration], _ test: () throws -> ()) throws {
         self.log("Running \(name)...")
         for migration in migrations {
             do {

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -71,8 +71,27 @@ public final class ID<Value>: AnyID, FieldRepresentable
         case .database:
             self.inputValue = .default
         case .random:
-            let generatable = Value.self as! (RandomGeneratable & Encodable).Type
-            self.inputValue = .bind(generatable.generateRandom())
+            // only generate an id if none is set
+            let generate: Bool
+
+            // check to see if an id has been set
+            switch inputValue {
+            case .some(let value):
+                switch value {
+                case .bind(let value):
+                    generate = (value as? Value) == nil
+                default:
+                    generate = true
+                }
+            case .none:
+                generate = true
+            }
+
+            // if no id set, generate the value
+            if generate {
+                let generatable = Value.self as! (RandomGeneratable & Encodable).Type
+                self.inputValue = .bind(generatable.generateRandom())
+            }
         case .user:
             // do nothing
             break


### PR DESCRIPTION
`ID.Generator.random` no longer overwrites user-supplied identifiers. Fixes https://github.com/vapor/fluent-kit/issues/132.

```swift
@ID(key: "id", generatedBy: .random)
var id: UUID?
```

`.random` is the default for `UUID`. 