### PR TITLE
Set supported platforms for used APIs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,10 @@ import PackageDescription
 let package = Package(
     name: "fluent-kit",
     platforms: [
-       .macOS(.v10_15)
+       .macOS(.v10_13),
+       .iOS(.v11),
+       .tvOS(.v11),
+       .watchOS(.v4)
     ],
     products: [
         .library(name: "FluentKit", targets: ["FluentKit"]),


### PR DESCRIPTION
Resolves compilation errors:
'ISO8601DateFormatter' is only available in watchOS 3.0 or newer
'withFractionalSeconds' is only available in watchOS 4.0 or newer
'ISO8601DateFormatter' is only available in iOS 10.0 or newer
'withFractionalSeconds' is only available in iOS 11.0 or newer