### PR TITLE
Format Deleted Timestamp For Soft Delete Exclusion

### DIFF
--- a/Sources/FluentBenchmark/Tests/TimestampTests.swift
+++ b/Sources/FluentBenchmark/Tests/TimestampTests.swift
@@ -113,7 +113,7 @@ private final class Event: Model {
     @Timestamp(key: "updated_at", on: .update, format: .iso8601)
     var updatedAt: Date?
 
-    @Timestamp(key: "deleted_at", on: .update, format: .iso8601)
+    @Timestamp(key: "deleted_at", on: .delete, format: .iso8601)
     var deletedAt: Date?
 
     init() { }

--- a/Sources/FluentBenchmark/Tests/TimestampTests.swift
+++ b/Sources/FluentBenchmark/Tests/TimestampTests.swift
@@ -113,6 +113,9 @@ private final class Event: Model {
     @Timestamp(key: "updated_at", on: .update, format: .iso8601)
     var updatedAt: Date?
 
+    @Timestamp(key: "deleted_at", on: .update, format: .iso8601)
+    var deletedAt: Date?
+
     init() { }
 
     init(id: IDValue? = nil, name: String) {
@@ -120,6 +123,7 @@ private final class Event: Model {
         self.name = name
         self.createdAt = nil
         self.updatedAt = nil
+        self.deletedAt = nil
     }
 }
 
@@ -130,6 +134,7 @@ private struct EventMigration: Migration {
             .field("name", .string, .required)
             .field("created_at", .string)
             .field("updated_at", .string)
+            .field("deleted_at", .string)
             .create()
     }
 

--- a/Sources/FluentBenchmark/Tests/TimestampTests.swift
+++ b/Sources/FluentBenchmark/Tests/TimestampTests.swift
@@ -50,6 +50,9 @@ extension FluentBenchmarker {
                     XCTFail("Timestamp decoding from database output failed with error: \(error)")
                 }
             }).wait()
+
+            try event.delete(on: self.database).wait()
+            try XCTAssertEqual(Event.query(on: self.database).all().wait().count, 0)
         }
     }
 }

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -99,6 +99,7 @@ extension TimestampProperty: AnyProperty {
 extension TimestampProperty: AnyTimestamp { }
 
 protocol AnyTimestamp: AnyProperty {
+    var formatter: AnyTimestampFormatter { get }
     var trigger: TimestampTrigger { get }
     func touch(date: Date?)
 }
@@ -140,12 +141,13 @@ extension Schema {
             return
         }
 
+        let date = timestamp.formatter.anyTimestamp(from: Date()) ?? Optional<Date>.none
         let deletedAtField = DatabaseQuery.Field.path(
             timestamp.path,
             schema: self.schemaOrAlias
         )
         let isNull = DatabaseQuery.Filter.value(deletedAtField, .equal, .null)
-        let isFuture = DatabaseQuery.Filter.value(deletedAtField, .greaterThan, .bind(Date()))
+        let isFuture = DatabaseQuery.Filter.value(deletedAtField, .greaterThan, .bind(date))
         query.filters.append(.group([isNull, isFuture], .or))
     }
 }


### PR DESCRIPTION
Fixes model exclusion when querying soft deletable models that use formatted timestamps.