### PR TITLE
Add QueryBuilder.group for Grouping Filters

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker+Group.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker+Group.swift
@@ -1,0 +1,26 @@
+extension FluentBenchmarker {
+    public func testGroup() throws {
+        try runTest(#function, [
+            GalaxyMigration(),
+            PlanetMigration(),
+            GalaxySeed(),
+            PlanetSeed()
+        ]) {
+            let planets = try Planet.query(on: self.database)
+                .group(.or) {
+                    $0.filter(\.$name == "Earth")
+                        .filter(\.$name == "Mars")
+                }
+                .sort(\.$name)
+                .all().wait()
+
+            switch planets.count {
+            case 2:
+                XCTAssertEqual(planets[0].name, "Earth")
+                XCTAssertEqual(planets[1].name, "Mars")
+            default:
+                XCTFail("Unexpected planets count: \(planets.count)")
+            }
+        }
+    }
+}

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -56,6 +56,7 @@ public final class FluentBenchmarker {
         try self.testCustomID()
         try self.testMultipleSet()
         try self.testRelationMethods()
+        try self.testGroup()
     }
     
     public func testCreate() throws {

--- a/Sources/FluentKit/Query/QueryBuilder+Group.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Group.swift
@@ -1,0 +1,11 @@
+extension QueryBuilder {
+    public func group(
+        _ relation: DatabaseQuery.Filter.Relation = .and,
+        _ closure: (QueryBuilder<Model>) throws -> ()
+    ) rethrows -> Self {
+        let group = QueryBuilder(database: self.database)
+        try closure(group)
+        self.query.filters.append(.group(group.query.filters, relation))
+        return self
+    }
+}


### PR DESCRIPTION
Adds `QueryBuilder.group` for building grouped filters related by `OR` or `AND` logic. `group` accepts a `DatabaseQuery.Filter.Relation` (either `.and` or `.or`) as the first parameter. The second parameter is a closure accepting a temporary `QueryBuilder` that is used to accumulate the grouped filters. 

```swift
let planets = try Planet.query(on: self.database)
    .group(.or) {
        $0.filter(\.$name == "Earth")
            .filter(\.$name == "Mars")
    }
    .sort(\.$name)
    .all().wait()
```

The above example selects all planets where name is equal to Earth _or_ Mars. 

SQLite fulfills this query using the following SQL:

```sql
SELECT "planets"."id", "planets"."name", "planets"."galaxy_id" 
    FROM "planets" 
    WHERE ("planets"."name" = ? OR "planets"."name" = ?) 
    ORDER BY "planets"."name" ASC 
```

With binds: 
```swift
["Earth", "Mars"]
```