### PR TITLE
Revert "Encode @OptionalParent to nil if id is nil"

### DIFF
--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -73,8 +73,6 @@ extension OptionalParentProperty: AnyProperty {
         var container = encoder.singleValueContainer()
         if let parent = self.value {
             try container.encode(parent)
-        } else if self.id == nil {
-            try container.encodeNil()	
         } else {
             try container.encode([
                 "id": self.id


### PR DESCRIPTION
Reverts vapor/fluent-kit#236 (#240). This change was inadvertently breaking. 