### PR TITLE
Add discardableResult to QueryBuilder.group

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Group.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Group.swift
@@ -1,4 +1,5 @@
 extension QueryBuilder {
+    @discardableResult
     public func group(
         _ relation: DatabaseQuery.Filter.Relation = .and,
         _ closure: (QueryBuilder<Model>) throws -> ()


### PR DESCRIPTION
Removes a warning when nesting multiple `query.group(relation:)` calls