### PR TITLE
add Database.inTransaction

### DIFF
--- a/Sources/FluentBenchmark/Tests/TransactionTests.swift
+++ b/Sources/FluentBenchmark/Tests/TransactionTests.swift
@@ -1,5 +1,10 @@
 extension FluentBenchmarker {
     public func testTransaction() throws {
+        try self.testTransaction_basic()
+        try self.testTransaction_in()
+    }
+
+    private func testTransaction_basic() throws {
         try self.runTest(#function, [
             SolarSystem()
         ]) {
@@ -37,6 +42,20 @@ extension FluentBenchmarker {
                 .first()
                 .wait()
             XCTAssertNil(pluto)
+        }
+    }
+
+    private func testTransaction_in() throws {
+        try self.runTest(#function, [
+            SolarSystem()
+        ]) {
+            try self.database.transaction { transaction in
+                XCTAssertEqual(transaction.inTransaction, true)
+                return transaction.transaction { nested in
+                    XCTAssertEqual(nested.inTransaction, true)
+                    return nested.eventLoop.makeSucceededFuture(())
+                }
+            }.wait()
         }
     }
 }

--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -14,12 +14,18 @@ public protocol Database {
         enum: DatabaseEnum
     ) -> EventLoopFuture<Void>
 
+    var inTransaction: Bool { get }
+
     func transaction<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T>
     
     func withConnection<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T>
 }
 
 extension Database {
+    public var inTransaction: Bool {
+        false
+    }
+
     public func query<Model>(_ model: Model.Type) -> QueryBuilder<Model>
         where Model: FluentKit.Model
     {


### PR DESCRIPTION
Adds `Database.inTransaction` for checking if a database is already in a transaction (fixes 23, #119).

Database drivers are expected to keep track of whether they are already in a transaction and not start a new one if they do not supported nested transactions. 