### PR TITLE
Publicize NestedProperty and DatabaseOutput utilities

### DIFF
--- a/Sources/FluentKit/Database/DatabaseOutput+Cascade.swift
+++ b/Sources/FluentKit/Database/DatabaseOutput+Cascade.swift
@@ -1,5 +1,5 @@
 extension DatabaseOutput {
-    func cascading(to output: DatabaseOutput) -> DatabaseOutput {
+    public func cascading(to output: DatabaseOutput) -> DatabaseOutput {
         return CombinedOutput(first: self, second: output)
     }
 }

--- a/Sources/FluentKit/Database/DatabaseOutput+Nested.swift
+++ b/Sources/FluentKit/Database/DatabaseOutput+Nested.swift
@@ -1,5 +1,5 @@
 extension DatabaseOutput {
-    func nested(_ key: FieldKey) -> DatabaseOutput {
+    public func nested(_ key: FieldKey) -> DatabaseOutput {
         return NestedOutput(wrapped: self, prefix: key)
     }
 }

--- a/Sources/FluentKit/Properties/NestedProperty.swift
+++ b/Sources/FluentKit/Properties/NestedProperty.swift
@@ -5,7 +5,7 @@ public final class NestedProperty<Model, Property>
     public let prefix: [FieldKey]
     public let property: Property
 
-    init(prefix: [FieldKey], property: Property) {
+    public init(prefix: [FieldKey], property: Property) {
         self.prefix = prefix
         self.property = property
     }


### PR DESCRIPTION
- Makes `NestedProperty` Initializer public (#262).
- Makes `DatabaseOutput` `cascading` and `nested` functions public (#262).