### PR TITLE
Bind String Contains Operator Values

### DIFF
--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -210,11 +210,11 @@ public struct SQLQueryConverter {
                 let right: SQLExpression
                 switch method {
                 case .anywhere:
-                    right = SQLLiteral.string("%" + string.description + "%")
+                    right = SQLBind("%" + string.description + "%")
                 case .prefix:
-                    right = SQLLiteral.string(string.description + "%")
+                    right = SQLBind(string.description + "%")
                 case .suffix:
-                    right = SQLLiteral.string("%" + string.description)
+                    right = SQLBind("%" + string.description)
                 }
                 return SQLBinaryExpression(
                     left: self.field(field),

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -210,11 +210,11 @@ public struct SQLQueryConverter {
                 let right: SQLExpression
                 switch method {
                 case .anywhere:
-                    right = SQLRaw("\"%" + string.description + "%\"")
+                    right = SQLLiteral.string("%" + string.description + "%")
                 case .prefix:
-                    right = SQLRaw("\"" + string.description + "%\"")
+                    right = SQLLiteral.string(string.description + "%")
                 case .suffix:
-                    right = SQLRaw("\"%" + string.description + "\"")
+                    right = SQLLiteral.string("%" + string.description)
                 }
                 return SQLBinaryExpression(
                     left: self.field(field),

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -212,7 +212,7 @@ public struct SQLQueryConverter {
                 case .anywhere:
                     right = SQLRaw("\"%" + string.description + "%\"")
                 case .prefix:
-                    right = SQLRaw("\"” + string.description + "%\"")
+                    right = SQLRaw("\"" + string.description + "%\"")
                 case .suffix:
                     right = SQLRaw("\"%" + string.description + "\"")
                 }

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -210,11 +210,11 @@ public struct SQLQueryConverter {
                 let right: SQLExpression
                 switch method {
                 case .anywhere:
-                    right = SQLRaw("%" + string.description + "%")
+                    right = SQLRaw("\"%" + string.description + "%\"")
                 case .prefix:
-                    right = SQLRaw(string.description + "%")
+                    right = SQLRaw("\"” + string.description + "%\"")
                 case .suffix:
-                    right = SQLRaw("%" + string.description)
+                    right = SQLRaw("\"%" + string.description + "\"")
                 }
                 return SQLBinaryExpression(
                     left: self.field(field),


### PR DESCRIPTION
String contains operator values (`~~`, `!~`, `~=`, etc) are now correctly bound as query parameters for SQL databases (#140).