### PR TITLE
Make @Timestamp properties stable again

### DIFF
--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -245,6 +245,14 @@ extension TimestampFormat {
 }
 
 extension TimestampFormat {
+    public static let iso8601WithMilliseconds = TimestampFormat("iso8601WithMilliseconds", formatter: {
+        let formatter = ISO8601DateFormatter.init()
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        return formatter
+    })
+}
+
+extension TimestampFormat {
     public static let unix = TimestampFormat("unix", formatter: UnixTimestampFormatter.init)
 }
 

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -251,7 +251,7 @@ extension TimestampFormat {
 
 extension TimestampFormat {
     public static let iso8601WithMilliseconds = TimestampFormat("iso8601WithMilliseconds", formatter: {
-        let formatter = ISO8601DateFormatter.init()
+        let formatter = ISO8601DateFormatter()
         formatter.formatOptions.insert(.withFractionalSeconds)
         return formatter
     })

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -71,8 +71,13 @@ extension TimestampProperty: AnyProperty {
     }
     
     public func input(to input: inout DatabaseInput) {
-        let timestamp = self.value.flatMap { date in self.formatter.anyTimestamp(from: date) }
-        input.values[self.field.key] = .bind(timestamp ?? Optional<Date>.none)
+        switch self.field.inputValue {
+        case .bind(_):
+            let timestamp = self.value.flatMap { date in self.formatter.anyTimestamp(from: date) }
+            input.values[self.field.key] = .bind(timestamp ?? Optional<Date>.none)
+        default:
+            input.values[self.field.key] = self.field.inputValue
+        }
     }
 
     public func output(from output: DatabaseOutput) throws {


### PR DESCRIPTION
- Fixes a bug which caused `@Timestamp` properties to have their values specified as inputs to _every_ `INSERT` and `UPDATE` query issued for any model containing them, regardless of whether the query was supposed to update them. (For example, an `UPDATE` query really should not be specifying `createdAt` unless it was explicitly overwritten by the user.)

- As part of the test verifying the fix, a new built-in `iso8601WithMilliseconds` timestamp format is now available. This is `iso8601` with the addition of exactly three digits of sub-second precision.