### PR TITLE
MigrationLog use UUID

### DIFF
--- a/Sources/FluentBenchmark/Tests/Migrator.swift
+++ b/Sources/FluentBenchmark/Tests/Migrator.swift
@@ -17,12 +17,12 @@ extension FluentBenchmarker {
             try migrator.prepareBatch().wait()
 
             let logs = try MigrationLog.query(on: self.database)
+                .sort(\.$batch, .ascending)
                 .all().wait()
                 .map { $0.batch }
             XCTAssertEqual(logs, [1, 1, 2], "batch did not increment")
 
             try migrator.revertAllBatches().wait()
-
         }
     }
 

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -9,7 +9,7 @@ public final class MigrationLog: Model {
     }
 
     @ID(key: .id)
-    public var id: Int?
+    public var id: UUID?
 
     @Field(key: "name")
     public var name: String
@@ -25,7 +25,7 @@ public final class MigrationLog: Model {
 
     public init() { }
 
-    public init(id: Int? = nil, name: String, batch: Int) {
+    public init(id: IDValue? = nil, name: String, batch: Int) {
         self.id = id
         self.name = name
         self.batch = batch
@@ -34,10 +34,10 @@ public final class MigrationLog: Model {
     }
 }
 
-private final class MigrationLogMigration: Migration {
+private struct MigrationLogMigration: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         return database.schema("fluent")
-            .field(.id, .int, .identifier(auto: true))
+            .field(.id, .uuid, .identifier(auto: false))
             .field("name", .string, .required)
             .field("batch", .int, .required)
             .field("created_at", .datetime)


### PR DESCRIPTION
Updates `MigrationLog` to use a `UUID` identifier so that it is compatible with MongoDB. This is a breaking change for Vapor 4 databases with pre-existing migrations. Reverting the database and re-running migrations or running the following scripts will update your log table to using UUID.

**MySQL**
```sql
ALTER TABLE `fluent` DROP COLUMN `id`;
ALTER TABLE `fluent` ADD `id` VARBINARY(16);
UPDATE `fluent` SET `id` = uuid_to_bin(uuid());
ALTER TABLE `fluent` MODIFY COLUMN `id` VARBINARY(16) PRIMARY KEY;
```

**PostgreSQL**
```sql
CREATE extension IF NOT EXISTS "uuid-ossp";
ALTER TABLE "fluent" DROP COLUMN "id";
ALTER TABLE "fluent" ADD "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4();
ALTER TABLE "fluent" ALTER COLUMN "id" DROP DEFAULT;
```

It is not possible to update a pre-existing SQLite database since SQLite does not expose a method for generating UUIDs. 