### PR TITLE
QueryBuilder.fields helpers

### DIFF
--- a/Sources/FluentBenchmark/Tests/CRUDTests.swift
+++ b/Sources/FluentBenchmark/Tests/CRUDTests.swift
@@ -60,6 +60,8 @@ extension FluentBenchmarker {
             try galaxy.save(on: self.database).wait()
             galaxy.name = "Milky Way"
             try galaxy.save(on: self.database).wait()
+            // Test save without changes.
+            try galaxy.save(on: self.database).wait()
 
             // verify
             let galaxies = try Galaxy.query(on: self.database).filter(\.$name == "Milky Way").all().wait()

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -42,6 +42,9 @@ extension Model {
     private func _update(on database: Database) -> EventLoopFuture<Void> {
         self.touchTimestamps(.update)
         precondition(self._$id.exists)
+        guard self.hasChanges else {
+            return database.eventLoop.makeSucceededFuture(())
+        }
         let input = self.input
         return Self.query(on: database)
             .filter(\._$id == self.id!)

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -51,6 +51,18 @@ public final class QueryBuilder<Model>
 
     // MARK: Fields
 
+    public func field<Field>(_ field: KeyPath<Model, Field>) -> Self
+        where Field: QueryField, Field.Model == Model
+    {
+        self.field(Model.self, field)
+    }
+
+    public func field<Joined, Field>(_ joined: Joined.Type, _ field: KeyPath<Joined, Field>) -> Self
+        where Joined: Schema, Field: QueryField, Field.Model == Joined
+    {
+        self.fields(Joined.self, .key(for: field))
+    }
+
     public func fields(_ fields: FieldKey...) -> Self {
         self.fields(Model.self, fields)
     }
@@ -68,7 +80,7 @@ public final class QueryBuilder<Model>
     public func fields<Joined>(_ joined: Joined.Type, _ fields: [FieldKey]) -> Self
         where Joined: Schema
     {
-        self.query.fields = fields.map { .field($0, schema: Joined.schema) }
+        self.query.fields += fields.map { .field($0, schema: Joined.schema) }
         return self
     }
 

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -49,6 +49,29 @@ public final class QueryBuilder<Model>
         )
     }
 
+    // MARK: Fields
+
+    public func fields(_ fields: FieldKey...) -> Self {
+        self.fields(Model.self, fields)
+    }
+
+    public func fields(_ fields: [FieldKey]) -> Self {
+        self.fields(Model.self, fields)
+    }
+
+    public func fields<Joined>(_ joined: Joined.Type, _ fields: FieldKey...) -> Self
+        where Joined: Schema
+    {
+        self.fields(Joined.self, fields)
+    }
+
+    public func fields<Joined>(_ joined: Joined.Type, _ fields: [FieldKey]) -> Self
+        where Joined: Schema
+    {
+        self.query.fields = fields.map { .field($0, schema: Joined.schema) }
+        return self
+    }
+
     // MARK: Soft Delete
 
     public func withDeleted() -> Self {


### PR DESCRIPTION
Adds `QueryBuilder.fields` methods for selecting a subset of fields. `Model.update` now checks for changes before attempting to save (#186, fixes #183). 

```swift
// Only selects name field from result set. 
Planet.query(on: db).field(\.$name).all()
```