### PR TITLE
Cleanup DatabaseSchema foreign key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: apt update -y; apt install -y libsqlite3-dev
-    - run: git clone -b tn-beta-5 https://github.com/vapor/fluent-sqlite-driver.git
+    - run: git clone -b master https://github.com/vapor/fluent-sqlite-driver.git
       working-directory: ./
     - run: swift package edit fluent-kit --revision ${{ github.sha }}
       working-directory: ./fluent-sqlite-driver
@@ -42,7 +42,7 @@ jobs:
           POSTGRES_PASSWORD: vapor_password
     runs-on: ubuntu-latest
     steps:
-    - run: git clone -b tn-beta-5 https://github.com/vapor/fluent-postgres-driver.git
+    - run: git clone -b master https://github.com/vapor/fluent-postgres-driver.git
       working-directory: ./
     - run: swift package edit fluent-kit --revision ${{ github.sha }}
       working-directory: ./fluent-postgres-driver
@@ -63,7 +63,7 @@ jobs:
           MYSQL_PASSWORD: vapor_password
     runs-on: ubuntu-latest
     steps:
-    - run: git clone -b tn-beta-5 https://github.com/vapor/fluent-mysql-driver.git
+    - run: git clone -b master https://github.com/vapor/fluent-mysql-driver.git
       working-directory: ./
     - run: swift package edit fluent-kit --revision ${{ github.sha }}
       working-directory: ./fluent-mysql-driver
@@ -82,7 +82,7 @@ jobs:
           - 27017:27017
     runs-on: ubuntu-latest
     steps:
