### PR TITLE
Provide custom value operator handling for enum 

### DIFF
--- a/Sources/FluentBenchmark/Tests/EnumTests.swift
+++ b/Sources/FluentBenchmark/Tests/EnumTests.swift
@@ -58,51 +58,39 @@ extension FluentBenchmarker {
                 .first()
                 .wait()
             XCTAssertEqual(fetched?.bar, .baz)
-        }
 
-        // not equal
-        try self.runTest(#function, [
-            FooMigration()
-        ]) {
-            let foo = Foo(bar: .baz)
-            try foo.save(on: self.database).wait()
+            // not equal
+            let foo2 = Foo(bar: .baz)
+            try foo2.save(on: self.database).wait()
 
-            let fetched = try Foo
+            let fetched2 = try Foo
                 .query(on: self.database)
                 .filter(\.$bar != .qux)
                 .first()
                 .wait()
-            XCTAssertEqual(fetched?.bar, .baz)
-        }
+            XCTAssertEqual(fetched2?.bar, .baz)
 
-        // in
-        try self.runTest(#function, [
-            FooMigration()
-        ]) {
-            let foo = Foo(bar: .baz)
-            try foo.save(on: self.database).wait()
+            // in
+            let foo3 = Foo(bar: .baz)
+            try foo3.save(on: self.database).wait()
 
-            let fetched = try Foo
+            let fetched3 = try Foo
                 .query(on: self.database)
                 .filter(\.$bar ~~ [.baz, .qux])
                 .first()
                 .wait()
-            XCTAssertEqual(fetched?.bar, .baz)
-        }
+            XCTAssertEqual(fetched3?.bar, .baz)
 
-        // not in
-        try self.runTest(#function, [
-            FooMigration()
-        ]) {
-            let foo = Foo(bar: .baz)
-            try foo.save(on: self.database).wait()
+            // not in
+            let foo4 = Foo(bar: .baz)
+            try foo4.save(on: self.database).wait()
 
-            let fetched = try Foo
+            let fetched4 = try Foo
                 .query(on: self.database)
                 .filter(\.$bar !~ [.qux])
                 .first()
                 .wait()
-            XCTAssertEqual(fetched?.bar, .baz)
+            XCTAssertEqual(fetched4?.bar, .baz)
         }
     }
 
@@ -120,51 +108,39 @@ extension FluentBenchmarker {
                 .first()
                 .wait()
             XCTAssertNil(fetched)
-        }
 
-        // not equal
-        try self.runTest(#function, [
-            FooMigration()
-        ]) {
-            let foo = Foo(bar: .baz)
-            try foo.save(on: self.database).wait()
+            // not equal
+            let foo2 = Foo(bar: .baz)
+            try foo2.save(on: self.database).wait()
 
-            let fetched = try Foo
+            let fetched2 = try Foo
                 .query(on: self.database)
                 .filter(\.$bar != .baz)
                 .first()
                 .wait()
-            XCTAssertNil(fetched)
-        }
+            XCTAssertNil(fetched2)
 
-        // in
-        try self.runTest(#function, [
-            FooMigration()
-        ]) {
-            let foo = Foo(bar: .baz)
-            try foo.save(on: self.database).wait()
+            // in
+            let foo3 = Foo(bar: .baz)
+            try foo3.save(on: self.database).wait()
 
-            let fetched = try Foo
+            let fetched3 = try Foo
                 .query(on: self.database)
                 .filter(\.$bar ~~ [.qux])
                 .first()
                 .wait()
-            XCTAssertNil(fetched)
-        }
+            XCTAssertNil(fetched3)
 
-        // not in
-        try self.runTest(#function, [
-            FooMigration()
-        ]) {
-            let foo = Foo(bar: .baz)
-            try foo.save(on: self.database).wait()
+            // not in
+            let foo4 = Foo(bar: .baz)
+            try foo4.save(on: self.database).wait()
 
-            let fetched = try Foo
+            let fetched4 = try Foo
                 .query(on: self.database)
                 .filter(\.$bar !~ [.baz, .qux])
                 .first()
                 .wait()
-            XCTAssertNil(fetched)
+            XCTAssertNil(fetched4)
         }
     }
 }

