### PR TITLE
Add ability to specify `IF NOT EXISTS` for schema create actions

### DIFF
--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -41,6 +41,7 @@ private struct MigrationLogMigration: Migration {
             .field("created_at", .datetime)
             .field("updated_at", .datetime)
             .unique(on: "name")
+            .ignoreExisting()
             .create()
     }
 

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -34,11 +34,7 @@ public struct Migrator {
     // MARK: Setup
     
     public func setupIfNeeded() -> EventLoopFuture<Void> {
-        MigrationLog.query(on: self.database(nil)).all().map { migrations in
-            ()
-        }.flatMapError { error in
-            MigrationLog.migration.prepare(on: self.database(nil))
-        }
+        MigrationLog.migration.prepare(on: self.database(nil))
     }
     
     // MARK: Prepare

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -121,6 +121,7 @@ public struct DatabaseSchema {
     public var updateFields: [FieldUpdate]
     public var deleteFields: [FieldName]
     public var constraints: [Constraint]
+    public var exclusiveCreate: Bool
     
     public init(schema: String) {
         self.action = .create
@@ -129,5 +130,6 @@ public struct DatabaseSchema {
         self.updateFields = []
         self.deleteFields = []
         self.constraints = []
+        self.exclusiveCreate = true
     }
 }

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -82,6 +82,11 @@ public final class SchemaBuilder {
         return self
     }
 
+    public func ignoreExisting() -> Self {
+        self.schema.exclusiveCreate = false
+        return self
+    }
+
     public func create() -> EventLoopFuture<Void> {
         self.schema.action = .create
         return self.database.execute(schema: self.schema)

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -40,6 +40,9 @@ public struct SQLSchemaConverter {
         create.tableConstraints = schema.constraints.map {
             self.constraint($0, table: schema.schema)
         }
+        if !schema.exclusiveCreate {
+            create.ifNotExists = true
+        }
         return create
     }
     

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -205,6 +205,27 @@ final class FluentKitTests: XCTestCase {
         XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:planets.galaxy_id+planets.id" FOREIGN KEY ("galaxy_id") REFERENCES "galaxies" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)"#)
     }
     
+    func testIfNotExistsTableCreate() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        try db.schema("planets")
+            .field("galaxy_id", .int64)
+            .ignoreExisting()
+            .create()
+            .wait()
+            
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE IF NOT EXISTS "planets"("galaxy_id" BIGINT)"#)
+        db.reset()
+
+        try db.schema("planets")
+            .field("galaxy_id", .int64)
+            .create()
+            .wait()
+            
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT)"#)
+    }
+    
     func testDecodeWithoutID() throws {
         let json = """
         {"name": "Earth", "moonCount": 1}


### PR DESCRIPTION
- Takes the form of a new API on `SchemaBuilder` and additional flag on `DatabaseSchema`. The behavior is 100% backwards compatible.
- Specifying this flag has no effect on `.update` or `.delete` schema actions.
- This flag has no effect on the MongoDB driver.
- `MigrationLog` now both uses this flag and issues its create action unconditionally instead of gating it behind a spurious query; as a result, it no longer issues an error message whenever migrations are run on an empty database (which may happen often in comprehensive unit tests). This should not be a breaking change for anyone.
- If `MigrationLog`'s schema ever needs to change in the future, the use of this flag will require additional code be added to support that requirement. Hopefully the schema should not change short of a `semver-major` upgrade.