### PR TITLE
Handle .bind EnumProperty

### DIFF
--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -42,6 +42,12 @@ extension EnumProperty: PropertyProtocol {
                 switch value {
                 case .enumCase(let string):
                     return Value(rawValue: string)!
+                case .bind(let string as String):
+                    guard let value = Value(rawValue: string) else {
+                        fatalError("Invalid enum case name '\(string)' for enum \(Value.self)")
+                    }
+
+                    return value
                 default:
                     fatalError("Unexpected enum input value type: \(value)")
                 }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -249,7 +249,20 @@ final class FluentKitTests: XCTestCase {
             print(error)
         }
     }
-    
+
+    // GitHub PR: https://github.com/vapor/fluent-kit/pull/209
+    func testDecodeEnumProperty() throws {
+        let json = """
+        {"name": "Squeeky", "type": "mouse"}
+        """
+        do {
+            let toy = try JSONDecoder().decode(Toy.self, from: Data(json.utf8))
+            XCTAssertNotNil(toy.$type.value)
+        } catch {
+            return XCTFail("\(error)")
+        }
+    }
+
     func testCreateEmptyModelArrayDoesntQuery() throws {
         let db = DummyDatabaseForTestSQLSerializer()
         try [Planet2]().create(on: db).wait()


### PR DESCRIPTION
When you decode a `Fields` type from a database row that has an `Enum` property, because the `Enum.decode(from:)` method simply calls its internal `field.decode(from:)` method, the `field.inputValue` property ends up having a `.bind` case with a perfectly valid case name as it's associated value. This PR adds handling to the `EnumProperty.value` property for the `.bind` case.