### PR TITLE
Convert AnyModel.schema to a class func

### DIFF
--- a/Sources/FluentBenchmark/City.swift
+++ b/Sources/FluentBenchmark/City.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 public final class City: Model {
-    public static let schema = "cities"
+    public class func schema() -> String { "cities" }
 
     @ID(key: "id")
     public var id: Int?

--- a/Sources/FluentBenchmark/FluentBenchmarker+CustomID.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker+CustomID.swift
@@ -18,7 +18,7 @@ extension FluentBenchmarker {
 
 
 private final class Foo: Model {
-    static let schema = "foos"
+    class func schema() -> String { "foos" }
 
     @ID(key: "id")
     var id: UUID?

--- a/Sources/FluentBenchmark/FluentBenchmarker+MultipleSet.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker+MultipleSet.swift
@@ -21,7 +21,7 @@ extension FluentBenchmarker {
 private final class TestModel: Model {
     struct Migration: FluentKit.Migration {
         func prepare(on database: Database) -> EventLoopFuture<Void> {
-            return database.schema(TestModel.schema)
+            return database.schema(TestModel.schema())
                 .field("id", .int, .identifier(auto: true))
                 .field("int_value", .int)
                 .field("string_value", .string)
@@ -29,10 +29,10 @@ private final class TestModel: Model {
         }
 
         func revert(on database: Database) -> EventLoopFuture<Void> {
-            return database.schema(TestModel.schema).delete()
+            return database.schema(TestModel.schema()).delete()
         }
     }
-    static let schema = "test"
+    class func schema() -> String { "test" }
 
     @ID(key: "id")
     var id: Int?

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -590,7 +590,7 @@ public final class FluentBenchmarker {
     
     public func testNullifyField() throws {
         final class Foo: Model {
-            static let schema = "foos"
+            class func schema() -> String { "foos" }
 
             @ID(key: "id")
             var id: Int?
@@ -684,7 +684,7 @@ public final class FluentBenchmarker {
     
     public func testUniqueFields() throws {
         final class Foo: Model {
-            static let schema = "foos"
+            class func schema() -> String { "foos" }
 
             @ID(key: "id")
             var id: Int?
@@ -781,7 +781,7 @@ public final class FluentBenchmarker {
 
     public func testTimestampable() throws {
         final class User: Model {
-            static let schema = "users"
+            class func schema() -> String { "users" }
 
             @ID(key: "id")
             var id: Int?
@@ -843,7 +843,7 @@ public final class FluentBenchmarker {
             var string: String
         }
         final class User: Model {
-            static let schema = "users"
+            class func schema() -> String { "users" }
 
             @ID(key: "id")
             var id: Int?
@@ -982,7 +982,7 @@ public final class FluentBenchmarker {
 
     public func testUUIDModel() throws {
         final class User: Model {
-            static let schema = "users"
+            class func schema() -> String { "users" }
 
             @ID(key: "id")
             var id: UUID?
@@ -1024,7 +1024,7 @@ public final class FluentBenchmarker {
 
     public func testNewModelDecode() throws {
         final class Todo: Model {
-            static let schema = "todos"
+            class func schema() -> String { "todos" }
 
             @ID(key: "id")
             var id: UUID?
@@ -1427,7 +1427,7 @@ public final class FluentBenchmarker {
     
     public func testSameChildrenFromKey() throws {
         final class Foo: Model {
-            static let schema = "foos"
+            class func schema() -> String { "foos" }
 
             struct _Migration: Migration {
                 func prepare(on database: Database) -> EventLoopFuture<Void> {
@@ -1463,7 +1463,7 @@ public final class FluentBenchmarker {
         }
         
         final class Bar: Model {
-            static let schema = "bars"
+            class func schema() -> String { "bars" }
         
             struct _Migration: Migration {
                 func prepare(on database: Database) -> EventLoopFuture<Void> {
@@ -1498,7 +1498,7 @@ public final class FluentBenchmarker {
         }
         
         final class Baz: Model {
-            static let schema = "bazs"
+            class func schema() -> String { "bazs" }
         
             struct _Migration: Migration {
                 func prepare(on database: Database) -> EventLoopFuture<Void> {
@@ -1561,7 +1561,7 @@ public final class FluentBenchmarker {
         }
 
         final class Foo: Model {
-            static let schema = "foos"
+            class func schema() -> String { "foos" }
 
             struct _Migration: Migration {
                 func prepare(on database: Database) -> EventLoopFuture<Void> {
@@ -1621,7 +1621,7 @@ public final class FluentBenchmarker {
 
     public func testPerformance() throws {
         final class Foo: Model {
-            static let schema = "foos"
+            class func schema() -> String { "foos" }
 
             struct _Migration: Migration {
                 func prepare(on database: Database) -> EventLoopFuture<Void> {
@@ -1808,7 +1808,7 @@ public final class FluentBenchmarker {
             case baz, qux
         }
         final class Foo: Model {
-            static let schema = "foos"
+            class func schema() -> String { "foos" }
 
             struct _Migration: Migration {
                 func prepare(on database: Database) -> EventLoopFuture<Void> {

--- a/Sources/FluentBenchmark/Galaxy.swift
+++ b/Sources/FluentBenchmark/Galaxy.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 public final class Galaxy: Model {
-    public class func schema() -> String { "galaxies" }
+    // Use the default schema name "Galaxy"
 
     public static var migration: Migration {
         return GalaxyMigration()
@@ -27,13 +27,13 @@ public final class Galaxy: Model {
 struct GalaxyMigration: Migration {
     init() {}
     func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("galaxies")
+        return database.schema(Galaxy.schema())
             .field("id", .int, .identifier(auto: true))
             .field("name", .string, .required)
             .create()
     }
 
     func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("galaxies").delete()
+        return database.schema(Galaxy.schema()).delete()
     }
 }

--- a/Sources/FluentBenchmark/Galaxy.swift
+++ b/Sources/FluentBenchmark/Galaxy.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 public final class Galaxy: Model {
-    public static let schema = "galaxies"
+    public class func schema() -> String { "galaxies" }
 
     public static var migration: Migration {
         return GalaxyMigration()

--- a/Sources/FluentBenchmark/Match.swift
+++ b/Sources/FluentBenchmark/Match.swift
@@ -1,5 +1,5 @@
 final class Match: Model {
-    static let schema = "matches"
+    class func schema() -> String { "matches" }
 
     @ID(key: "id")
     var id: Int?

--- a/Sources/FluentBenchmark/Moon.swift
+++ b/Sources/FluentBenchmark/Moon.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 public final class Moon: Model {
-    public static let schema = "moons"
+    public class func schema() -> String { "moons" }
 
     @ID(key: "id")
     public var id: Int?

--- a/Sources/FluentBenchmark/Planet.swift
+++ b/Sources/FluentBenchmark/Planet.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 public final class Planet: Model {
-    public static let schema = "planets"
+    public class func schema() -> String { "planets" }
 
     @ID(key: "id")
     public var id: Int?

--- a/Sources/FluentBenchmark/PlanetTag.swift
+++ b/Sources/FluentBenchmark/PlanetTag.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 final class PlanetTag: Model {
-    static let schema = "planet+tag"
+    class func schema() -> String { "planet+tag" }
     
     @ID(key: "id")
     var id: Int?

--- a/Sources/FluentBenchmark/School.swift
+++ b/Sources/FluentBenchmark/School.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 public final class School: Model {
-    public static let schema = "schools"
+    public class func schema() -> String { "schools" }
 
     @ID(key: "id")
     public var id: Int?

--- a/Sources/FluentBenchmark/Tag.swift
+++ b/Sources/FluentBenchmark/Tag.swift
@@ -1,7 +1,7 @@
 import FluentKit
 
 public final class Tag: Model {
-    public static let schema = "tags"
+    public class func schema() -> String { "tags" }
 
     @ID(key: "id")
     public var id: Int?

--- a/Sources/FluentBenchmark/Team.swift
+++ b/Sources/FluentBenchmark/Team.swift
@@ -1,5 +1,5 @@
 final class Team: Model {
-    static let schema = "teams"
+    class func schema() -> String { "teams" }
 
     @ID(key: "id")
     var id: Int?

--- a/Sources/FluentBenchmark/Trash.swift
+++ b/Sources/FluentBenchmark/Trash.swift
@@ -2,7 +2,7 @@ import Foundation
 import FluentKit
 
 final class Trash: Model {
-    static let schema = "trash"
+    class func schema() -> String { "trash" }
 
     @ID(key: "id")
     var id: UUID?
@@ -27,7 +27,7 @@ final class Trash: Model {
 
 struct TrashMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(Trash.schema)
+        return database.schema(Trash.schema())
             .field("id", .uuid, .identifier(auto: false), .custom("UNIQUE"))
             .field("contents", .string, .required)
             .field("deleted_at", .datetime)
@@ -35,6 +35,6 @@ struct TrashMigration: Migration {
     }
 
     func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(Trash.schema).delete()
+        return database.schema(Trash.schema()).delete()
     }
 }

--- a/Sources/FluentBenchmark/User.swift
+++ b/Sources/FluentBenchmark/User.swift
@@ -8,7 +8,7 @@ final class User: Model {
         var name: String
         var type: Animal
     }
-    static let schema = "users"
+    class func schema() -> String { "users" }
     
     @ID(key: "id")
     var id: Int?

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Stores information about `Migration`s that have been run.
 public final class MigrationLog: Model {
-    public static let schema = "fluent"
+    public class func schema() -> String { "fluent" }
 
     public static var migration: Migration {
         return MigrationLogMigration()

--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -1,5 +1,5 @@
 public protocol AnyModel: class, CustomStringConvertible, Codable {
-    static var schema: String { get }
+    static func schema() -> String
     init()
 }
 
@@ -221,7 +221,7 @@ extension AnyModel {
         }
         let joined = Joined()
         try joined.output(
-            from: output.row.prefixed(by: Joined.schema + "_").output(for: output.database)
+            from: output.row.prefixed(by: Joined.schema() + "_").output(for: output.database)
         )
         return joined
     }

--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -3,6 +3,12 @@ public protocol AnyModel: class, CustomStringConvertible, Codable {
     init()
 }
 
+extension AnyModel {
+    public static func schema() -> String {
+        return "\(Self.self)"
+    }
+}
+
 public protocol ModelAlias {
     associatedtype Model: FluentKit.Model
     static var alias: String { get }

--- a/Sources/FluentKit/Model/Timestampable.swift
+++ b/Sources/FluentKit/Model/Timestampable.swift
@@ -31,7 +31,7 @@ extension AnyModel {
 
         let deletedAtField = DatabaseQuery.Field.field(
             path: [timestamp.key],
-            schema: Self.schema,
+            schema: Self.schema(),
             alias: nil
         )
         let isNull = DatabaseQuery.Filter.value(deletedAtField, .equal, .null)

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -117,9 +117,9 @@ extension Children: AnyEagerLoadable {
         let ref = To()
         switch self.parentKey {
         case .optional(let optional):
-            return "c:\(To.schema):\(ref[keyPath: optional].key)"
+            return "c:\(To.schema()):\(ref[keyPath: optional].key)"
         case .required(let required):
-            return "c:\(To.schema):\(ref[keyPath: required].key)"
+            return "c:\(To.schema()):\(ref[keyPath: required].key)"
         }
     }
 

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -17,7 +17,7 @@ public final class QueryBuilder<Model>
     
     public init(database: Database) {
         self.database = database
-        self.query = .init(schema: Model.schema)
+        self.query = .init(schema: Model.schema())
         self.eagerLoads = .init()
         self.includeDeleted = false
         self.joinedModels = []
@@ -191,15 +191,15 @@ public final class QueryBuilder<Model>
     {
         self.joinedModels.append(.init(model: Foreign(), alias: schemaAlias))
         self.query.joins.append(.join(
-            schema: .schema(name: Foreign.schema, alias: schemaAlias),
+            schema: .schema(name: Foreign.schema(), alias: schemaAlias),
             foreign: .field(
                 path: [foreignField],
-                schema: schemaAlias ?? Foreign.schema,
+                schema: schemaAlias ?? Foreign.schema(),
                 alias: nil
             ),
             local: .field(
                 path: [localField],
-                schema: Local.schema,
+                schema: Local.schema(),
                 alias: nil
             ),
             method: method
@@ -212,7 +212,7 @@ public final class QueryBuilder<Model>
     @discardableResult
     public func filter(_ filter: ModelValueFilter<Model>) -> Self {
         return self.filter(
-            .field(path: filter.path, schema: Model.schema, alias: nil),
+            .field(path: filter.path, schema: Model.schema(), alias: nil),
             filter.method,
             filter.value
         )
@@ -221,9 +221,9 @@ public final class QueryBuilder<Model>
     @discardableResult
     public func filter(_ filter: ModelFieldFilter<Model, Model>) -> Self {
         return self.filter(
-            .field(path: filter.lhsPath, schema: Model.schema, alias: nil),
+            .field(path: filter.lhsPath, schema: Model.schema(), alias: nil),
             filter.method,
-            .field(path: filter.rhsPath, schema: Model.schema, alias: nil)
+            .field(path: filter.rhsPath, schema: Model.schema(), alias: nil)
         )
     }
 
@@ -232,9 +232,9 @@ public final class QueryBuilder<Model>
         where Left: FluentKit.Model, Right: FluentKit.Model
     {
         return self.filter(
-            .field(path: filter.lhsPath, schema: Left.schema, alias: nil),
+            .field(path: filter.lhsPath, schema: Left.schema(), alias: nil),
             filter.method,
-            .field(path: filter.rhsPath, schema: Right.schema, alias: nil)
+            .field(path: filter.rhsPath, schema: Right.schema(), alias: nil)
         )
     }
 
@@ -275,7 +275,7 @@ public final class QueryBuilder<Model>
         return self.filter(
             .field(
                 path: [fieldName],
-                schema: alias ?? Joined.schema,
+                schema: alias ?? Joined.schema(),
                 alias: nil
             ),
             .subset(inverse: false),
@@ -310,7 +310,7 @@ public final class QueryBuilder<Model>
         where Joined: FluentKit.Model
     {
         return self.filter(
-            .field(path: filter.path, schema: Joined.schema, alias: nil),
+            .field(path: filter.path, schema: Joined.schema(), alias: nil),
             filter.method,
             filter.value
         )
@@ -321,9 +321,9 @@ public final class QueryBuilder<Model>
         where Joined: FluentKit.Model
     {
         return self.filter(
-            .field(path: filter.lhsPath, schema: Joined.schema, alias: nil),
+            .field(path: filter.lhsPath, schema: Joined.schema(), alias: nil),
             filter.method,
-            .field(path: filter.rhsPath, schema: Joined.schema, alias: nil)
+            .field(path: filter.rhsPath, schema: Joined.schema(), alias: nil)
         )
     }
     
@@ -343,7 +343,7 @@ public final class QueryBuilder<Model>
     {
         return self.filter(.field(
             path: [fieldName],
-            schema: Model.schema,
+            schema: Model.schema(),
             alias: nil
         ), method, .bind(value))
     }
@@ -351,9 +351,9 @@ public final class QueryBuilder<Model>
     @discardableResult
     public func filter(_ lhsFieldName: String, _ method: DatabaseQuery.Filter.Method, _ rhsFieldName: String) -> Self {
         return self.filter(
-            .field(path: [lhsFieldName], schema: Model.schema, alias: nil),
+            .field(path: [lhsFieldName], schema: Model.schema(), alias: nil),
             method,
-            .field(path: [rhsFieldName], schema: Model.schema, alias: nil)
+            .field(path: [rhsFieldName], schema: Model.schema(), alias: nil)
         )
     }
 
@@ -439,7 +439,7 @@ public final class QueryBuilder<Model>
     {
         self.query.sorts.append(.sort(field: .field(
             path: [field],
-            schema: alias ?? Joined.schema,
+            schema: alias ?? Joined.schema(),
             alias: nil
         ), direction: direction))
         return self
@@ -468,7 +468,7 @@ public final class QueryBuilder<Model>
     {
         let field: DatabaseQuery.Field = .field(
             path: [fieldName] + path.path,
-            schema: Model.schema,
+            schema: Model.schema(),
             alias: nil
         )
         return self.filter(field, method, .bind(value))
@@ -568,7 +568,7 @@ public final class QueryBuilder<Model>
             method: method,
             fields: [.field(
                 path: [fieldName],
-                schema: Model.schema,
+                schema: Model.schema(),
                 alias: nil)
             ]
         ))]
@@ -683,7 +683,7 @@ public final class QueryBuilder<Model>
             query.fields = Model().fields.map { (_, field) in
                 return .field(
                     path: [field.key],
-                    schema: Model.schema,
+                    schema: Model.schema(),
                     alias: nil
                 )
             }
@@ -691,8 +691,8 @@ public final class QueryBuilder<Model>
                 query.fields += joined.model.fields.map { (_, field) in
                     return .field(
                         path: [field.key],
-                        schema: joined.alias ?? type(of: joined.model).schema,
-                        alias: (joined.alias ?? type(of: joined.model).schema) + "_" + field.key
+                        schema: joined.alias ?? type(of: joined.model).schema(),
+                        alias: (joined.alias ?? type(of: joined.model).schema()) + "_" + field.key
                     )
                 }
             }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -217,7 +217,7 @@ final class FluentKitTests: XCTestCase {
 }
 
 final class Planet2: Model {
-    static let schema = "planets"
+    class func schema() -> String { "planets" }
     
     @ID(key: "id")
     var id: Int?

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -31,7 +31,7 @@ final class FluentKitTests: XCTestCase {
         
         _ = try Planet.query(on: db).join(\.$galaxy).sort(\Galaxy.$name, .ascending).all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"ORDER BY "galaxies"."name" ASC"#), true)
+        XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"ORDER BY "Galaxy"."name" ASC"#), true)
         db.reset()
         
         _ = try Planet.query(on: db).sort(\.$id, .descending).all().wait()
@@ -41,7 +41,7 @@ final class FluentKitTests: XCTestCase {
         
         _ = try Planet.query(on: db).join(\.$galaxy).sort(\Galaxy.$id, .ascending).all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"ORDER BY "galaxies"."id" ASC"#), true)
+        XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"ORDER BY "Galaxy"."id" ASC"#), true)
         db.reset()
         
         _ = try Planet.query(on: db).sort("name", .descending).all().wait()
@@ -51,7 +51,7 @@ final class FluentKitTests: XCTestCase {
         
         _ = try Planet.query(on: db).join(\.$galaxy).sort(Galaxy.self, "name", .ascending).all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"ORDER BY "galaxies"."name" ASC"#), true)
+        XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"ORDER BY "Galaxy"."name" ASC"#), true)
         db.reset()
     }
 
@@ -92,19 +92,19 @@ final class FluentKitTests: XCTestCase {
     func testForeignKeyFieldConstraint() throws {
         let db = DummyDatabaseForTestSQLSerializer()
         try db.schema("planets")
-            .field("galaxy_id", .int64, .references("galaxies", "id"))
+            .field("galaxy_id", .int64, .references(Galaxy.schema(), "id"))
             .create()
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT REFERENCES "galaxies" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT REFERENCES "Galaxy" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)"#)
         db.reset()
 
         try db.schema("planets")
-            .field("galaxy_id", .int64, .references("galaxies", "id", onDelete: .restrict, onUpdate: .cascade))
+            .field("galaxy_id", .int64, .references(Galaxy.schema(), "id", onDelete: .restrict, onUpdate: .cascade))
             .create()
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT REFERENCES "galaxies" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT REFERENCES "Galaxy" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)"#)
     }
 
     func testMultipleFieldConstraint() throws {
@@ -142,25 +142,25 @@ final class FluentKitTests: XCTestCase {
         let db = DummyDatabaseForTestSQLSerializer()
         try db.schema("planets")
             .field("galaxy_id", .int64)
-            .foreignKey("galaxy_id", references: "galaxies", "id")
+            .foreignKey("galaxy_id", references: Galaxy.schema(), "id")
             .create()
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:planets.galaxy_id+planets.id" FOREIGN KEY ("galaxy_id") REFERENCES "galaxies" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:planets.galaxy_id+planets.id" FOREIGN KEY ("galaxy_id") REFERENCES "Galaxy" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)"#)
         db.reset()
 
         try db.schema("planets")
             .field("galaxy_id", .int64)
             .foreignKey(
                 "galaxy_id",
-                references: "galaxies", "id",
+                references: Galaxy.schema(), "id",
                 onDelete: .restrict,
                 onUpdate: .cascade
             )
             .create()
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:planets.galaxy_id+planets.id" FOREIGN KEY ("galaxy_id") REFERENCES "galaxies" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:planets.galaxy_id+planets.id" FOREIGN KEY ("galaxy_id") REFERENCES "Galaxy" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)"#)
     }
     
     func testDecodeWithoutID() throws {


### PR DESCRIPTION
This pull request changes AnyModel.schema from:

```swift
static var schema: String { get }
```

to

```swift
static func schema() -> String
```

The purpose of this change is to allow users to create generic types that inherit from Model, like:

```swift
class Annotations<ModelType: Model>: Model {
    class func schema() -> String {
        return ModelType.schema() + "_annotations"
    }
    
    @ID(key: "id")
    var id: Int?
    
    @Parent(key: "entity_id")
    var entity: ModelType

    @Field(key: "note")
    var note: String
}
```

Swift does not allow generic types to define static properties, but it does allow them to define class functions.

In addition, I have provided a default implementation of AnyModel.schema() that simply returns the name of the class. This means that many models do not need to specify the schema at all.
In the unit tests, I have updated the Galaxy class to use the default schema name instead of a custom one.

We may want to enhance the default implementation of AnyModel.schema() to be smarter about the rules for naming database tables. It might need to substitute underscores for other punctuation, or use all lowercase letters. But since the user can always override the default implementation, this is not critical.

I have also changed the examples in the unit tests to use `class func` rather than `static`, because `static` implies `final` and users may not want their model classes to be final. While static is fine in the unit tests, users who copy this into their own code may not realize that static implies final, and then get stuck when they try to subclass their own model classes.