### PR TITLE
Fixes timestamp update when model doesn't have changes  

### DIFF
--- a/Sources/FluentBenchmark/Tests/ModelTests.swift
+++ b/Sources/FluentBenchmark/Tests/ModelTests.swift
@@ -7,7 +7,7 @@ extension FluentBenchmarker {
         try self.testModel_nullField()
         try self.testModel_idGeneration()
         try self.testModel_jsonColumn()
-        try self.testModel_hasChangesTests()
+        try self.testModel_hasChanges()
     }
 
     private func testModel_uuid() throws {
@@ -112,7 +112,7 @@ extension FluentBenchmarker {
         }
     }
 
-    private func testModel_hasChangesTests() throws {
+    private func testModel_hasChanges() throws {
         try runTest(#function, [
             FooMigration(),
         ]) {

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -14,8 +14,8 @@ extension Model {
     }
 
     private func _create(on database: Database) -> EventLoopFuture<Void> {
-        self.touchTimestamps(.create, .update)
         precondition(!self._$id.exists)
+        self.touchTimestamps(.create, .update)
         self._$id.generate()
         let promise = database.eventLoop.makePromise(of: DatabaseOutput.self)
         Self.query(on: database)
@@ -40,11 +40,11 @@ extension Model {
     }
 
     private func _update(on database: Database) -> EventLoopFuture<Void> {
-        self.touchTimestamps(.update)
         precondition(self._$id.exists)
         guard self.hasChanges else {
             return database.eventLoop.makeSucceededFuture(())
         }
+        self.touchTimestamps(.update)
         let input = self.input
         return Self.query(on: database)
             .filter(\._$id == self.id!)


### PR DESCRIPTION
- Fixes updated timestamp being updated when model doesn't have changes (#263).
- Adds tests for `model.hasChanges` (#263).
- Adds tests to test updates without changes on models with `@Timestamp` (#263).