### PR TITLE
Added DatabaseDriver.closeConnections() Method

### DIFF
--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -39,6 +39,7 @@ extension Database {
 
 public protocol DatabaseDriver {
     func makeDatabase(with context: DatabaseContext) -> Database
+    func closeConnections()
     func shutdown()
 }
 

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -82,6 +82,12 @@ public final class Databases {
         }
     }
 
+    public func closeConnections(_ id: DatabaseID? = nil) {
+        if let driver = self.driver(id) {
+            driver.closeConnections()
+        }
+    }
+
     public func shutdown() {
         for driver in self.drivers.values {
             driver.shutdown()

--- a/Sources/FluentKit/Database/DummyDatabase.swift
+++ b/Sources/FluentKit/Database/DummyDatabase.swift
@@ -50,6 +50,10 @@ public final class DummyDatabaseDriver: DatabaseDriver {
         DummyDatabase(context: context)
     }
 
+    public func closeConnections() {
+        // Do nothing. This is more for closing the connections in a connection pool.
+    }
+
     public func shutdown() {
         self.didShutdown = true
     }


### PR DESCRIPTION
Adds `DatabaseDriver.closeConnections()` and `Databases.closeConnections(_:)` methods so you can close all the connections to a given database. This causes the driver to have to create new connections to the database for subsequent calls.

Driver implementation relies on https://github.com/vapor/async-kit/pull/53. 