### PR TITLE
Include superclasses when searching for model properties

### DIFF
--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -227,10 +227,16 @@ extension AnyModel {
     }
 
     var anyID: AnyID {
-        guard let id = Mirror(reflecting: self).descendant("_id") as? AnyID else {
-            fatalError("id property must be declared using @ID")
+        var mirror: Mirror = Mirror(reflecting: self)
+        while true {
+            if let id = mirror.descendant("_id") as? AnyID { return id }
+            if let m = mirror.superclassMirror {
+                mirror = m
+            }
+            else {
+                fatalError("id property must be declared using @ID")
+            }
         }
-        return id
     }
 }
 

--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -232,8 +232,7 @@ extension AnyModel {
             if let id = mirror.descendant("_id") as? AnyID { return id }
             if let m = mirror.superclassMirror {
                 mirror = m
-            }
-            else {
+            } else {
                 fatalError("id property must be declared using @ID")
             }
         }

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -79,8 +79,8 @@ extension AnyModel {
     
     var properties: [(String, AnyProperty)] {
         var props: [(String, AnyProperty)] = []
-        var mirror: Mirror = Mirror(reflecting: self)
-        while true {
+        var currentMirror: Mirror? = Mirror(reflecting: self)
+        while let mirror = currentMirror {
             props.append(contentsOf: mirror.children
                 .compactMap { child in
                     guard let label = child.label else {
@@ -92,13 +92,9 @@ extension AnyModel {
                     // remove underscore
                     return (String(label.dropFirst()), property)
             })
-            if let m = mirror.superclassMirror {
-                mirror = m
-            }
-            else {
-                return props
-            }
+            currentMirror = mirror.superclassMirror
         }
+        return props
     }
 }
 

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -78,18 +78,27 @@ extension AnyModel {
     }
     
     var properties: [(String, AnyProperty)] {
-        return Mirror(reflecting: self)
-            .children
-            .compactMap { child in
-                guard let label = child.label else {
-                    return nil
-                }
-                guard let property = child.value as? AnyProperty else {
-                    return nil
-                }
-                // remove underscore
-                return (String(label.dropFirst()), property)
+        var props: [(String, AnyProperty)] = []
+        var mirror: Mirror = Mirror(reflecting: self)
+        while true {
+            props.append(contentsOf: mirror.children
+                .compactMap { child in
+                    guard let label = child.label else {
+                        return nil
+                    }
+                    guard let property = child.value as? AnyProperty else {
+                        return nil
+                    }
+                    // remove underscore
+                    return (String(label.dropFirst()), property)
+            })
+            if let m = mirror.superclassMirror {
+                mirror = m
             }
+            else {
+                return props
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Improves `AnyModel.anyID` and `AnyModel.properties` so they can find model properties in superclasses. This is needed to allow class inheritance in models like:

```swift
class Foo: Model {
    class var schema: String { "foo" }

    @ID(key: "id")
    var id: Int?
    
    required init() { }
}

class Bar: Foo {
    class override var schema: String { "bar" }
    
    @Field(key: "value")
    var value: String
}
```