### PR TITLE
Add Relation Protocol + Load Method

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker+RelationMethods.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker+RelationMethods.swift
@@ -1,0 +1,38 @@
+extension FluentBenchmarker {
+    public func testRelationMethods() throws {
+        try runTest(#function, [
+            GalaxyMigration(),
+            PlanetMigration(),
+            GalaxySeed(),
+            PlanetSeed()
+        ]) {
+            guard let earth = try Planet.query(on: self.database)
+                .filter(\.$name == "Earth")
+                .first().wait()
+            else {
+                throw Failure("Could not load Planet earth")
+            }
+
+            // test loading relation manually
+            XCTAssertNil(earth.$galaxy.value)
+            try earth.$galaxy.load(on: self.database).wait()
+            XCTAssertNotNil(earth.$galaxy.value)
+            XCTAssertEqual(earth.galaxy.name, "Milky Way")
+
+            let test = Galaxy(name: "Foo")
+            earth.$galaxy.value = test
+            XCTAssertEqual(earth.galaxy.name, "Foo")
+            // test get uses cached value
+            try XCTAssertEqual(earth.$galaxy.get(on: self.database).wait().name, "Foo")
+            // test get can reload relation
+            try XCTAssertEqual(earth.$galaxy.get(reload: true, on: self.database).wait().name, "Milky Way")
+
+            // test clearing loaded relation
+            earth.$galaxy.value = nil
+            XCTAssertNil(earth.$galaxy.value)
+
+            // test get loads relation if nil
+            try XCTAssertEqual(earth.$galaxy.get(on: self.database).wait().name, "Milky Way")
+        }
+    }
+}

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -55,6 +55,7 @@ public final class FluentBenchmarker {
         try self.testRange()
         try self.testCustomID()
         try self.testMultipleSet()
+        try self.testRelationMethods()
     }
     
     public func testCreate() throws {

--- a/Sources/FluentKit/Error.swift
+++ b/Sources/FluentKit/Error.swift
@@ -4,7 +4,7 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
     case idRequired
     case invalidField(name: String, valueType: Any.Type, error: Error)
     case missingField(name: String)
-    case missingEagerLoad(name: String)
+    case relationNotLoaded(name: String)
     case missingParent
     case noResults
 
@@ -14,8 +14,8 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
             return "ID required"
         case .missingField(let name):
             return "field missing: \(name)"
-        case .missingEagerLoad(let name):
-            return "eager load missing: \(name)"
+        case .relationNotLoaded(let name):
+            return "relation not loaded: \(name)"
         case .missingParent:
             return "parent missing"
         case .invalidField(let name, let valueType, let error):

--- a/Sources/FluentKit/Properties/Parent+EagerLoad.swift
+++ b/Sources/FluentKit/Properties/Parent+EagerLoad.swift
@@ -4,7 +4,7 @@ extension Parent: AnyEagerLoadable {
     }
 
     var eagerLoadValueDescription: CustomStringConvertible? {
-        return self.eagerLoadedValue
+        return self.value
     }
 
     func eagerLoad(from eagerLoads: EagerLoads) throws {
@@ -13,7 +13,7 @@ extension Parent: AnyEagerLoadable {
         }
 
         if let subquery = request as? ParentSubqueryEagerLoad<To> {
-            self.eagerLoadedValue = try subquery.get(id: id)
+            self.value = try subquery.get(id: id)
         } else {
             fatalError("unsupported eagerload request: \(request)")
         }
@@ -21,10 +21,6 @@ extension Parent: AnyEagerLoadable {
 }
 
 extension Parent: EagerLoadable {
-    public var eagerLoaded: To? {
-        self.eagerLoadedValue
-    }
-
     public func eagerLoad<Model>(to builder: QueryBuilder<Model>)
         where Model: FluentKit.Model
     {
@@ -41,7 +37,7 @@ extension OptionalParent: AnyEagerLoadable {
     }
 
     var eagerLoadValueDescription: CustomStringConvertible? {
-        return self.eagerLoadedValue
+        return self.value
     }
 
     func eagerLoad(from eagerLoads: EagerLoads) throws {
@@ -49,13 +45,12 @@ extension OptionalParent: AnyEagerLoadable {
             return
         }
 
-        self.didEagerLoad = true
         guard let id = self.id else {
             return
         }
 
         if let subquery = request as? ParentSubqueryEagerLoad<To> {
-            self.eagerLoadedValue = try subquery.get(id: id)
+            self.value = try subquery.get(id: id)
         } else {
             fatalError("unsupported eagerload request: \(request)")
         }
@@ -63,10 +58,6 @@ extension OptionalParent: AnyEagerLoadable {
 }
 
 extension OptionalParent: EagerLoadable {
-    public var eagerLoaded: To? {
-        self.eagerLoadedValue
-    }
-
     public func eagerLoad<Model>(to builder: QueryBuilder<Model>)
         where Model: FluentKit.Model
     {

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -35,8 +35,6 @@ extension AnyField where Self: FieldRepresentable {
 }
 
 public protocol EagerLoadable {
-    associatedtype EagerLoadValue
-    var eagerLoaded: EagerLoadValue? { get }
     func eagerLoad<Model>(to builder: QueryBuilder<Model>)
         where Model: FluentKit.Model
 }

--- a/Sources/FluentKit/Properties/Relation.swift
+++ b/Sources/FluentKit/Properties/Relation.swift
@@ -1,0 +1,23 @@
+public protocol Relation {
+    associatedtype RelatedValue
+
+    var name: String { get }
+    var value: RelatedValue? { get set }
+
+    func load(on database: Database) -> EventLoopFuture<Void>
+}
+
+extension Relation {
+    public func get(reload: Bool = false, on database: Database) -> EventLoopFuture<RelatedValue> {
+        if let value = self.value, !reload {
+            return database.eventLoop.makeSucceededFuture(value)
+        } else {
+            return self.load(on: database).flatMapThrowing {
+                guard let value = self.value else {
+                    throw FluentError.relationNotLoaded(name: self.name)
+                }
+                return value
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `Relation` protocol that `@Parent`, `@OptionalParent`, `@Children`, and `@Siblings` conform to. This protocol exposes a mutable `value` property for manually getting and setting the relation's currently loaded value. This value can be set automatically by eager loading using `QueryBuilder.with`. The `Relation` protocol also adds an asynchronous `load()` method for manually loading the relation's value from the database. `Relation.get()` will now use the currently loaded relation value by default. `get` also has a new `reload` parameter that, if set to `true`, will ignore the currently loaded relation value and always fetch the relation from the database.

```swift
// Fetch a model without eager-loading any relations
let planet = Planet.find(...)

// Relation is not loaded, accessing planet.star would fatalError
// Accessing planet.$star however does not fatalError
print(planet.$star.value) // nil

// Load the relation manually
// This could also be done using `with(\.$star)` in the query builder
try planet.$star.load(on: db).wait() 

// Relation is now loaded
print(planet.$star.value) // Star
print(planet.star.name) // String

// Gets previously loaded star
// No query will be performed
let star = try planet.$star.get(on: db).wait()

// Ignores previously loaded star and fetches from DB
// A single query will be performed
let star = try planet.$star.get(reload: true, on: db).wait()

// Advanced use case for setting custom relation value
planet.$star.value = customStar
```

Note that setting a custom relation value will not affect the relation in the database. Saving a model only updates the models properties. 

The `eagerLoaded` property has been removed since it is now redundant with `value`. 