### PR TITLE
Don't perform eager loads on aggregate queries

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -546,6 +546,20 @@ public final class FluentBenchmarker {
             guard maxID == 9 else {
                 throw Failure("unexpected maxID: \(maxID ?? 0)")
             }
+            // eager loads ignored
+            let countWEagerLoads = try Galaxy.query(on: self.database)
+                .with(\.$planets)
+                .count().wait()
+            guard countWEagerLoads == 3 else {
+                throw Failure("unexpected count: \(countWEagerLoads)")
+            }
+            // eager loads ignored again
+            let maxIDWEagerLoads = try Galaxy.query(on: self.database)
+                .with(\.$planets)
+                .max(\.$id).wait()
+            guard maxIDWEagerLoads == 3 else {
+                throw Failure("unexpected maxID: \(maxIDWEagerLoads ?? 0)")
+            }
         }
         // empty db
         try runTest(#function, [

--- a/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
@@ -8,15 +8,8 @@ extension QueryBuilder {
     public func paginate(
         _ request: PageRequest
     ) -> EventLoopFuture<Page<Model>> {
-        // Remove all eager load requests when counting the rows
-        // otherwise we try to read IDs from the count reply when
-        // performing the eager load subqueries.
-        let countQueryBuilder = self.copy()
-        countQueryBuilder.eagerLoads = .init()
-        let count = countQueryBuilder.count()
-        
+        let count = self.copy().count()
         let items = self.range(request.start..<request.end).all()
-        
         return items.and(count).map { (models, total) in
             Page(
                 items: models,

--- a/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Paginate.swift
@@ -8,8 +8,8 @@ extension QueryBuilder {
     public func paginate(
         _ request: PageRequest
     ) -> EventLoopFuture<Page<Model>> {
-        let count = self.copy().count()
-        let items = self.range(request.start..<request.end).all()
+        let count = self.count()
+        let items = self.copy().range(request.start..<request.end).all()
         return items.and(count).map { (models, total) in
             Page(
                 items: models,

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -564,6 +564,10 @@ public final class QueryBuilder<Model>
         where Result: Codable
     {
         let copy = self.copy()
+        // Remove all eager load requests otherwise we try to
+        // read IDs from the aggreate reply when performing
+        // the eager load subqueries.
+        copy.eagerLoads = .init()
         copy.query.fields = [.aggregate(.fields(
             method: method,
             fields: [.field(


### PR DESCRIPTION
Fixes an error when using eager loading and aggregate methods on the same query. Previously this would generate a fatalError when attempting to perform the subquery for eager loading.