### PR TITLE
Pass join method parameter

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
@@ -9,7 +9,7 @@ extension QueryBuilder {
     ) -> Self
         where Foreign: Schema, Local: Schema
     {
-        self.join(Foreign.self, filter.foreign, to: Local.self, filter.local)
+        self.join(Foreign.self, filter.foreign, to: Local.self, filter.local , method: method)
     }
 
     @discardableResult


### PR DESCRIPTION
Correctly passes join method parameter through to underlying methods (#193). 