### PR TITLE
Normalize constraint names

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,13 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.0.0-rc.1"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "FluentKit", dependencies: [
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "Logging", package: "swift-log"),
+            .product(name: "Crypto", package: "swift-crypto"),
         ]),
         .target(name: "FluentBenchmark", dependencies: [
             .target(name: "FluentKit"),


### PR DESCRIPTION
Replaces functionality from Fluent 3 that would normalize constraint names to avoid hitting length requirements. 

FYI - looks like hex encode helpers don't exist anymore so I went with Base64. We can swap in hex if there's an implementation that I didn't see.

Fixes #121 