### PR TITLE
Make MigrationLog's name unique

### DIFF
--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -40,6 +40,7 @@ private struct MigrationLogMigration: Migration {
             .field("batch", .int, .required)
             .field("created_at", .datetime)
             .field("updated_at", .datetime)
+            .unique(on: "name")
             .create()
     }
 


### PR DESCRIPTION
Adds a unique constraint to the MigrationLog schema (#190, fixes #189). 

For existing databases, use SQL similar to the following to add this constraint manually.
```sql
ALTER TABLE "_fluent_migrations" CONSTRAINT "uq:_fluent_migrations.name" UNIQUE ("name")
```