### PR TITLE
Support dynamic ID key on create

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker+ID.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker+ID.swift
@@ -1,0 +1,41 @@
+extension FluentBenchmarker {
+    public func testNonstandardIDKey() throws {
+        try self.runTest(#function, [
+            FooMigration()
+        ]) {
+            let foo = Foo(baz: "qux")
+            try foo.save(on: self.database).wait()
+            XCTAssertNotNil(foo.id)
+        }
+    }
+}
+
+private final class Foo: Model {
+    static let schema = "foos"
+
+    @ID(key: "bar")
+    var id: Int?
+
+    @Field(key: "baz")
+    var baz: String
+
+    init() { }
+
+    init(id: Int? = nil, baz: String) {
+        self.id = id
+        self.baz = baz
+    }
+}
+
+private struct FooMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("foos")
+            .field("bar", .int, .identifier(auto: true))
+            .field("baz", .string, .required)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("foos").delete()
+    }
+}

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -57,6 +57,7 @@ public final class FluentBenchmarker {
         try self.testMultipleSet()
         try self.testRelationMethods()
         try self.testGroup()
+        try self.testNonstandardIDKey()
     }
     
     public func testCreate() throws {

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -26,8 +26,8 @@ extension Model {
         return promise.futureResult.flatMapThrowing { output in
             var input = self.input
             if self._$id.generator == .database {
-                let id = try output.decode("fluentID", as: Self.IDValue.self)
-                input[Self.key(for: \._$id)] = .bind(id)
+                let idKey = Self.key(for: \._$id)
+                input[idKey] = try .bind(output.decode(idKey, as: Self.IDValue.self))
             }
             try self.output(from: SavedInput(input).output(for: database))
         }
@@ -48,8 +48,9 @@ extension Model {
             .set(input)
             .action(.update)
             .run()
-            .flatMapThrowing {
-                try self.output(from: SavedInput(input).output(for: database))
+            .flatMapThrowing
+        {
+            try self.output(from: SavedInput(input).output(for: database))
         }
     }
     
@@ -75,8 +76,9 @@ extension Model {
             .filter(\._$id == self.id!)
             .action(.delete)
             .run()
-            .map {
-                self._$id.exists = false
+            .map
+        {
+            self._$id.exists = false
         }
     }
     
@@ -98,9 +100,10 @@ extension Model {
             .set(self.input)
             .action(.update)
             .run()
-            .flatMapThrowing {
-                try self.output(from: SavedInput(self.input).output(for: database))
-                self._$id.exists = true
+            .flatMapThrowing
+        {
+            try self.output(from: SavedInput(self.input).output(for: database))
+            self._$id.exists = true
         }
     }
     

--- a/Sources/FluentKit/Query/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/DatabaseQuery.swift
@@ -219,6 +219,7 @@ public struct DatabaseQuery: CustomStringConvertible {
     public var limits: [Limit]
     public var offsets: [Offset]
     public var schema: String
+    public var idKey: String
     
     public var description: String {
         var parts = [
@@ -237,8 +238,9 @@ public struct DatabaseQuery: CustomStringConvertible {
         return parts.joined(separator: " ")
     }
 
-    init(schema: String) {
+    init(schema: String, idKey: String) {
         self.schema = schema
+        self.idKey = idKey
         self.fields = []
         self.action = .read
         self.filters = []

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -17,7 +17,7 @@ public final class QueryBuilder<Model>
     
     public init(database: Database) {
         self.database = database
-        self.query = .init(schema: Model.schema)
+        self.query = .init(schema: Model.schema, idKey: Model.key(for: \._$id))
         self.eagerLoads = .init()
         self.includeDeleted = false
         self.joinedModels = []


### PR DESCRIPTION
Support ID keys other than `"id"` when saving a model that uses a database-generated identifier (fixes https://github.com/vapor/fluent-postgres-driver/issues/123, #153). This change adds `idKey` to `DatabaseQuery` and updates models to expect newly saved IDs to be returned using the id key instead of hard-coded `"fluentID"`. 