### PR TITLE
Include `name` in relation not loaded message

### DIFF
--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -26,7 +26,7 @@ public final class Children<From, To>: AnyProperty
     public var wrappedValue: [To] {
         get {
             guard let value = self.value else {
-                fatalError("Children relation not loaded.")
+                fatalError("Children relation not eager loaded, use $ prefix to access: \(name)")
             }
             return value
         }

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -8,7 +8,7 @@ public final class Parent<To>
     public var wrappedValue: To {
         get {
             guard let value = self.value else {
-                fatalError("Parent relation \(name) not eager loaded, use $ prefix to access")
+                fatalError("Parent relation not eager loaded, use $ prefix to access: \(name)")
             }
             return value
         }

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -8,7 +8,7 @@ public final class Parent<To>
     public var wrappedValue: To {
         get {
             guard let value = self.value else {
-                fatalError("Parent relation not eager loaded, use $ prefix to access")
+                fatalError("Parent relation \(name) not eager loaded, use $ prefix to access")
             }
             return value
         }

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -28,7 +28,7 @@ public final class Siblings<From, To, Through>: AnyProperty
     public var wrappedValue: [To] {
         get {
             guard let value = self.value else {
-                fatalError("Siblings relation not loaded.")
+                fatalError("Siblings relation not eager loaded, use $ prefix to access: \(name)")
             }
             return value
         }


### PR DESCRIPTION
Includes the name of the relation in the error message if the relation is accessed before being loaded. 