--- a/Sources/FluentBenchmark/Tests/EnumTests.swift
+++ b/Sources/FluentBenchmark/Tests/EnumTests.swift
@@ -161,7 +161,7 @@ extension FluentBenchmarker {
 
             let fetched = try Foo
                 .query(on: self.database)
-                .filter(\.$bar ~~ [.baz, .qux])
+                .filter(\.$bar !~ [.baz, .qux])
                 .first()
                 .wait()
             XCTAssertNil(fetched)

--- a/Sources/FluentBenchmark/Tests/EnumTests.swift
+++ b/Sources/FluentBenchmark/Tests/EnumTests.swift
@@ -99,7 +99,7 @@ extension FluentBenchmarker {
 
             let fetched = try Foo
                 .query(on: self.database)
-                .filter(\.$bar ~~ [.qux])
+                .filter(\.$bar !~ [.qux])
                 .first()
                 .wait()
             XCTAssertEqual(fetched?.bar, .baz)

--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -59,7 +59,9 @@ extension EnumProperty: PropertyProtocol {
     }
 }
 
-extension EnumProperty: FieldProtocol { }
+extension EnumProperty: FieldProtocol {
+    public static func queryValue(_ value: Value) -> DatabaseQuery.Value { .enumCase(value.rawValue) }
+}
 
 extension EnumProperty: AnyField {
     public var path: [FieldKey] {

--- a/Sources/FluentKit/Operators/ValueOperators+Array.swift
+++ b/Sources/FluentKit/Operators/ValueOperators+Array.swift
@@ -6,7 +6,7 @@ public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
         Values: Collection,
         Values.Element == Field.Value
 {
-    lhs ~~ .array(rhs.map { .bind($0) })
+    lhs ~~ .array(rhs.map { Field.queryValue($0) })
 }
 
 public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -> ModelValueFilter<Model>
@@ -26,7 +26,7 @@ public func !~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
         Values: Collection,
         Values.Element == Field.Value
 {
-    lhs !~ .array(rhs.map { .bind($0) })
+    lhs !~ .array(rhs.map { Field.queryValue($0) })
 }
 
 public func !~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -> ModelValueFilter<Model>

--- a/Sources/FluentKit/Operators/ValueOperators+String.swift
+++ b/Sources/FluentKit/Operators/ValueOperators+String.swift
@@ -3,37 +3,37 @@
 public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: FluentKit.Model, Field: FieldProtocol, Field.Value: CustomStringConvertible
 {
-    lhs ~= .bind(rhs)
+    lhs ~= Field.queryValue(rhs)
 }
 
 public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: FluentKit.Model, Field: FieldProtocol, Field.Value: CustomStringConvertible
 {
-    lhs ~~ .bind(rhs)
+    lhs ~~ Field.queryValue(rhs)
 }
 
 public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: FluentKit.Model, Field: FieldProtocol, Field.Value: CustomStringConvertible
 {
-    lhs =~ .bind(rhs)
+    lhs =~ Field.queryValue(rhs)
 }
 
 public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: FluentKit.Model, Field: FieldProtocol, Field.Value: CustomStringConvertible
 {
-    lhs !~= .bind(rhs)
+    lhs !~= Field.queryValue(rhs)
 }
 
 public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: FluentKit.Model, Field: FieldProtocol, Field.Value: CustomStringConvertible
 {
-    lhs !~ .bind(rhs)
+    lhs !~ Field.queryValue(rhs)
 }
 
 public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: FluentKit.Model, Field: FieldProtocol, Field.Value: CustomStringConvertible
 {
-    lhs !=~ .bind(rhs)
+    lhs !=~ Field.queryValue(rhs)
 }
 
 // MARK: DatabaseQuery.Value

--- a/Sources/FluentKit/Operators/ValueOperators.swift
+++ b/Sources/FluentKit/Operators/ValueOperators.swift
@@ -19,56 +19,42 @@ extension QueryBuilder {
     }
 }
 
-// MARK: Enum
-
-public func == <Model, Value>(lhs: KeyPath<Model, Model.Enum<Value>>, rhs: Value) -> ModelValueFilter<Model>
-where Model: Fields, Value: Codable, Value: RawRepresentable, Value.RawValue == String
-{
-    lhs == .enumCase(rhs.rawValue)
-}
-
-public func != <Model, Value>(lhs: KeyPath<Model, Model.Enum<Value>>, rhs: Value) -> ModelValueFilter<Model>
-    where Model: Fields, Value: Codable, Value: RawRepresentable, Value.RawValue == String
-{
-    lhs != .enumCase(rhs.rawValue)
-}
-
 // MARK: Field.Value
 
 public func == <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: Fields, Field: FieldProtocol
 {
-    lhs == .bind(rhs)
+    lhs == Field.queryValue(rhs)
 }
 
 public func != <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: Fields, Field: FieldProtocol
 {
-    lhs != .bind(rhs)
+    lhs != Field.queryValue(rhs)
 }
 
 public func >= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: Fields, Field: FieldProtocol
 {
-    lhs >= .bind(rhs)
+    lhs >= Field.queryValue(rhs)
 }
 
 public func > <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: Fields, Field: FieldProtocol
 {
-    lhs > .bind(rhs)
+    lhs > Field.queryValue(rhs)
 }
 
 public func < <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: Fields, Field: FieldProtocol
 {
-    lhs < .bind(rhs)
+    lhs < Field.queryValue(rhs)
 }
 
 public func <= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: Fields, Field: FieldProtocol
 {
-    lhs <= .bind(rhs)
+    lhs <= Field.queryValue(rhs)
 }
 
 // MARK: DatabaseQuery.Value

--- a/Sources/FluentKit/Operators/ValueOperators.swift
+++ b/Sources/FluentKit/Operators/ValueOperators.swift
@@ -19,12 +19,26 @@ extension QueryBuilder {
     }
 }
 
+// MARK: Enum
+
+public func == <Model, Value>(lhs: KeyPath<Model, Model.Enum<Value>>, rhs: Value) -> ModelValueFilter<Model>
+where Model: Fields, Value: Codable, Value: RawRepresentable, Value.RawValue == String
+{
+    return lhs == .enumCase(rhs.rawValue)
+}
+
+public func != <Model, Value>(lhs: KeyPath<Model, Model.Enum<Value>>, rhs: Value) -> ModelValueFilter<Model>
+    where Model: Fields, Value: Codable, Value: RawRepresentable, Value.RawValue == String
+{
+    return lhs != .enumCase(rhs.rawValue)
+}
+
 // MARK: Field.Value
 
 public func == <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: Fields, Field: FieldProtocol
 {
-    lhs == .bind(rhs)
+    return lhs == .bind(rhs)
 }
 
 public func != <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>

--- a/Sources/FluentKit/Operators/ValueOperators.swift
+++ b/Sources/FluentKit/Operators/ValueOperators.swift
@@ -24,13 +24,13 @@ extension QueryBuilder {
 public func == <Model, Value>(lhs: KeyPath<Model, Model.Enum<Value>>, rhs: Value) -> ModelValueFilter<Model>
 where Model: Fields, Value: Codable, Value: RawRepresentable, Value.RawValue == String
 {
-    return lhs == .enumCase(rhs.rawValue)
+    lhs == .enumCase(rhs.rawValue)
 }
 
 public func != <Model, Value>(lhs: KeyPath<Model, Model.Enum<Value>>, rhs: Value) -> ModelValueFilter<Model>
     where Model: Fields, Value: Codable, Value: RawRepresentable, Value.RawValue == String
 {
-    return lhs != .enumCase(rhs.rawValue)
+    lhs != .enumCase(rhs.rawValue)
 }
 
 // MARK: Field.Value
@@ -38,7 +38,7 @@ public func != <Model, Value>(lhs: KeyPath<Model, Model.Enum<Value>>, rhs: Value
 public func == <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where Model: Fields, Field: FieldProtocol
 {
-    return lhs == .bind(rhs)
+    lhs == .bind(rhs)
 }
 
 public func != <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -28,5 +28,15 @@ extension AnyProperty where Self: PropertyProtocol {
     }
 }
 
-public protocol FieldProtocol: AnyField, PropertyProtocol { }
+public protocol FieldProtocol: AnyField, PropertyProtocol {
+    /// Get the given Value in a form suitable for queries.
+    /// Most values can be bound to queries, but some need
+    /// to be inserted statically.
+    static func queryValue(_ value: Value) -> DatabaseQuery.Value
+}
+
+extension FieldProtocol {
+    public static func queryValue(_ value: Value) -> DatabaseQuery.Value { .bind(value) }
+}
+
 public protocol AnyField { }

--- a/Tests/FluentKitTests/FilterQueryTests.swift
+++ b/Tests/FluentKitTests/FilterQueryTests.swift
@@ -1,0 +1,73 @@
+//
+//  FilterQueryTests.swift
+//  
+//
+//  Created by Mathew Polzin on 3/8/20.
+//
+
+@testable import FluentKit
+@testable import FluentBenchmark
+import XCTest
+import Foundation
+import FluentSQL
+
+final class FilterQueryTests: XCTestCase {
+    // MARK: Enum
+    func test_enumEquals() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Task.query(on: db).filter(\.$status == .done).all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."status" = 'done'"#)
+        db.reset()
+    }
+
+    func test_enumNotEquals() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Task.query(on: db).filter(\.$status != .done).all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."status" <> 'done'"#)
+        db.reset()
+    }
+
+    // MARK: String
+    func test_stringEquals() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Task.query(on: db).filter(\.$description == "hello").all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."description" = $2"#)
+        db.reset()
+    }
+
+    func test_stringNotEquals() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Task.query(on: db).filter(\.$description != "hello").all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."description" <> $2"#)
+        db.reset()
+    }
+}
+
+enum Diggity: String, Codable {
+    case done, notDone
+}
+
+final class Task: Model {
+    static let schema = "tasks"
+
+    @ID(custom: "id", generatedBy: .user)
+    var id: Int?
+
+    @Field(key: "description")
+    var description: String
+
+    @Enum(key: "status")
+    var status: Diggity
+
+    init() {}
+
+    init(id: Int, status: Diggity, description: String) {
+        self.id = id
+        self.status = status
+        self.description = description
+    }
+}