-    - run: git clone -b tn-beta-5 https://github.com/vapor/fluent-mongo-driver.git
+    - run: git clone -b master https://github.com/vapor/fluent-mongo-driver.git
       working-directory: ./
     - run: swift package edit fluent-kit --revision ${{ github.sha }}
       working-directory: ./fluent-mongo-driver

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -9,12 +9,12 @@ public final class ChildrenProperty<From, To>
 {
     // MARK: ID
 
-    enum Key {
+    public enum Key {
         case required(KeyPath<To, To.Parent<From>>)
         case optional(KeyPath<To, To.OptionalParent<From>>)
     }
 
-    let parentKey: Key
+    public let parentKey: Key
     var idValue: From.IDValue?
 
     // MARK: Wrapper
@@ -126,7 +126,7 @@ extension ChildrenProperty: AnyField {
 }
 
 extension ChildrenProperty.Key: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         switch self {
         case .optional(let keyPath):
             return To.path(for: keyPath.appending(path: \.$id)).description

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -58,8 +58,8 @@ public struct DatabaseSchema {
             onUpdate: ForeignKeyAction = .noAction
         ) -> Self {
             .foreignKey(
+                schema,
                 .key(field),
-                schema: schema,
                 onDelete: onDelete,
                 onUpdate: onUpdate
             )
@@ -68,8 +68,8 @@ public struct DatabaseSchema {
         case required
         case identifier(auto: Bool)
         case foreignKey(
+            _ schema: String,
             _ field: FieldName,
-            schema: String,
             onDelete: ForeignKeyAction,
             onUpdate: ForeignKeyAction
         )
@@ -78,7 +78,13 @@ public struct DatabaseSchema {
     
     public enum Constraint {
         case unique(fields: [FieldName])
-        case foreignKey(fields: [FieldName], foreignSchema: String, foreignFields: [FieldName], onDelete: ForeignKeyAction, onUpdate: ForeignKeyAction)
+        case foreignKey(
+            _ fields: [FieldName],
+            _ schema: String,
+            _ foreign: [FieldName],
+            onDelete: ForeignKeyAction,
+            onUpdate: ForeignKeyAction
+        )
         case custom(Any)
     }
 

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -53,12 +53,13 @@ public struct DatabaseSchema {
     public enum FieldConstraint {
         public static func references(
             _ schema: String,
-            _ field: String,
-            onDelete: DatabaseSchema.Constraint.ForeignKeyAction = .noAction,
-            onUpdate: DatabaseSchema.Constraint.ForeignKeyAction = .noAction
+            _ field: FieldKey,
+            onDelete: ForeignKeyAction = .noAction,
+            onUpdate: ForeignKeyAction = .noAction
         ) -> Self {
             .foreignKey(
-                field: .string(schema: schema, field: field),
+                .key(field),
+                schema: schema,
                 onDelete: onDelete,
                 onUpdate: onUpdate
             )
@@ -67,9 +68,10 @@ public struct DatabaseSchema {
         case required
         case identifier(auto: Bool)
         case foreignKey(
-            field: ForeignFieldName,
-            onDelete: Constraint.ForeignKeyAction,
-            onUpdate: Constraint.ForeignKeyAction
+            _ field: FieldName,
+            schema: String,
+            onDelete: ForeignKeyAction,
+            onUpdate: ForeignKeyAction
         )
         case custom(Any)
     }
@@ -78,14 +80,14 @@ public struct DatabaseSchema {
         case unique(fields: [FieldName])
         case foreignKey(fields: [FieldName], foreignSchema: String, foreignFields: [FieldName], onDelete: ForeignKeyAction, onUpdate: ForeignKeyAction)
         case custom(Any)
+    }
 
-        public enum ForeignKeyAction {
-            case noAction
-            case restrict
-            case cascade
-            case setNull
-            case setDefault
-        }
+    public enum ForeignKeyAction {
+        case noAction
+        case restrict
+        case cascade
+        case setNull
+        case setDefault
     }
     
     public enum FieldDefinition {
@@ -105,11 +107,6 @@ public struct DatabaseSchema {
     public enum FieldName {
         case key(FieldKey)
         case custom(Any)
-    }
-
-    public enum ForeignFieldName {
-        case string(schema: String, field: String)
-        case custom(schema: Any, field: Any)
     }
 
     public var action: Action

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -45,8 +45,8 @@ public final class SchemaBuilder {
         _ field: FieldKey,
         references foreignSchema: String,
         _ foreignField: FieldKey,
-        onDelete: DatabaseSchema.Constraint.ForeignKeyAction = .noAction,
-        onUpdate: DatabaseSchema.Constraint.ForeignKeyAction = .noAction
+        onDelete: DatabaseSchema.ForeignKeyAction = .noAction,
+        onUpdate: DatabaseSchema.ForeignKeyAction = .noAction
     ) -> Self {
         self.schema.constraints.append(.foreignKey(
             fields: [.key(field)],

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -49,9 +49,9 @@ public final class SchemaBuilder {
         onUpdate: DatabaseSchema.ForeignKeyAction = .noAction
     ) -> Self {
         self.schema.constraints.append(.foreignKey(
-            fields: [.key(field)],
-            foreignSchema: foreignSchema,
-            foreignFields: [.key(foreignField)],
+            [.key(field)],
+            foreignSchema,
+            [.key(foreignField)],
             onDelete: onDelete,
             onUpdate: onUpdate
         ))

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -67,19 +67,18 @@ public struct SQLSchemaConverter {
                 algorithm: SQLTableConstraintAlgorithm.unique(columns: fields.map(self.fieldName)),
                 name: SQLIdentifier("uq:\(name)")
             )
-        case .foreignKey(fields: let fields, foreignSchema: let parent, foreignFields: let parentFields, onDelete: let onDelete, onUpdate: let onUpdate):
-            let name = identifier(fields + parentFields)
-
+        case .foreignKey(let local, let schema, let foreign, let onDelete, let onUpdate):
+            let name = identifier(local + foreign)
             let reference = SQLForeignKey(
-                table: self.name(parent),
-                columns: parentFields.map(self.fieldName),
+                table: self.name(schema),
+                columns: foreign.map(self.fieldName),
                 onDelete: self.foreignKeyAction(onDelete),
                 onUpdate: self.foreignKeyAction(onUpdate)
             )
 
             return SQLConstraint(
                 algorithm: SQLTableConstraintAlgorithm.foreignKey(
-                    columns: fields.map(self.fieldName),
+                    columns: local.map(self.fieldName),
                     references: reference
                 ),
                 name: SQLIdentifier("fk:\(name)")
@@ -195,7 +194,7 @@ public struct SQLSchemaConverter {
             return SQLColumnConstraintAlgorithm.notNull
         case .identifier(let auto):
             return SQLColumnConstraintAlgorithm.primaryKey(autoIncrement: auto)
-        case .foreignKey(let field, let schema, let onDelete, let onUpdate):
+        case .foreignKey(let schema, let field, let onDelete, let onUpdate):
             return SQLColumnConstraintAlgorithm.references(
                 SQLIdentifier(schema),
                 self.fieldName(field),


### PR DESCRIPTION
Cleans up inconsistencies left over in `DatabaseSchema`'s foreign key types from beta.5 updates (#185, fixes #184). 