### PR TITLE
Support All Collection Types for Relation Property Wrappers

### DIFF
--- a/Sources/FluentKit/Utilities/SequenceInitializable.swift
+++ b/Sources/FluentKit/Utilities/SequenceInitializable.swift
@@ -1,0 +1,6 @@
+public protocol SequenceInitializeable: Collection {
+    init<Source>(_ source: Source) where Element == Source.Element, Source: Sequence
+}
+
+extension Array: SequenceInitializeable { }
+extension Set: SequenceInitializeable { }


### PR DESCRIPTION
Right now we simply added support for `Set` along with `Array`. Hopefully, I can get a clean implementation that allows all `Collection` types, or if not that, all `ExpressibleByArrayLiteral` types.