### PR TITLE
Fix decoding of OptionalParent

### DIFF
--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -74,7 +74,7 @@ extension OptionalParentProperty: AnyProperty {
         if let parent = self.value {
             try container.encode(parent)
         } else if self.id == nil {
-            try container.encodeNil()	
+            try container.encodeNil()
         } else {
             try container.encode([
                 "id": self.id
@@ -83,9 +83,13 @@ extension OptionalParentProperty: AnyProperty {
     }
 
     public func decode(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: ModelCodingKey.self)
-        try self.$id.decode(from: container.superDecoder(forKey: .string("id")))
-        // TODO: allow for nested decoding
+        if try decoder.singleValueContainer().decodeNil() {
+            self.id = nil
+        } else {
+            let container = try decoder.container(keyedBy: ModelCodingKey.self)
+            try self.$id.decode(from: container.superDecoder(forKey: .string("id")))
+            // TODO: allow for nested decoding
+        }
     }
 }
 


### PR DESCRIPTION
For me it was quite interesting, that https://github.com/vapor/fluent-kit/pull/236 was just a minor patch, because in my project it was breaking.
Anyway, when you decide to encode it to `null`, I think we should decode it from `null`, too, to be able to decode the objects we created. :)