### PR TITLE
Fix dummy db placeholder

### DIFF
--- a/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
+++ b/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
@@ -102,7 +102,7 @@ struct DummyDatabaseDialect: SQLDialect {
     }
 
     func bindPlaceholder(at position: Int) -> SQLExpression {
-        return SQLRaw("$" + (position + 1).description)
+        return SQLRaw("$" + position.description)
     }
 
     func literalBoolean(_ value: Bool) -> SQLExpression {

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -295,7 +295,67 @@ final class FluentKitTests: XCTestCase {
             XCTAssertEqual(result, expected)
         }
     }
-}
+
+    func testPlanel2FilterPlaceholder1() throws {
+            let db = DummyDatabaseForTestSQLSerializer()
+            _ = try Planet2
+                .query(on: db)
+                .filter(\.$nickName != "first")
+                .count()
+                .wait()
+            XCTAssertEqual(db.sqlSerializers.count, 1)
+            let extractedExpr: String = (db.sqlSerializers.first?.sql)!
+            let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" <> $1"#
+            XCTAssertEqual(extractedExpr, expected)
+            db.reset()
+        }
+
+    func testPlanel2FilterPlaceholder2() throws {
+            let db = DummyDatabaseForTestSQLSerializer()
+            _ = try Planet2
+                .query(on: db)
+                .filter(\.$nickName != nil)
+                .count()
+                .wait()
+            XCTAssertEqual(db.sqlSerializers.count, 1)
+            let extractedExpr: String = (db.sqlSerializers.first?.sql)!
+            let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" IS NOT NULL"#
+            XCTAssertEqual(extractedExpr, expected)
+            db.reset()
+        }
+
+    func testPlanel2FilterPlaceholder3() throws {
+            let db = DummyDatabaseForTestSQLSerializer()
+            _ = try Planet2
+                .query(on: db)
+                .filter(\.$nickName != "first")
+                .filter(\.$nickName == "second")
+                .filter(\.$nickName != "third")
+                .count()
+                .wait()
+            XCTAssertEqual(db.sqlSerializers.count, 1)
+            let extractedExpr: String = (db.sqlSerializers.first?.sql)!
+            let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" <> $1 AND "planets"."nickname" = $2 AND "planets"."nickname" <> $3"#
+            XCTAssertEqual(extractedExpr, expected)
+            db.reset()
+        }
+
+    func testPlanel2FilterPlaceholder4() throws {
+            let db = DummyDatabaseForTestSQLSerializer()
+            _ = try Planet2
+                .query(on: db)
+                .filter(\.$nickName != "first")
+                .filter(\.$nickName != nil)
+                .filter(\.$nickName == "second")
+                .count()
+                .wait()
+            XCTAssertEqual(db.sqlSerializers.count, 1)
+            let extractedExpr: String = (db.sqlSerializers.first?.sql)!
+            let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" <> $1 AND "planets"."nickname" IS NOT NULL AND "planets"."nickname" = $2"#
+            XCTAssertEqual(extractedExpr, expected)
+            db.reset()
+        }
+    }
 
 final class User: Model {
     static let schema = "users"

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -304,9 +304,9 @@ final class FluentKitTests: XCTestCase {
                 .count()
                 .wait()
             XCTAssertEqual(db.sqlSerializers.count, 1)
-            let extractedExpr: String = (db.sqlSerializers.first?.sql)!
+            let result: String = (db.sqlSerializers.first?.sql)!
             let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" <> $1"#
-            XCTAssertEqual(extractedExpr, expected)
+            XCTAssertEqual(result, expected)
             db.reset()
         }
 
@@ -318,9 +318,9 @@ final class FluentKitTests: XCTestCase {
                 .count()
                 .wait()
             XCTAssertEqual(db.sqlSerializers.count, 1)
-            let extractedExpr: String = (db.sqlSerializers.first?.sql)!
+            let result: String = (db.sqlSerializers.first?.sql)!
             let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" IS NOT NULL"#
-            XCTAssertEqual(extractedExpr, expected)
+            XCTAssertEqual(result, expected)
             db.reset()
         }
 
@@ -334,9 +334,9 @@ final class FluentKitTests: XCTestCase {
                 .count()
                 .wait()
             XCTAssertEqual(db.sqlSerializers.count, 1)
-            let extractedExpr: String = (db.sqlSerializers.first?.sql)!
+            let result: String = (db.sqlSerializers.first?.sql)!
             let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" <> $1 AND "planets"."nickname" = $2 AND "planets"."nickname" <> $3"#
-            XCTAssertEqual(extractedExpr, expected)
+            XCTAssertEqual(result, expected)
             db.reset()
         }
 
@@ -350,9 +350,9 @@ final class FluentKitTests: XCTestCase {
                 .count()
                 .wait()
             XCTAssertEqual(db.sqlSerializers.count, 1)
-            let extractedExpr: String = (db.sqlSerializers.first?.sql)!
+            let result: String = (db.sqlSerializers.first?.sql)!
             let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" <> $1 AND "planets"."nickname" IS NOT NULL AND "planets"."nickname" = $2"#
-            XCTAssertEqual(extractedExpr, expected)
+            XCTAssertEqual(result, expected)
             db.reset()
         }
     }


### PR DESCRIPTION
Placeholders in `DummyDatabaseForTestSQLSerializer` are numbered from `2` instead of `1`. 


Code would output:
```
SELECT COUNT("planets"."id") AS "aggregate"
FROM "planets"
WHERE "planets"."nickname" <> $2 
AND "planets"."nickname" = $3 
AND "planets"."nickname" <> $4
```

Instead of:
```
SELECT COUNT("planets"."id") AS "aggregate"
FROM "planets"
WHERE "planets"."nickname" <> $1
AND "planets"."nickname" = $2
AND "planets"."nickname" <> $3
```
