### PR TITLE
Fix join(_:on:) Typo

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -395,8 +395,29 @@ public final class FluentBenchmarker {
             let planets = try Planet.query(on: self.database)
                 .join(\.$galaxy)
                 .all().wait()
+
             for planet in planets {
                 let galaxy = try planet.joined(Galaxy.self)
+                switch planet.name {
+                case "Earth":
+                    guard galaxy.name == "Milky Way" else {
+                        throw Failure("unexpected galaxy name: \(galaxy.name)")
+                    }
+                case "PA-99-N2":
+                    guard galaxy.name == "Andromeda" else {
+                        throw Failure("unexpected galaxy name: \(galaxy.name)")
+                    }
+                default: break
+                }
+            }
+
+            let galaxies = try Galaxy.query(on: self.database)
+                .join(Planet.self, on: \Galaxy.$id == \Planet.$galaxy.$id)
+                .all()
+                .wait()
+
+            for galaxy in galaxies {
+                let planet = try galaxy.joined(Planet.self)
                 switch planet.name {
                 case "Earth":
                     guard galaxy.name == "Milky Way" else {

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -152,7 +152,7 @@ public final class QueryBuilder<Model>
 
     @discardableResult
     public func join<Foreign, Local, Value>(
-        _ foreign: KeyPath<Foreign, Field<Value>>,
+        _ foreign: Foreign.Type,
         on filter: JoinFilter<Foreign, Local, Value>,
         method: DatabaseQuery.Join.Method = .inner
     ) -> Self


### PR DESCRIPTION
Fixes a typo in `QueryBuilder.join(_:on:)` which prevented key paths from being passed correctly. 