### PR TITLE
add FieldKey type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: apt update -y; apt install -y libsqlite3-dev
-    - run: git clone -b master https://github.com/vapor/fluent-sqlite-driver.git
+    - run: git clone -b tn-field-key https://github.com/vapor/fluent-sqlite-driver.git
       working-directory: ./
     - run: swift package edit fluent-kit --revision ${{ github.sha }}
       working-directory: ./fluent-sqlite-driver
@@ -42,7 +42,7 @@ jobs:
           POSTGRES_PASSWORD: vapor_password
     runs-on: ubuntu-latest
     steps:
-    - run: git clone -b master https://github.com/vapor/fluent-postgres-driver.git
+    - run: git clone -b tn-field-key https://github.com/vapor/fluent-postgres-driver.git
       working-directory: ./
     - run: swift package edit fluent-kit --revision ${{ github.sha }}
       working-directory: ./fluent-postgres-driver
@@ -63,7 +63,7 @@ jobs:
           MYSQL_PASSWORD: vapor_password
     runs-on: ubuntu-latest
     steps:
-    - run: git clone -b master https://github.com/vapor/fluent-mysql-driver.git
+    - run: git clone -b tn-field-key https://github.com/vapor/fluent-mysql-driver.git
       working-directory: ./
     - run: swift package edit fluent-kit --revision ${{ github.sha }}
       working-directory: ./fluent-mysql-driver

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -38,7 +38,6 @@ public final class FluentBenchmarker {
         try self.testMultipleSet()
         try self.testNestedModel()
         try self.testNewModelDecode()
-        try self.testNonstandardIDKey()
         try self.testNullifyField()
         try self.testOptionalParent()
         try self.testPagination()

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -4,8 +4,6 @@ import NIO
 import XCTest
 
 public final class FluentBenchmarker {
-    public static var idKey: String = "id"
-
     public let database: Database
     
     public init(database: Database) {

--- a/Sources/FluentBenchmark/SolarSystem/Galaxy.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Galaxy.swift
@@ -3,7 +3,7 @@ import FluentKit
 public final class Galaxy: Model {
     public static let schema = "galaxies"
     
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     public var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/SolarSystem/Moon.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Moon.swift
@@ -3,7 +3,7 @@ import FluentKit
 public final class Moon: Model {
     public static let schema = "moons"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     public var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/SolarSystem/Planet.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Planet.swift
@@ -3,7 +3,7 @@ import FluentKit
 public final class Planet: Model {
     public static let schema = "planets"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     public var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/SolarSystem/PlanetTag.swift
+++ b/Sources/FluentBenchmark/SolarSystem/PlanetTag.swift
@@ -3,7 +3,7 @@ import FluentKit
 public final class PlanetTag: Model {
     public static let schema = "planet+tag"
     
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     public var id: UUID?
 
     @Parent(key: "planet_id")

--- a/Sources/FluentBenchmark/SolarSystem/Star.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Star.swift
@@ -3,7 +3,7 @@ import FluentKit
 public final class Star: Model {
     public static let schema = "stars"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     public var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/SolarSystem/Tag.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Tag.swift
@@ -3,7 +3,7 @@ import FluentKit
 public final class Tag: Model {
     public static let schema = "tags"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     public var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/Tests/Array.swift
+++ b/Sources/FluentBenchmark/Tests/Array.swift
@@ -22,7 +22,7 @@ extension FluentBenchmarker {
                 }
             }
 
-            @ID(key: FluentBenchmarker.idKey)
+            @ID(key: .id)
             var id: UUID?
 
             @Field(key: "bar")

--- a/Sources/FluentBenchmark/Tests/Children.swift
+++ b/Sources/FluentBenchmark/Tests/Children.swift
@@ -29,7 +29,7 @@ extension FluentBenchmarker {
 private final class Foo: Model {
     static let schema = "foos"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")
@@ -65,7 +65,7 @@ private struct FooMigration: Migration {
 private final class Bar: Model {
     static let schema = "bars"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "bar")
@@ -100,7 +100,7 @@ private struct BarMigration: Migration {
 private final class Baz: Model {
     static let schema = "bazs"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "baz")

--- a/Sources/FluentBenchmark/Tests/CustomID.swift
+++ b/Sources/FluentBenchmark/Tests/CustomID.swift
@@ -20,7 +20,7 @@ extension FluentBenchmarker {
 private final class Foo: Model {
     static let schema = "foos"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     init() { }

--- a/Sources/FluentBenchmark/Tests/Enum.swift
+++ b/Sources/FluentBenchmark/Tests/Enum.swift
@@ -19,7 +19,7 @@ private enum Bar: UInt8, Codable {
 private final class Foo: Model {
     static let schema = "foos"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "bar")

--- a/Sources/FluentBenchmark/Tests/ID.swift
+++ b/Sources/FluentBenchmark/Tests/ID.swift
@@ -1,14 +1,4 @@
 extension FluentBenchmarker {
-    public func testNonstandardIDKey() throws {
-        try self.runTest(#function, [
-            FooMigration()
-        ]) {
-            let foo = Foo(baz: "qux")
-            try foo.save(on: self.database).wait()
-            XCTAssertNotNil(foo.id)
-        }
-    }
-
     public func testAutoincrementingID() throws {
         try self.runTest(#function, [
             FooMigration()
@@ -26,8 +16,8 @@ extension FluentBenchmarker {
 private final class Foo: Model {
     static let schema = "foos"
 
-    @ID(key: "bar")
-    var id: UUID?
+    @ID(key: .id)
+    var id: Int?
 
     @Field(key: "baz")
     var baz: String
@@ -43,7 +33,7 @@ private final class Foo: Model {
 private struct FooMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         database.schema("foos")
-            .field("bar", .uuid, .identifier(auto: false))
+            .field(.id, .int, .identifier(auto: true))
             .field("baz", .string, .required)
             .create()
     }

--- a/Sources/FluentBenchmark/Tests/ID.swift
+++ b/Sources/FluentBenchmark/Tests/ID.swift
@@ -15,10 +15,10 @@ extension FluentBenchmarker {
         ]) {
             let foo1 = Foo(baz: "qux")
             try foo1.save(on: self.database).wait()
-            XCTAssertEqual(foo1.id, 1)
+            XCTAssertNotNil(foo1.id)
             let foo2 = Foo(baz: "qux")
             try foo2.save(on: self.database).wait()
-            XCTAssertEqual(foo2.id, 2)
+            XCTAssertNotNil(foo2.id)
         }
     }
 }
@@ -27,14 +27,14 @@ private final class Foo: Model {
     static let schema = "foos"
 
     @ID(key: "bar")
-    var id: Int?
+    var id: UUID?
 
     @Field(key: "baz")
     var baz: String
 
     init() { }
 
-    init(id: Int? = nil, baz: String) {
+    init(id: IDValue? = nil, baz: String) {
         self.id = id
         self.baz = baz
     }
@@ -43,7 +43,7 @@ private final class Foo: Model {
 private struct FooMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         database.schema("foos")
-            .field("bar", .int, .identifier(auto: true))
+            .field("bar", .uuid, .identifier(auto: false))
             .field("baz", .string, .required)
             .create()
     }

--- a/Sources/FluentBenchmark/Tests/Join.swift
+++ b/Sources/FluentBenchmark/Tests/Join.swift
@@ -134,7 +134,7 @@ extension FluentBenchmarker {
 private final class Team: Model {
     static let schema = "teams"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")
@@ -170,7 +170,7 @@ private struct TeamMigration: Migration {
 private final class Match: Model {
     static let schema = "matches"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")
@@ -237,7 +237,7 @@ private struct TeamMatchSeed: Migration {
 private final class School: Model {
     static let schema = "schools"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")
@@ -323,7 +323,7 @@ private struct SchoolSeed: Migration {
 private final class City: Model {
     static let schema = "cities"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/Tests/Middleware.swift
+++ b/Sources/FluentBenchmark/Tests/Middleware.swift
@@ -57,7 +57,7 @@ private struct TestError: Error {
 private final class User: Model {
     static let schema = "users"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/Tests/Model.swift
+++ b/Sources/FluentBenchmark/Tests/Model.swift
@@ -3,7 +3,7 @@ extension FluentBenchmarker {
         final class User: Model {
             static let schema = "users"
 
-            @ID(key: FluentBenchmarker.idKey)
+            @ID(key: .id)
             var id: UUID?
 
             @Field(key: "name")
@@ -43,7 +43,7 @@ extension FluentBenchmarker {
         final class Todo: Model {
             static let schema = "todos"
 
-            @ID(key: FluentBenchmarker.idKey)
+            @ID(key: .id)
             var id: UUID?
 
             @Field(key: "title")
@@ -143,7 +143,7 @@ extension FluentBenchmarker {
 private final class Foo: Model {
     static let schema = "foos"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "bar")

--- a/Sources/FluentBenchmark/Tests/MultipleSet.swift
+++ b/Sources/FluentBenchmark/Tests/MultipleSet.swift
@@ -21,7 +21,7 @@ extension FluentBenchmarker {
 private final class Test: Model {
     static let schema = "test"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "int_value")

--- a/Sources/FluentBenchmark/Tests/NestedModel.swift
+++ b/Sources/FluentBenchmark/Tests/NestedModel.swift
@@ -56,7 +56,7 @@ private final class User: Model {
     }
     static let schema = "users"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/Tests/OptionalParent.swift
+++ b/Sources/FluentBenchmark/Tests/OptionalParent.swift
@@ -59,7 +59,7 @@ private final class User: Model {
     }
     static let schema = "users"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/Tests/Performance.swift
+++ b/Sources/FluentBenchmark/Tests/Performance.swift
@@ -33,7 +33,7 @@ extension FluentBenchmarker {
                 var baz: String
             }
 
-            @ID(key: FluentBenchmarker.idKey) var id: UUID?
+            @ID(key: .id) var id: UUID?
             @Field(key: "bar") var bar: Int
             @Field(key: "baz") var baz: Double
             @Field(key: "qux") var qux: String

--- a/Sources/FluentBenchmark/Tests/SoftDelete.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDelete.swift
@@ -64,7 +64,7 @@ extension FluentBenchmarker {
 private final class Trash: Model {
     static let schema = "trash"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "contents")

--- a/Sources/FluentBenchmark/Tests/Timestamp.swift
+++ b/Sources/FluentBenchmark/Tests/Timestamp.swift
@@ -22,7 +22,7 @@ extension FluentBenchmarker {
 private final class User: Model {
     static let schema = "users"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")

--- a/Sources/FluentBenchmark/Tests/Unique.swift
+++ b/Sources/FluentBenchmark/Tests/Unique.swift
@@ -28,7 +28,7 @@ extension FluentBenchmarker {
 private final class Foo: Model {
     static let schema = "foos"
 
-    @ID(key: FluentBenchmarker.idKey)
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "bar")

--- a/Sources/FluentKit/Database/DummyDatabase.swift
+++ b/Sources/FluentKit/Database/DummyDatabase.swift
@@ -61,13 +61,13 @@ public final class DummyDatabaseDriver: DatabaseDriver {
 // MARK: Private
 
 private struct DummyRow: DatabaseRow {
-    func decode<T>(field: String, as type: T.Type, for database: Database) throws -> T
+    func decode<T>(field: FieldKey, as type: T.Type, for database: Database) throws -> T
         where T: Decodable
     {
         return try T(from: DummyDecoder())
     }
 
-    func contains(field: String) -> Bool {
+    func contains(field: FieldKey) -> Bool {
         return true
     }
     

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -8,7 +8,7 @@ public final class MigrationLog: Model {
         return MigrationLogMigration()
     }
 
-    @ID(key: "id")
+    @ID(key: .id)
     public var id: Int?
 
     @Field(key: "name")
@@ -37,7 +37,7 @@ public final class MigrationLog: Model {
 private final class MigrationLogMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         return database.schema("fluent")
-            .field("id", .int, .identifier(auto: true))
+            .field(.id, .int, .identifier(auto: true))
             .field("name", .string, .required)
             .field("batch", .int, .required)
             .field("created_at", .datetime)

--- a/Sources/FluentKit/Model/AnyModel.swift
+++ b/Sources/FluentKit/Model/AnyModel.swift
@@ -66,8 +66,8 @@ extension AnyModel {
         fatalError("Property not found on model: \(property)")
     }
 
-    var input: [String: DatabaseQuery.Value] {
-        var input: [String: DatabaseQuery.Value] = [:]
+    var input: [FieldKey: DatabaseQuery.Value] {
+        var input: [FieldKey: DatabaseQuery.Value] = [:]
         for (_, field) in self.fields {
             input[field.key] = field.inputValue
         }

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -154,17 +154,17 @@ extension Array where Element: FluentKit.Model {
 
 // MARK: Private
 private struct SavedInput: DatabaseRow {
-    var input: [String: DatabaseQuery.Value]
+    var input: [FieldKey: DatabaseQuery.Value]
     
-    init(_ input: [String: DatabaseQuery.Value]) {
+    init(_ input: [FieldKey: DatabaseQuery.Value]) {
         self.input = input
     }
     
-    func contains(field: String) -> Bool {
+    func contains(field: FieldKey) -> Bool {
         return self.input[field] != nil
     }
     
-    func decode<T>(field: String, as type: T.Type, for database: Database) throws -> T where T : Decodable {
+    func decode<T>(field: FieldKey, as type: T.Type, for database: Database) throws -> T where T : Decodable {
         if let value = self.input[field] {
             // not in output, get from saved input
             switch value {
@@ -174,7 +174,7 @@ private struct SavedInput: DatabaseRow {
                 fatalError("Invalid input type: \(value)")
             }
         } else {
-            throw FluentError.missingField(name: field)
+            throw FluentError.missingField(name: field.description)
         }
     }
     

--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -5,7 +5,7 @@ public protocol Model: AnyModel {
 }
 
 extension Model {
-    public static func key<Field>(for field: KeyPath<Self, Field>) -> String
+    public static func key<Field>(for field: KeyPath<Self, Field>) -> FieldKey
         where Field: FieldRepresentable
     {
         return Self.init()[keyPath: field].field.key

--- a/Sources/FluentKit/Operators/FieldOperators.swift
+++ b/Sources/FluentKit/Operators/FieldOperators.swift
@@ -213,7 +213,7 @@ public struct ModelFieldFilter<Left, Right>
         self.rhsPath = [Right.init()[keyPath: rhs].field.key]
     }
 
-    let lhsPath: [String]
+    let lhsPath: [FieldKey]
     let method: DatabaseQuery.Filter.Method
-    let rhsPath: [String]
+    let rhsPath: [FieldKey]
 }

--- a/Sources/FluentKit/Operators/ValueOperators.swift
+++ b/Sources/FluentKit/Operators/ValueOperators.swift
@@ -120,7 +120,7 @@ public struct ModelValueFilter<Model> where Model: FluentKit.Model {
         self.value = rhs
     }
 
-    let path: [String]
+    let path: [FieldKey]
     let method: DatabaseQuery.Filter.Method
     let value: DatabaseQuery.Value
 }

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -122,9 +122,9 @@ extension ModelChildren.Key: CustomStringConvertible {
     var description: String {
         switch self {
         case .optional(let keyPath):
-            return To.key(for: keyPath)
+            return To.key(for: keyPath).description
         case .required(let keyPath):
-            return To.key(for: keyPath)
+            return To.key(for: keyPath).description
         }
     }
 }

--- a/Sources/FluentKit/Properties/Field.swift
+++ b/Sources/FluentKit/Properties/Field.swift
@@ -7,7 +7,7 @@ extension Model {
 public final class ModelField<Model, Value>: AnyField, FieldRepresentable
     where Model: FluentKit.Model, Value: Codable
 {
-    public let key: String
+    public let key: FieldKey
     var outputValue: Value?
     var inputValue: DatabaseQuery.Value?
 
@@ -41,7 +41,7 @@ public final class ModelField<Model, Value>: AnyField, FieldRepresentable
         }
     }
 
-    public init(key: String) {
+    public init(key: FieldKey) {
         self.key = key
     }
 
@@ -54,7 +54,7 @@ public final class ModelField<Model, Value>: AnyField, FieldRepresentable
                 self.outputValue = try output.decode(self.key, as: Value.self)
             } catch {
                 throw FluentError.invalidField(
-                    name: self.key,
+                    name: self.key.description,
                     valueType: Value.self,
                     error: error
                 )
@@ -88,12 +88,12 @@ public protocol FieldRepresentable {
 }
 
 protocol AnyField: AnyProperty {
-    var key: String { get }
+    var key: FieldKey { get }
     var inputValue: DatabaseQuery.Value? { get set }
 }
 
 extension AnyField where Self: FieldRepresentable {
-    var key: String {
+    var key: FieldKey {
         return self.field.key
     }
 

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -30,7 +30,12 @@ public indirect enum FieldKey: Equatable, Hashable, ExpressibleByStringLiteral, 
     }
 
     public init(stringLiteral value: String) {
-        self = .name(value)
+        switch value {
+        case "id", "_id":
+            self = .id
+        default:
+            self = .name(value)
+        }
     }
 }
 

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -13,6 +13,27 @@ extension Model {
         where Value: Codable
 }
 
+public indirect enum FieldKey: Equatable, Hashable, ExpressibleByStringLiteral, CustomStringConvertible {
+    case id
+    case name(String)
+    case prefixed(String, FieldKey)
+
+    public var description: String {
+        switch self {
+        case .id:
+            return "id"
+        case .name(let name):
+            return name
+        case .prefixed(let prefix, let key):
+            return prefix + key.description
+        }
+    }
+
+    public init(stringLiteral value: String) {
+        self = .name(value)
+    }
+}
+
 @propertyWrapper
 public final class ModelID<Model, Value>: AnyID, FieldRepresentable
     where Model: FluentKit.Model, Value: Codable
@@ -38,7 +59,7 @@ public final class ModelID<Model, Value>: AnyID, FieldRepresentable
     let generator: Generator
     var cachedOutput: DatabaseOutput?
 
-    public var key: String {
+    public var key: FieldKey {
         return self.field.key
     }
 
@@ -64,7 +85,7 @@ public final class ModelID<Model, Value>: AnyID, FieldRepresentable
         }
     }
 
-    public init(key: String, generatedBy generator: Generator? = nil) {
+    public init(key: FieldKey, generatedBy generator: Generator? = nil) {
         self.field = .init(key: key)
         self.generator = generator ?? Generator.default(for: Value.self)
         self.exists = false

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -15,14 +15,14 @@ extension Model {
 
 public indirect enum FieldKey: Equatable, Hashable, ExpressibleByStringLiteral, CustomStringConvertible {
     case id
-    case name(String)
+    case string(String)
     case prefixed(String, FieldKey)
 
     public var description: String {
         switch self {
         case .id:
             return "id"
-        case .name(let name):
+        case .string(let name):
             return name
         case .prefixed(let prefix, let key):
             return prefix + key.description
@@ -34,7 +34,7 @@ public indirect enum FieldKey: Equatable, Hashable, ExpressibleByStringLiteral, 
         case "id", "_id":
             self = .id
         default:
-            self = .name(value)
+            self = .string(value)
         }
     }
 }

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -17,6 +17,7 @@ public indirect enum FieldKey: Equatable, Hashable, ExpressibleByStringLiteral, 
     case id
     case string(String)
     case prefixed(String, FieldKey)
+    case aggregate
 
     public var description: String {
         switch self {
@@ -24,6 +25,8 @@ public indirect enum FieldKey: Equatable, Hashable, ExpressibleByStringLiteral, 
             return "id"
         case .string(let name):
             return name
+        case .aggregate:
+            return "aggregate"
         case .prefixed(let prefix, let key):
             return prefix + key.description
         }

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -91,6 +91,10 @@ public final class ModelID<Model, Value>: AnyID, FieldRepresentable
     }
 
     public init(key: FieldKey, generatedBy generator: Generator? = nil) {
+        // Ensure that @ID is using the special .id key.
+        // Additional identifying fields can be added using @Field
+        // with a unique constraint.
+        assert(key == .id, "@ID key must be .id.")
         self.field = .init(key: key)
         self.generator = generator ?? Generator.default(for: Value.self)
         self.exists = false

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -25,7 +25,7 @@ public final class ModelOptionalParent<From, To>
 
     public var value: To?
 
-    public init(key: String) {
+    public init(key: FieldKey) {
         self._id = .init(key: key)
     }
 
@@ -60,14 +60,14 @@ extension ModelOptionalParent: AnyProperty {
             try container.encode(parent)
         } else {
             try container.encode([
-                To.key(for: \._$id): self.id
+                To.key(for: \._$id).description: self.id
             ])
         }
     }
 
     func decode(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: ModelCodingKey.self)
-        try self.$id.decode(from: container.superDecoder(forKey: .string(To.key(for: \._$id))))
+        try self.$id.decode(from: container.superDecoder(forKey: .string(To.key(for: \._$id).description)))
         // TODO: allow for nested decoding
     }
 }

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -26,7 +26,7 @@ public final class ModelParent<From, To>
 
     public var value: To?
 
-    public init(key: String) {
+    public init(key: FieldKey) {
         self._id = .init(key: key)
     }
 
@@ -61,14 +61,14 @@ extension ModelParent: AnyProperty {
             try container.encode(parent)
         } else {
             try container.encode([
-                To.key(for: \._$id): self.id
+                To.key(for: \._$id).description: self.id
             ])
         }
     }
 
     func decode(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: ModelCodingKey.self)
-        try self.$id.decode(from: container.superDecoder(forKey: .string(To.key(for: \._$id))))
+        try self.$id.decode(from: container.superDecoder(forKey: .string(To.key(for: \._$id).description)))
         // TODO: allow for nested decoding
     }
 }

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -18,7 +18,7 @@ public final class ModelTimestamp<Model>: AnyTimestamp, FieldRepresentable
 
     public let trigger: TimestampTrigger
 
-    public var key: String {
+    public var key: FieldKey {
         return self.field.key
     }
 
@@ -44,7 +44,7 @@ public final class ModelTimestamp<Model>: AnyTimestamp, FieldRepresentable
         }
     }
 
-    public init(key: String, on trigger: TimestampTrigger) {
+    public init(key: FieldKey, on trigger: TimestampTrigger) {
         self.field = .init(key: key)
         self.trigger = trigger
     }

--- a/Sources/FluentKit/Query/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/DatabaseQuery.swift
@@ -41,7 +41,7 @@ public struct DatabaseQuery: CustomStringConvertible {
             case .aggregate(let aggregate):
                 return aggregate.description
             case .field(let path, let schema, let alias):
-                var description = path.joined(separator: ".")
+                var description = path.map { $0.description }.joined(separator: ".")
                 if let schema = schema {
                     description = schema + "." + description
                 }
@@ -55,7 +55,7 @@ public struct DatabaseQuery: CustomStringConvertible {
         }
         
         case aggregate(Aggregate)
-        case field(path: [String], schema: String?, alias: String?)
+        case field(path: [FieldKey], schema: String?, alias: String?)
         case custom(Any)
     }
     
@@ -220,7 +220,6 @@ public struct DatabaseQuery: CustomStringConvertible {
     public var limits: [Limit]
     public var offsets: [Offset]
     public var schema: String
-    public var idKey: String
     
     public var description: String {
         var parts = [
@@ -242,10 +241,9 @@ public struct DatabaseQuery: CustomStringConvertible {
         return parts.joined(separator: " ")
     }
 
-    init(schema: String, idKey: String) {
+    init(schema: String) {
         self.schema = schema
         self.isUnique = false
-        self.idKey = idKey
         self.fields = []
         self.action = .read
         self.filters = []

--- a/Sources/FluentKit/Query/QueryBuilder+Aggregate.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Aggregate.swift
@@ -109,7 +109,7 @@ extension QueryBuilder {
             guard let res = res else {
                 throw FluentError.noResults
             }
-            return try res._$id.cachedOutput!.decode("fluentAggregate", as: Result.self)
+            return try res._$id.cachedOutput!.decode(.aggregate, as: Result.self)
         }
     }
 }

--- a/Sources/FluentKit/Query/QueryBuilder+Aggregate.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Aggregate.swift
@@ -84,7 +84,7 @@ extension QueryBuilder {
 
     public func aggregate<Result>(
         _ method: DatabaseQuery.Field.Aggregate.Method,
-        _ fieldName: String,
+        _ fieldName: FieldKey,
         as type: Result.Type = Result.self
     ) -> EventLoopFuture<Result>
         where Result: Codable

--- a/Sources/FluentKit/Query/QueryBuilder+Filter.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Filter.swift
@@ -28,7 +28,7 @@ extension QueryBuilder {
 
     @discardableResult
     public func filter<Value>(
-        _ fieldName: String,
+        _ fieldName: FieldKey,
         _ method: DatabaseQuery.Filter.Method,
         _ value: Value
     ) -> Self
@@ -43,9 +43,9 @@ extension QueryBuilder {
 
     @discardableResult
     public func filter(
-        _ lhsFieldName: String,
+        _ lhsFieldName: FieldKey,
         _ method: DatabaseQuery.Filter.Method,
-        _ rhsFieldName: String
+        _ rhsFieldName: FieldKey
     ) -> Self {
         self.filter(
             .field(path: [lhsFieldName], schema: Model.schema, alias: nil),

--- a/Sources/FluentKit/Query/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Join.swift
@@ -115,9 +115,9 @@ extension QueryBuilder {
     @discardableResult
     private func join<Foreign, Local>(
         _ foreign: Foreign.Type,
-        _ foreignField: String,
+        _ foreignField: FieldKey,
         to local: Local.Type,
-        _ localField: String,
+        _ localField: FieldKey,
         method: DatabaseQuery.Join.Method = .inner,
         alias schemaAlias: String? = nil
     ) -> Self
@@ -180,6 +180,6 @@ public func == <Foreign, ForeignField, Local, LocalField>(
 public struct JoinFilter<Foreign, Local, Value>
     where Foreign: Model, Local: Model, Value: Codable
 {
-    let foreign: String
-    let local: String
+    let foreign: FieldKey
+    let local: FieldKey
 }

--- a/Sources/FluentKit/Query/QueryBuilder+Nested.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Nested.swift
@@ -37,6 +37,6 @@ public struct NestedPath: ExpressibleByStringLiteral {
     }
 
     public init(stringLiteral value: String) {
-        self.path = value.split(separator: ".").map(String.init).map { .name($0) }
+        self.path = value.split(separator: ".").map(String.init).map { .string($0) }
     }
 }

--- a/Sources/FluentKit/Query/QueryBuilder+Nested.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Nested.swift
@@ -13,7 +13,7 @@ extension QueryBuilder {
     }
 
     public func filter<NestedValue>(
-        _ fieldName: String,
+        _ fieldName: FieldKey,
         _ path: NestedPath,
         _ method: DatabaseQuery.Filter.Method,
         _ value: NestedValue
@@ -30,13 +30,13 @@ extension QueryBuilder {
 }
 
 public struct NestedPath: ExpressibleByStringLiteral {
-    public var path: [String]
+    public var path: [FieldKey]
 
-    public init(path: [String]) {
+    public init(path: [FieldKey]) {
         self.path = path
     }
 
     public init(stringLiteral value: String) {
-        self.path = value.split(separator: ".").map(String.init)
+        self.path = value.split(separator: ".").map(String.init).map { .name($0) }
     }
 }

--- a/Sources/FluentKit/Query/QueryBuilder+Set.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Set.swift
@@ -2,12 +2,12 @@ extension QueryBuilder {
     // MARK: Set
     
     @discardableResult
-    public func set(_ data: [String: DatabaseQuery.Value]) -> Self {
+    public func set(_ data: [FieldKey: DatabaseQuery.Value]) -> Self {
         self.set([data])
     }
 
     @discardableResult
-    public func set(_ data: [[String: DatabaseQuery.Value]]) -> Self {
+    public func set(_ data: [[FieldKey: DatabaseQuery.Value]]) -> Self {
         assert(self.query.fields.isEmpty, "Conflicting query fields already exist.")
         // ensure there is at least one
         guard let keys = data.first?.keys else {

--- a/Sources/FluentKit/Query/QueryBuilder+Sort.swift
+++ b/Sources/FluentKit/Query/QueryBuilder+Sort.swift
@@ -24,7 +24,7 @@ extension QueryBuilder {
     }
 
     public func sort(
-        _ field: String,
+        _ field: FieldKey,
         _ direction: DatabaseQuery.Sort.Direction = .ascending
     ) -> Self {
         self.sort(Model.self, field, direction, alias: nil)
@@ -32,7 +32,7 @@ extension QueryBuilder {
 
     public func sort<Joined>(
         _ model: Joined.Type,
-        _ field: String,
+        _ field: FieldKey,
         _ direction: DatabaseQuery.Sort.Direction = .ascending,
         alias: String? = nil
     ) -> Self

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -17,7 +17,7 @@ public final class QueryBuilder<Model>
     
     public init(database: Database) {
         self.database = database
-        self.query = .init(schema: Model.schema, idKey: Model.key(for: \._$id))
+        self.query = .init(schema: Model.schema)
         self.eagerLoaders = []
         self.includeDeleted = false
         self.joinedModels = []
@@ -217,7 +217,7 @@ public final class QueryBuilder<Model>
                     return .field(
                         path: [field.key],
                         schema: joined.alias ?? type(of: joined.model).schema,
-                        alias: (joined.alias ?? type(of: joined.model).schema) + "_" + field.key
+                        alias: (joined.alias ?? type(of: joined.model).schema) + "_" + field.key.description
                     )
                 }
             }

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -63,7 +63,11 @@ public struct DatabaseSchema {
     public enum FieldConstraint {
         case required
         case identifier(auto: Bool)
-        case foreignKey(field: ForeignFieldName, onDelete: Constraint.ForeignKeyAction, onUpdate: Constraint.ForeignKeyAction)
+        case foreignKey(
+            field: ForeignFieldName,
+            onDelete: Constraint.ForeignKeyAction,
+            onUpdate: Constraint.ForeignKeyAction
+        )
         case custom(Any)
     }
     
@@ -82,12 +86,16 @@ public struct DatabaseSchema {
     }
     
     public enum FieldDefinition {
-        case definition(name: FieldName, dataType: DataType, constraints: [FieldConstraint])
+        case definition(
+            name: FieldName,
+            dataType: DataType,
+            constraints: [FieldConstraint]
+        )
         case custom(Any)
     }
     
     public enum FieldName {
-        case string(String)
+        case key(FieldKey)
         case custom(Any)
     }
 

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -16,18 +16,6 @@ public final class SchemaBuilder {
     }
 
     public func field(
-        _ name: String,
-        _ dataType: DatabaseSchema.DataType,
-        _ constraints: DatabaseSchema.FieldConstraint...
-    ) -> Self {
-        self.field(.definition(
-            name: .key(.name(name)),
-            dataType: dataType,
-            constraints: constraints
-        ))
-    }
-
-    public func field(
         _ key: FieldKey,
         _ dataType: DatabaseSchema.DataType,
         _ constraints: DatabaseSchema.FieldConstraint...
@@ -43,34 +31,10 @@ public final class SchemaBuilder {
         self.schema.createFields.append(field)
         return self
     }
-    
-    public func unique(on fields: String...) -> Self {
-        self.schema.constraints.append(.unique(
-            fields: fields.map { .key(.name($0)) }
-        ))
-        return self
-    }
 
     public func unique(on fields: FieldKey...) -> Self {
         self.schema.constraints.append(.unique(
             fields: fields.map { .key($0) }
-        ))
-        return self
-    }
-
-    public func foreignKey(
-        _ field: String,
-        references foreignSchema: String,
-        _ foreignField: String,
-        onDelete: DatabaseSchema.Constraint.ForeignKeyAction = .noAction,
-        onUpdate: DatabaseSchema.Constraint.ForeignKeyAction = .noAction
-    ) -> Self {
-        self.schema.constraints.append(.foreignKey(
-            fields: [.key(.name(field))],
-            foreignSchema: foreignSchema,
-            foreignFields: [.key(.name(foreignField))],
-            onDelete: onDelete,
-            onUpdate: onUpdate
         ))
         return self
     }
@@ -90,10 +54,6 @@ public final class SchemaBuilder {
             onUpdate: onUpdate
         ))
         return self
-    }
-    
-    public func deleteField(_ name: String) -> Self {
-        return self.deleteField(.key(.name(name)))
     }
 
     public func deleteField(_ name: FieldKey) -> Self {

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -20,8 +20,20 @@ public final class SchemaBuilder {
         _ dataType: DatabaseSchema.DataType,
         _ constraints: DatabaseSchema.FieldConstraint...
     ) -> Self {
-        return self.field(.definition(
-            name: .string(name),
+        self.field(.definition(
+            name: .key(.name(name)),
+            dataType: dataType,
+            constraints: constraints
+        ))
+    }
+
+    public func field(
+        _ key: FieldKey,
+        _ dataType: DatabaseSchema.DataType,
+        _ constraints: DatabaseSchema.FieldConstraint...
+    ) -> Self {
+        self.field(.definition(
+            name: .key(key),
             dataType: dataType,
             constraints: constraints
         ))
@@ -34,7 +46,14 @@ public final class SchemaBuilder {
     
     public func unique(on fields: String...) -> Self {
         self.schema.constraints.append(.unique(
-            fields: fields.map { .string($0) }
+            fields: fields.map { .key(.name($0)) }
+        ))
+        return self
+    }
+
+    public func unique(on fields: FieldKey...) -> Self {
+        self.schema.constraints.append(.unique(
+            fields: fields.map { .key($0) }
         ))
         return self
     }
@@ -47,9 +66,26 @@ public final class SchemaBuilder {
         onUpdate: DatabaseSchema.Constraint.ForeignKeyAction = .noAction
     ) -> Self {
         self.schema.constraints.append(.foreignKey(
-            fields: [.string(field)],
+            fields: [.key(.name(field))],
             foreignSchema: foreignSchema,
-            foreignFields: [.string(foreignField)],
+            foreignFields: [.key(.name(foreignField))],
+            onDelete: onDelete,
+            onUpdate: onUpdate
+        ))
+        return self
+    }
+
+    public func foreignKey(
+        _ field: FieldKey,
+        references foreignSchema: String,
+        _ foreignField: FieldKey,
+        onDelete: DatabaseSchema.Constraint.ForeignKeyAction = .noAction,
+        onUpdate: DatabaseSchema.Constraint.ForeignKeyAction = .noAction
+    ) -> Self {
+        self.schema.constraints.append(.foreignKey(
+            fields: [.key(field)],
+            foreignSchema: foreignSchema,
+            foreignFields: [.key(foreignField)],
             onDelete: onDelete,
             onUpdate: onUpdate
         ))
@@ -57,7 +93,11 @@ public final class SchemaBuilder {
     }
     
     public func deleteField(_ name: String) -> Self {
-        return self.deleteField(.string(name))
+        return self.deleteField(.key(.name(name)))
+    }
+
+    public func deleteField(_ name: FieldKey) -> Self {
+        return self.deleteField(.key(name))
     }
     
     public func deleteField(_ name: DatabaseSchema.FieldName) -> Self {

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -162,22 +162,22 @@ public struct SQLQueryConverter {
             // TODO: if joins don't exist, use short column name
             switch path.count {
             case 1:
-                let name = path[0]
+                let key = path[0]
                 if let schema = schema {
-                    let id = SQLColumn(SQLIdentifier(name), table: SQLIdentifier(schema))
+                    let id = SQLColumn(SQLIdentifier(self.key(key)), table: SQLIdentifier(schema))
                     if let alias = alias {
                         return SQLAlias(id, as: SQLIdentifier(alias))
                     } else {
                         return id
                     }
                 } else {
-                    return SQLIdentifier(name)
+                    return SQLIdentifier(self.key(key))
                 }
             case 2:
                 // row->".code" = 4
                 // return SQLRaw("\(path[0])->>'\(path[1])'")
                 // return SQLRaw("JSON_EXTRACT(\(path[0]), '$.\(path[1])')")
-                return self.delegate.nestedFieldExpression(path[0], [path[1]])
+                return self.delegate.nestedFieldExpression(self.key(path[0]), [self.key(path[1])])
             default:
                 fatalError("Deep SQL JSON nesting not yet supported.")
             }
@@ -338,6 +338,17 @@ public struct SQLQueryConverter {
             fatalError("Contains filter method not supported at this scope.")
         case .custom(let any):
             return custom(any)
+        }
+    }
+
+    private func key(_ key: FieldKey) -> String {
+        switch key {
+        case .id:
+            return "id"
+        case .name(let name):
+            return name
+        case .prefixed(let prefix, let key):
+            return prefix + self.key(key)
         }
     }
 }

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -201,7 +201,7 @@ public struct SQLQueryConverter {
                         args: isUnique ?
                             [SQLDistinct(fields.map(self.field))]
                             : fields.map { self.field($0) }),
-                        as: SQLIdentifier("fluentAggregate")
+                        as: SQLIdentifier(FieldKey.aggregate.description)
                     )
             }
         }
@@ -347,6 +347,8 @@ public struct SQLQueryConverter {
             return "id"
         case .string(let name):
             return name
+        case .aggregate:
+            return key.description
         case .prefixed(let prefix, let key):
             return prefix + self.key(key)
         }

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -345,7 +345,7 @@ public struct SQLQueryConverter {
         switch key {
         case .id:
             return "id"
-        case .name(let name):
+        case .string(let name):
             return name
         case .prefixed(let prefix, let key):
             return prefix + self.key(key)

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -218,7 +218,7 @@ public struct SQLSchemaConverter {
         switch key {
         case .id:
             return "id"
-        case .name(let name):
+        case .string(let name):
             return name
         case .prefixed(let prefix, let key):
             return prefix + self.key(key)

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -220,6 +220,8 @@ public struct SQLSchemaConverter {
             return "id"
         case .string(let name):
             return name
+        case .aggregate:
+            return key.description
         case .prefixed(let prefix, let key):
             return prefix + self.key(key)
         }

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -55,8 +55,8 @@ public struct SQLSchemaConverter {
                 switch field {
                 case .custom:
                     return ""
-                case .string(let name):
-                    return "\(table).\(name)"
+                case .key(let key):
+                    return "\(table).\(self.key(key))"
                 }
             }.joined(separator: "+")
         }
@@ -120,8 +120,8 @@ public struct SQLSchemaConverter {
     
     private func fieldName(_ fieldName: DatabaseSchema.FieldName) -> SQLExpression {
         switch fieldName {
-        case .string(let string):
-            return SQLIdentifier(string)
+        case .key(let key):
+            return SQLIdentifier(self.key(key))
         case .custom(let any):
             return custom(any)
         }
@@ -211,6 +211,17 @@ public struct SQLSchemaConverter {
             )
         case .custom(let any):
             return custom(any)
+        }
+    }
+
+    private func key(_ key: FieldKey) -> String {
+        switch key {
+        case .id:
+            return "id"
+        case .name(let name):
+            return name
+        case .prefixed(let prefix, let key):
+            return prefix + self.key(key)
         }
     }
 }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -6,7 +6,7 @@ import FluentSQL
 
 final class FluentKitTests: XCTestCase {
     func testMigrationLogNames() throws {
-        XCTAssertEqual(MigrationLog.key(for: \.$id), "id")
+        XCTAssertEqual(MigrationLog.key(for: \.$id), .id)
         XCTAssertEqual(MigrationLog.key(for: \.$name), "name")
         XCTAssertEqual(MigrationLog.key(for: \.$batch), "batch")
         XCTAssertEqual(MigrationLog.key(for: \.$createdAt), "created_at")
@@ -14,10 +14,10 @@ final class FluentKitTests: XCTestCase {
     }
 
     func testGalaxyPlanetNames() throws {
-        XCTAssertEqual(Galaxy.key(for: \.$id), "id")
+        XCTAssertEqual(Galaxy.key(for: \.$id), .id)
         XCTAssertEqual(Galaxy.key(for: \.$name), "name")
 
-        XCTAssertEqual(Planet.key(for: \.$id), "id")
+        XCTAssertEqual(Planet.key(for: \.$id), .id)
         XCTAssertEqual(Planet.key(for: \.$name), "name")
         XCTAssertEqual(Planet.key(for: \.$star.$id), "star_id")
     }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -79,12 +79,12 @@ final class FluentKitTests: XCTestCase {
         
         _ = try? Planet.query(on: db).unique().count(\.$name).wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT COUNT(DISTINCT("planets"."name")) AS "fluentAggregate" FROM "planets" LIMIT 1"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT COUNT(DISTINCT("planets"."name")) AS "aggregate" FROM "planets" LIMIT 1"#)
         db.reset()
         
         _ = try? Planet.query(on: db).unique().sum(\.$id).wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT SUM(DISTINCT("planets"."id")) AS "fluentAggregate" FROM "planets" LIMIT 1"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT SUM(DISTINCT("planets"."id")) AS "aggregate" FROM "planets" LIMIT 1"#)
         db.reset()
     }
 


### PR DESCRIPTION
Adds a new top-level `FieldKey` type to FluentKit. This type represents possible field key values but in a slightly more type-safe way than `String` is currently able to. 

⚠️ This change removes the ability to use custom ID keys on models. `@ID`'s key parameter must be  either `"id"` (for backward compatibility) or the new `.id`. Additional identifying fields can be added with custom keys using `@Field` with a unique constraint. Read on for more information on this decision.

This is what the _basic_ structure of `FieldKey` looks like:

```swift
public enum FieldKey: ExpressibleByStringLiteral {
    case id
    case string(String)
}
```

The important piece here, and the reason for this change, is that `FieldKey.id` is a special type of key that does not have an actual string value. This key can be interpreted by the underlying driver and converted to the correct value. For Mongo this would be `_id` and for SQL it would be `id`. This is critical for defining models that can work across all of Fluent's supported driver types.

`FieldKey` is usable everywhere String keys were previously usable, including property wrappers, filter expressions, and schema builders.

```swift
final class Planet: Model {
    static let schema = "planets"

    @ID(key: .id)
    var id: UUID?
    
    @Field(key: "name")
    var name: String
}

Planet.query(on: database).filter(.id, .equals, ...)

struct CreatePlanet: Migration {
    func prepare(on database: Database) -> EventLoopFuture<Void> {
        database.schema("planets")
            .field(.id, .uuid, .identifier(auto: false)
            .field("name", .string, .required)
            .create()
    }

    func revert(on: database)  -> EventLoopFuture<Void> {
        database.schema("planets").delete()
    }
}
```

`FieldKey` neatly solves the problem of dynamic ID keys and it may also solve future problems where there are differences in keys between databases. For example, the currently hacky `"fluentAggregate"` key could be a part of this enum.

One other potentially useful aspect of `FieldKey`  is that it can be extended by the end user. This could be a good solution to keeping String key declarations DRY. For example:

```swift
extension FieldKey {
    static var name: Self { "name" }
}
```

Assuming this extension, we could refactor the previous `Planet` code to look like this:

```swift
final class Planet: Model {
    static let schema = "planets"

    @ID(key: .id)
    var id: UUID?
    
    @Field(key: .name)
    var name: String
}

Planet.query(on: database).filter(.name, .equals, "Earth")

struct CreatePlanet: Migration {
    func prepare(on database: Database) -> EventLoopFuture<Void> {
        database.schema("planets")
            .field(.id, .uuid, .identifier(auto: false)
            .field(.name, .string, .required)
            .create()
    }

    func revert(on: database)  -> EventLoopFuture<Void> {
        database.schema("planets").delete()
    }
}
```