### PR TITLE
Add QueryHistory

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -9,6 +9,7 @@ public final class FluentBenchmarker {
     public var database: Database {
         self.databases.database(
             logger: .init(label: "codes.fluent.benchmarker"),
+            history: .init(),
             on: self.databases.eventLoopGroup.next()
         )!
     }

--- a/Sources/FluentBenchmark/Tests/MigratorTests.swift
+++ b/Sources/FluentBenchmark/Tests/MigratorTests.swift
@@ -66,6 +66,7 @@ extension FluentBenchmarker {
                 self.databases.database(
                     databaseID.0,
                     logger: Logger(label: "codes.vapor.tests"),
+                    history: .init(),
                     on: self.databases.eventLoopGroup.next()
                 )
             )
@@ -73,6 +74,7 @@ extension FluentBenchmarker {
                 self.databases.database(
                     databaseID.1,
                     logger: Logger(label: "codes.vapor.tests"),
+                    history: .init(),
                     on: self.databases.eventLoopGroup.next()
                 )
             )

--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -55,15 +55,18 @@ public struct DatabaseContext {
     public let configuration: DatabaseConfiguration
     public let logger: Logger
     public let eventLoop: EventLoop
+    public let history: QueryHistory
     
     public init(
         configuration: DatabaseConfiguration,
         logger: Logger,
-        eventLoop: EventLoop
+        eventLoop: EventLoop,
+        history: QueryHistory
     ) {
         self.configuration = configuration
         self.logger = logger
         self.eventLoop = eventLoop
+        self.history = history
     }
 }
 

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -88,6 +88,7 @@ public final class Databases {
     public func database(
         _ id: DatabaseID? = nil,
         logger: Logger,
+        history: QueryHistory,
         on eventLoop: EventLoop
     ) -> Database? {
         self.lock.lock()
@@ -99,7 +100,8 @@ public final class Databases {
         let context = DatabaseContext(
             configuration: configuration,
             logger: logger,
-            eventLoop: eventLoop
+            eventLoop: eventLoop,
+            history: history
         )
         let driver: DatabaseDriver
         if let existing = self.drivers[id] {

--- a/Sources/FluentKit/Database/DummyDatabase.swift
+++ b/Sources/FluentKit/Database/DummyDatabase.swift
@@ -7,7 +7,8 @@ public struct DummyDatabase: Database {
         self.context = context ?? .init(
             configuration: DummyDatabaseConfiguration(middleware: []),
             logger: .init(label: "codes.vapor.test"),
-            eventLoop: EmbeddedEventLoop()
+            eventLoop: EmbeddedEventLoop(),
+            history: .init()
         )
     }
     

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -15,7 +15,7 @@ public struct Migrator {
     ) {
         self.init(
             databaseFactory: {
-                databases.database($0, logger: logger, on: eventLoop)!
+                databases.database($0, logger: logger, history: .init(), on: eventLoop)!
             },
             migrations: migrations,
             on: eventLoop

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -11,12 +11,14 @@ public final class QueryBuilder<Model>
     internal var shouldForceDelete: Bool
     internal var models: [Schema.Type]
     public var eagerLoaders: [AnyEagerLoader]
+    public var history: QueryHistory
 
     public convenience init(database: Database) {
         self.init(
             query: .init(schema: Model.schema),
             database: database,
-            models: [Model.self]
+            models: [Model.self],
+            history: .init()
         )
     }
 
@@ -26,7 +28,8 @@ public final class QueryBuilder<Model>
         models: [Schema.Type] = [],
         eagerLoaders: [AnyEagerLoader] = [],
         includeDeleted: Bool = false,
-        shouldForceDelete: Bool = false
+        shouldForceDelete: Bool = false,
+        history: QueryHistory
     ) {
         self.query = query
         self.database = database
@@ -34,6 +37,7 @@ public final class QueryBuilder<Model>
         self.eagerLoaders = eagerLoaders
         self.includeDeleted = includeDeleted
         self.shouldForceDelete = shouldForceDelete
+        self.history = history
         // Pass through custom ID key for database if used.
         let idKey = Model()._$id.key
         switch idKey {
@@ -50,7 +54,8 @@ public final class QueryBuilder<Model>
             models: self.models,
             eagerLoaders: self.eagerLoaders,
             includeDeleted: self.includeDeleted,
-            shouldForceDelete: self.shouldForceDelete
+            shouldForceDelete: self.shouldForceDelete,
+            history: self.history
         )
     }
 
@@ -277,6 +282,7 @@ public final class QueryBuilder<Model>
         }
 
         self.database.logger.info("\(self.query)")
+        self.history.add(self.query)
 
         let done = self.database.execute(query: query) { output in
             assert(

--- a/Sources/FluentKit/Query/QueryHistory.swift
+++ b/Sources/FluentKit/Query/QueryHistory.swift
@@ -1,0 +1,21 @@
+/// Holds the history of queries for a database
+public final class QueryHistory {
+
+    /// The queries that were executed over a period of time
+    public var queries: [DatabaseQuery]
+
+    /// Create a new `QueryHistory` with no existing history
+    public convenience init() {
+        self.init(queries: [])
+    }
+
+    /// Create a new `QueryHistory` object
+    /// - Parameter queries: The queries
+    public init(queries: [DatabaseQuery]) {
+        self.queries = queries
+    }
+
+    func add(_ query: DatabaseQuery) {
+        queries.append(query)
+    }
+}

--- a/Sources/XCTFluent/TestDatabase.swift
+++ b/Sources/XCTFluent/TestDatabase.swift
@@ -79,7 +79,8 @@ extension TestDatabase {
         self.database(context: .init(
             configuration: self.configuration,
             logger: Logger(label: "codes.vapor.fluent.test"),
-            eventLoop: EmbeddedEventLoop()
+            eventLoop: EmbeddedEventLoop(),
+            history: .init()
         ))
     }
 

--- a/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
+++ b/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
@@ -26,7 +26,8 @@ public class DummyDatabaseForTestSQLSerializer: Database, SQLDatabase {
         self.context = .init(
             configuration: Configuration(),
             logger: .init(label: "test"),
-            eventLoop: EmbeddedEventLoop()
+            eventLoop: EmbeddedEventLoop(),
+            history: .init()
         )
         self.sqlSerializers = []
     }


### PR DESCRIPTION
Adds a `QueryHistory` object which is used to maintain a history of queries run against a `Database`. After merging this PR there also needs to be a Fluent PR that adds a default history object to the database's request object, so that the end user can access the history via `request.dbHistory`.

This update needs to be made here: https://github.com/vapor/fluent/blob/master/Sources/Fluent/FluentProvider.swift#L8 to pass in a default `QueryHistory` object from `Request`. 