### PR TITLE
Added ETag protocols and middleware

### DIFF
--- a/Sources/FluentKit/Middleware/ETagModelMiddleware.swift
+++ b/Sources/FluentKit/Middleware/ETagModelMiddleware.swift
@@ -1,0 +1,21 @@
+
+/// Middleware for `Model` objects which implement `EntityTaggableModel`
+///
+/// Provides default implementations for `update(model:)` and `create(model:)` which
+/// set the eTag for you based on the model's `generateETag()` method.
+public protocol ETagModelMiddleware: ModelMiddleware {}
+
+public extension ETagModelMiddleware where Model: EntityTaggableModel {
+    func update(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
+        model.eTag = model.generateETag()
+        return next.update(model, on: db)
+    }
+
+    func create(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
+        if model._$eTag.value == nil {
+            model.eTag = model.generateETag()
+        }
+
+        return next.create(model, on: db)
+    }
+}

--- a/Sources/FluentKit/Model/EntityTaggableModel.swift
+++ b/Sources/FluentKit/Model/EntityTaggableModel.swift
@@ -1,0 +1,25 @@
+/// A `Model` which includes an eTag
+public protocol EntityTaggableModel: Model {
+    /// The eTag in the database
+    var eTag: String { get set }
+
+    /// Should generate the eTag for the given `Model`. The default generates a `UUID`.
+    func generateETag() -> String
+}
+
+public extension EntityTaggableModel {
+    var _$eTag: Field<String> {
+        guard let mirror = Mirror(reflecting: self).descendant("_eTag"),
+            let field = mirror as? Field<String> else {
+                fatalError("eTag property must be declared using @Field")
+        }
+
+        return field
+    }
+
+    func generateETag() -> String {
+        return "\"\(UUID().uuidString)\""
+    }
+}
+
+


### PR DESCRIPTION
Adds an `EntityTaggableModel` protocol for database objects which include an ETag value.

Adds an `ETagModelMiddleware` which automatically writes a new etag value during update and create of a database object that implements `EntityTaggableModel`.

**Must be released at the same time as https://github.com/vapor/fluent/pull/675**