### PR TITLE
Omit empty filter groups from query

### DIFF
--- a/Sources/FluentBenchmark/Tests/FilterTests.swift
+++ b/Sources/FluentBenchmark/Tests/FilterTests.swift
@@ -7,6 +7,7 @@ extension FluentBenchmarker {
             try self.testFilter_sqlValue()
         }
         try self.testFilter_group()
+        try self.testFilter_emptyGroup()
     }
 
     private func testFilter_field() throws {
@@ -60,6 +61,17 @@ extension FluentBenchmarker {
             default:
                 XCTFail("Unexpected planets count: \(planets.count)")
             }
+        }
+    }
+
+    private func testFilter_emptyGroup() throws {
+        try self.runTest(#function, [
+            SolarSystem()
+        ]) {
+            let planets = try Planet.query(on: self.database)
+                .group(.or) { _ in }
+                .all().wait()
+            XCTAssertEqual(planets.count, 9)
         }
     }
 }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Group.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Group.swift
@@ -5,7 +5,9 @@ extension QueryBuilder {
     ) rethrows -> Self {
         let group = QueryBuilder(database: self.database)
         try closure(group)
-        self.query.filters.append(.group(group.query.filters, relation))
+        if !group.query.filters.isEmpty {
+            self.query.filters.append(.group(group.query.filters, relation))
+        }
         return self
     }
 }


### PR DESCRIPTION
QueryBuilder filter groups that have no filters are now omitted from the query (#195, fixes #9). 