### PR TITLE
Rename !~~ Operator to !~

### DIFF
--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -805,8 +805,7 @@ public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> 
     return .init(lhs, .contains(inverse: true, .suffix), .bind(rhs))
 }
 
-infix operator !~~
-public func !~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: FluentKit.Model, Field: FieldRepresentable, Field.Value: CustomStringConvertible
 {
     return .init(lhs, .contains(inverse: true, .anywhere), .bind(rhs))
@@ -881,7 +880,7 @@ public func !~= <Left, Right, Field>(lhs: KeyPath<Left, Field>, rhs: KeyPath<Rig
     return .init(lhs, .contains(inverse: true, .suffix), rhs)
 }
 
-public func !~~ <Left, Right, Field>(lhs: KeyPath<Left, Field>, rhs: KeyPath<Right, Field>) -> ModelFieldFilter<Left, Right>
+public func !~ <Left, Right, Field>(lhs: KeyPath<Left, Field>, rhs: KeyPath<Right, Field>) -> ModelFieldFilter<Left, Right>
     where Left: FluentKit.Model, Right: FluentKit.Model, Field: FieldRepresentable, Field.Value: CustomStringConvertible
 {
     return .init(lhs, .contains(inverse: true, .anywhere), rhs)


### PR DESCRIPTION
Renames the `!~~` (value does not contain string) operator to `!~` to match the "value not in array" operator. This change makes the operators more consistent since `~~` is already overloaded to mean either "values contains string" or "value is in array" depending on usage.