### PR TITLE
Query builder timestamps + soft delete

### DIFF
--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -2,20 +2,22 @@ extension FluentBenchmarker {
     public func testSoftDelete() throws {
         try self.testSoftDelete_model()
         try self.testSoftDelete_query()
+        try self.testSoftDelete_onBulkDelete()
+        try self.testSoftDelete_forceOnQuery()
+    }
+    
+    private func testCounts(
+        allCount: Int,
+        realCount: Int,
+        line: UInt = #line
+    ) throws {
+        let all = try Trash.query(on: self.database).all().wait()
+        XCTAssertEqual(all.count, allCount, "excluding deleted", line: line)
+        let real = try Trash.query(on: self.database).withDeleted().all().wait()
+        XCTAssertEqual(real.count, realCount, "including deleted", line: line)
     }
 
     private func testSoftDelete_model() throws {
-        func testCounts(
-            allCount: Int,
-            realCount: Int,
-            line: UInt = #line
-        ) throws {
-            let all = try Trash.query(on: self.database).all().wait()
-            XCTAssertEqual(all.count, allCount, "excluding deleted", line: line)
-            let real = try Trash.query(on: self.database).withDeleted().all().wait()
-            XCTAssertEqual(real.count, realCount, "including deleted", line: line)
-        }
-
         try self.runTest(#function, [
             TrashMigration(),
         ]) {
@@ -60,6 +62,28 @@ extension FluentBenchmarker {
                 .filter(\.$contents == "c")
                 .all().wait()
             XCTAssertEqual(trash.count, 0)
+        }
+    }
+    
+    private func testSoftDelete_onBulkDelete() throws {
+        try self.runTest(#function, [
+            TrashMigration(),
+        ]) {
+            // save two users
+            try Trash(contents: "A").save(on: self.database).wait()
+            try Trash(contents: "B").save(on: self.database).wait()
+            try testCounts(allCount: 2, realCount: 2)
+
+            try Trash.query(on: self.database).delete().wait()
+            try testCounts(allCount: 0, realCount: 2)
+        }
+    }
+    
+    private func testSoftDelete_forceOnQuery() throws {
+        try self.runTest(#function, [
+            TrashMigration()
+        ]) {
+            XCTFail()
         }
     }
 }

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -83,7 +83,13 @@ extension FluentBenchmarker {
         try self.runTest(#function, [
             TrashMigration()
         ]) {
-            XCTFail()
+            // save two users
+            try Trash(contents: "A").save(on: self.database).wait()
+            try Trash(contents: "B").save(on: self.database).wait()
+            try testCounts(allCount: 2, realCount: 2)
+
+            try Trash.query(on: self.database).delete(force: true).wait()
+            try testCounts(allCount: 0, realCount: 0)
         }
     }
 }

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -14,7 +14,6 @@ extension Model {
     }
 
     private func _create(on database: Database) -> EventLoopFuture<Void> {
-        self.touchTimestamps(.create, .update)
         precondition(!self._$id.exists)
         self._$id.generate()
         let promise = database.eventLoop.makePromise(of: DatabaseOutput.self)
@@ -40,7 +39,6 @@ extension Model {
     }
 
     private func _update(on database: Database) -> EventLoopFuture<Void> {
-        self.touchTimestamps(.update)
         precondition(self._$id.exists)
         guard self.hasChanges else {
             return database.eventLoop.makeSucceededFuture(())

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -73,7 +73,7 @@ extension Model {
             _ = query.withDeleted()
         }
         
-        query.forceDelete = force
+        query.shouldForceDelete = force
         
         return query
             .filter(\._$id == self.id!)

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -141,8 +141,8 @@ extension Fields {
 }
 
 extension Schema {
-    static func excludeDeleted(from query: inout DatabaseQuery) {
-        guard let timestamp = self.init().deletedTimestamp else {
+    static func excludeDeleted(initialized: Schema, from query: inout DatabaseQuery) {
+        guard let timestamp = initialized.deletedTimestamp else {
             return
         }
 

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -141,8 +141,8 @@ extension Fields {
 }
 
 extension Schema {
-    static func excludeDeleted(initialized: Schema, from query: inout DatabaseQuery) {
-        guard let timestamp = initialized.deletedTimestamp else {
+    static func excludeDeleted(from query: inout DatabaseQuery) {
+        guard let timestamp = self.init().deletedTimestamp else {
             return
         }
 

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -258,6 +258,7 @@ public final class QueryBuilder<Model>
             
             for case .dictionary(var nested) in query.input {
                 addTimestamps(triggers: [.create, .update], nested: &nested)
+                model.touchTimestamps(.create, .update)
                 data.append(.dictionary(nested))
             }
             
@@ -267,6 +268,7 @@ public final class QueryBuilder<Model>
             
             for case .dictionary(var nested) in query.input {
                 addTimestamps(triggers: [.update], nested: &nested)
+                model.touchTimestamps(.update)
                 data.append(.dictionary(nested))
             }
             

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -258,7 +258,6 @@ public final class QueryBuilder<Model>
             
             for case .dictionary(var nested) in query.input {
                 addTimestamps(triggers: [.create, .update], nested: &nested)
-                model.touchTimestamps(.create, .update)
                 data.append(.dictionary(nested))
             }
             
@@ -268,7 +267,6 @@ public final class QueryBuilder<Model>
             
             for case .dictionary(var nested) in query.input {
                 addTimestamps(triggers: [.update], nested: &nested)
-                model.touchTimestamps(.update)
                 data.append(.dictionary(nested))
             }
             
@@ -300,7 +298,10 @@ public final class QueryBuilder<Model>
         let timestamps = Model().timestamps.filter { triggers.contains($0.trigger) }
 
         for timestamp in timestamps {
-            nested[timestamp.path.first!] = .bind(Date())
+            let path = timestamp.path.first!
+            if nested[path] == nil {
+                nested[timestamp.path.first!] = .bind(Date())
+            }
         }
     }
 }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -89,6 +89,7 @@ public final class QueryBuilder<Model>
     
     public func delete(force: Bool = false) -> EventLoopFuture<Void> {
         self.forceDelete = Model.init().deletedTimestamp == nil ? true : force
+        self.query.action = .delete
         return self.run()
     }
 

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -243,19 +243,20 @@ public final class QueryBuilder<Model>
             }
         }
        
+        let model = Model.init()
         switch query.action {
             case .delete:
                 if !self.forceDelete {
+                    model.touchTimestamps(.delete, .update)
                     query.action = .update
-                    query.input = [.dictionary(Model.init().input.values)]
-                    Model.init().touchTimestamps(.delete, .update)
+                    query.input = [.dictionary(model.input.values)]
                 }
             case .create:
-                Model.init().touchTimestamps(.create, .update)
-//                query.input = [.dictionary(Model.init().input.values)]
+                model.touchTimestamps(.create, .update)
+                query.input.append(.dictionary(model.input.values))
             default:
-                Model.init().touchTimestamps(.update)
-//                query.input = [.dictionary(Model.init().input.values)]
+                model.touchTimestamps(.update)
+                query.input.append(.dictionary(model.input.values))
         }
         
         self.database.logger.info("\(self.query)")

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -249,7 +249,8 @@ public final class QueryBuilder<Model>
             // update query. If it is a force delete, still
             // touch the timestamps
             if !self.forceDelete, let _ = initializedModel.deletedTimestamp {
-                initializedModel.touchTimestamps(.create, .update, .delete)
+                initializedModel.touchTimestamps(.update, .delete)
+                query.input = [.dictionary(initializedModel.input.values)]
             } else {
                 switch query.action {
                     case .create: initializedModel.touchTimestamps(.create, .update)

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -252,11 +252,14 @@ public final class QueryBuilder<Model>
                     query.input = [.dictionary(model.input.values)]
                 }
             case .create:
-                model.touchTimestamps(.create, .update)
-                query.input.append(.dictionary(model.input.values))
+                Model.init().touchTimestamps(.create, .update)
+
+//                model.touchTimestamps(.create, .update)
+//                query.input.append(.dictionary(model.input.values))
             default:
-                model.touchTimestamps(.update)
-                query.input.append(.dictionary(model.input.values))
+                Model.init().touchTimestamps(.update)
+//                model.touchTimestamps(.update)
+//                query.input.append(.dictionary(model.input.values))
         }
         
         self.database.logger.info("\(self.query)")

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -89,7 +89,6 @@ public final class QueryBuilder<Model>
     
     public func delete(force: Bool = false) -> EventLoopFuture<Void> {
         self.forceDelete = Model.init().deletedTimestamp == nil ? true : force
-        self.query.action = self.forceDelete ? .delete : .update
         return self.run()
     }
 
@@ -250,6 +249,7 @@ public final class QueryBuilder<Model>
             // touch the timestamps
             if !self.forceDelete, let _ = initializedModel.deletedTimestamp {
                 initializedModel.touchTimestamps(.update, .delete)
+                query.action = .update
                 query.input = [.dictionary(initializedModel.input.values)]
             } else {
                 switch query.action {


### PR DESCRIPTION
Adds a new `force` parameter to `QueryBuilder` `delete` calls:
```swift
MyModel.query(on: db).filter(\.$name == "Vapor").delete(force: true)
```
⚠️ The default behavior of `delete` on `QueryBuilder` has changed. If the model is soft deletable the query builder will now honor this instead of force deleting. 