### PR TITLE
Remove setters from read-only wrappers

### DIFF
--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -30,15 +30,10 @@ public final class ChildrenProperty<From, To>
     }
 
     public var wrappedValue: [To] {
-        get {
-            guard let value = self.value else {
-                fatalError("Children relation not eager loaded, use $ prefix to access: \(name)")
-            }
-            return value
+        guard let value = self.value else {
+            fatalError("Children relation not eager loaded, use $ prefix to access: \(name)")
         }
-        set {
-            fatalError("Children relation is get-only.")
-        }
+        return value
     }
 
     public var projectedValue: ChildrenProperty<From, To> {

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -11,13 +11,10 @@ public final class ParentProperty<From, To>
     public var id: To.IDValue
 
     public var wrappedValue: To {
-        get {
-            guard let value = self.value else {
-                fatalError("Parent relation not eager loaded, use $ prefix to access: \(name)")
-            }
-            return value
+        guard let value = self.value else {
+            fatalError("Parent relation not eager loaded, use $ prefix to access: \(name)")
         }
-        set { fatalError("use $ prefix to access") }
+        return value
     }
 
     public var projectedValue: ParentProperty<From, To> {

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -31,15 +31,10 @@ public final class SiblingsProperty<From, To, Through>
     }
 
     public var wrappedValue: [To] {
-        get {
-            guard let value = self.value else {
-                fatalError("Siblings relation not eager loaded, use $ prefix to access: \(name)")
-            }
-            return value
+        guard let value = self.value else {
+            fatalError("Siblings relation not eager loaded, use $ prefix to access: \(name)")
         }
-        set {
-            fatalError("Siblings relation is get-only.")
-        }
+        return value
     }
 
     public var projectedValue: SiblingsProperty<From, To, Through> {


### PR DESCRIPTION
I wondered why those setters are provided. If they aren't, the compiler will already tell users that those properties aren't writable, removing the need to fail at runtime.

However, there might be reasons for these setters to exist that I haven't seen. If so, feel free to close this.