### PR TITLE
Brute-force past a weird SPM issue in the Mongo test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,9 @@ jobs:
       working-directory: ./
     - run: swift package edit fluent-kit --revision ${{ github.sha }}
       working-directory: ./fluent-mongo-driver
+    # Temporary to workaround apparent SPM bug (?)
+    - run: rm Package.resolved
+      working-directory: ./fluent-mongo-driver
     - run: swift test --enable-test-discovery --sanitize=thread
       working-directory: ./fluent-mongo-driver
       env:


### PR DESCRIPTION
Running the tests in a Swift 5.2 container, even locally, fails out with the dreaded `Package.resolved` badly out of date error. Deleting it and letting package resolution re-run works around the problem without losing the revision pin on `fluent-kit`.