--- a/Tests/FluentKitTests/FilterQueryTests.swift
+++ b/Tests/FluentKitTests/FilterQueryTests.swift
@@ -29,6 +29,22 @@ final class FilterQueryTests: XCTestCase {
         db.reset()
     }
 
+    func test_enumIn() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Task.query(on: db).filter(\.$status ~~ [.done, .notDone]).all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."status" IN ('done' , 'notDone')"#)
+        db.reset()
+    }
+
+    func test_enumNotIn() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Task.query(on: db).filter(\.$status !~ [.done, .notDone]).all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."status" NOT IN ('done' , 'notDone')"#)
+        db.reset()
+    }
+
     // MARK: String
     func test_stringEquals() throws {
         let db = DummyDatabaseForTestSQLSerializer()
@@ -43,6 +59,22 @@ final class FilterQueryTests: XCTestCase {
         _ = try Task.query(on: db).filter(\.$description != "hello").all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
         XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."description" <> $2"#)
+        db.reset()
+    }
+
+    func test_stringIn() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Task.query(on: db).filter(\.$description ~~ ["hello"]).all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."description" IN ($2)"#)
+        db.reset()
+    }
+
+    func test_stringNotIn() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Task.query(on: db).filter(\.$description !~ ["hello"]).all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "tasks"."id" AS "tasks_id", "tasks"."description" AS "tasks_description", "tasks"."status" AS "tasks_status" FROM "tasks" WHERE "tasks"."description" NOT IN ($2)"#)
         db.reset()
     }
 }


### PR DESCRIPTION
Treat enum query filters differently than other types because they cannot be bound.

Fixes https://github.com/vapor/fluent-kit/issues/202.