### PR TITLE
Refactor aggregates

### DIFF
--- a/Sources/FluentKit/Query/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/DatabaseQuery.swift
@@ -4,6 +4,30 @@ public struct DatabaseQuery: CustomStringConvertible {
         case read
         case update
         case delete
+        case aggregate(Aggregate)
+        case custom(Any)
+    }
+
+    public enum Aggregate: CustomStringConvertible {
+        public enum Method {
+            case count
+            case sum
+            case average
+            case minimum
+            case maximum
+            case custom(Any)
+        }
+
+        public var description: String {
+            switch self {
+            case .custom(let custom):
+                return "\(custom)"
+            case .fields(let method, let field):
+                return "\(method)(\(field))"
+            }
+        }
+
+        case fields(method: Method, field: Field)
         case custom(Any)
     }
 
@@ -13,33 +37,8 @@ public struct DatabaseQuery: CustomStringConvertible {
     }
     
     public enum Field: CustomStringConvertible {
-        public enum Aggregate: CustomStringConvertible {
-            public enum Method {
-                case count
-                case sum
-                case average
-                case minimum
-                case maximum
-                case custom(Any)
-            }
-
-            public var description: String {
-                switch self {
-                case .custom(let custom):
-                    return "\(custom)"
-                case .fields(let method, let fields):
-                    return "\(method)(\(fields))"
-                }
-            }
-            
-            case fields(method: Method, fields: [Field])
-            case custom(Any)
-        }
-        
         public var description: String {
             switch self {
-            case .aggregate(let aggregate):
-                return aggregate.description
             case .field(let path, let schema, let alias):
                 var description = path.map { $0.description }.joined(separator: ".")
                 if let schema = schema {
@@ -53,8 +52,7 @@ public struct DatabaseQuery: CustomStringConvertible {
                 return "\(custom)"
             }
         }
-        
-        case aggregate(Aggregate)
+
         case field(path: [FieldKey], schema: String?, alias: String?)
         case custom(Any)
     }

--- a/Sources/FluentKit/Query/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/QueryBuilder.swift
@@ -197,8 +197,7 @@ public final class QueryBuilder<Model>
         return self
     }
 
-
-    func run(_ onOutput: @escaping (DatabaseOutput) -> ()) -> EventLoopFuture<Void> {
+    internal func run(_ onOutput: @escaping (DatabaseOutput) -> ()) -> EventLoopFuture<Void> {
         // make a copy of this query before mutating it
         // so that run can be called multiple times
         var query = self.query


### PR DESCRIPTION
This PR refactors aggregates to be part of `DatabaseQuery.Action` instead of nested in `DatabaseQuery.Field`. 