### PR TITLE
Add helper methods for adding multiple Migrations at once

### DIFF
--- a/Sources/FluentBenchmark/Tests/MigratorTests.swift
+++ b/Sources/FluentBenchmark/Tests/MigratorTests.swift
@@ -131,6 +131,7 @@ extension FluentBenchmarker {
         try self.runTest(#function, []) {
             let migrations = Migrations()
             migrations.add([GalaxyMigration(), StarMigration(), GalaxySeed()])
+            migrations.add(PlanetMigration(), PlanetTagMigration(), to: self.databases.ids().first)
 
             let migrator = Migrator(
                 databaseFactory: { _ in self.database },
@@ -144,7 +145,7 @@ extension FluentBenchmarker {
                 .sort(\.$batch, .ascending)
                 .all().wait()
                 .map { $0.batch }
-            XCTAssertEqual(logs, [1, 1, 1], "batch did not apply all three")
+            XCTAssertEqual(logs, [1, 1, 1, 1, 1], "batch did not apply all five")
 
             try migrator.revertAllBatches().wait()
         }

--- a/Sources/FluentKit/Migration/Migrations.swift
+++ b/Sources/FluentKit/Migration/Migrations.swift
@@ -14,7 +14,8 @@ public final class Migrations {
     public func add(_ migration: Migration, to id: DatabaseID? = nil) {
         self.storage.append(.init(id: id, migration: migration))
     }
-
+    
+    @inlinable
     public func add(_ migrations: Migration..., to id: DatabaseID? = nil) {
         self.add(migrations, to: id)
     }

--- a/Sources/FluentKit/Migration/Migrations.swift
+++ b/Sources/FluentKit/Migration/Migrations.swift
@@ -15,6 +15,10 @@ public final class Migrations {
         self.storage.append(.init(id: id, migration: migration))
     }
 
+    public func add(_ migrations: Migration..., to id: DatabaseID? = nil) {
+        self.add(migrations, to: id)
+    }
+
     public func add(_ migrations: [Migration], to id: DatabaseID? = nil) {
         self.storage.append(contentsOf: migrations.map { .init(id: id, migration: $0) })
     }

--- a/Sources/FluentKit/Migration/Migrations.swift
+++ b/Sources/FluentKit/Migration/Migrations.swift
@@ -14,4 +14,8 @@ public final class Migrations {
     public func add(_ migration: Migration, to id: DatabaseID? = nil) {
         self.storage.append(.init(id: id, migration: migration))
     }
+
+    public func add(_ migrations: [Migration], to id: DatabaseID? = nil) {
+        self.storage.append(contentsOf: migrations.map { .init(id: id, migration: $0) })
+    }
 }


### PR DESCRIPTION
- Adds an overload of `Migrations.add(_:to:)` which accepts an array of `Migration`, e.g.:
        
    ````swift
    app.migrations.add([ConfigModel.Migration(), SolarSystem.Migration()])
    app.migrations.add([UserModel.Migration(), PostModel.Migration()], to: .psql)
    ````

    As a new public API, this requires a `semver-minor` release.

- Also adds an overload which accepts a variadic parameter of `Migration` type:
        
    ````swift
    app.migrations.add(ConfigModel.Migration(), SolarSystem.Migration())
    app.migrations.add(UserModel.Migration(), PostModel.Migration(), to: .psql)
    ````

- Adds a benchmark test for the new methods, just for the heck of it.