### PR TITLE
Add optional string contains operators

### DIFF
--- a/Sources/FluentKit/Operators/ValueOperators+String.swift
+++ b/Sources/FluentKit/Operators/ValueOperators+String.swift
@@ -1,117 +1,117 @@
 // MARK: Field.Value
 
-public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
-        Field.Value: CustomStringConvertible
+        Field.Value == String
 {
     lhs ~= Field.queryValue(rhs)
 }
 
-public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: OptionalType,
-        Field.Value.Wrapped: CustomStringConvertible
+        Field.Value.Wrapped == String
 {
-    lhs ~= Field.queryValue(rhs)
+    lhs ~= Field.queryValue(.init(rhs))
 }
 
-public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
-        Field.Value: CustomStringConvertible
+        Field.Value == String
 {
     lhs ~~ Field.queryValue(rhs)
 }
 
-public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: OptionalType,
-        Field.Value.Wrapped: CustomStringConvertible
+        Field.Value.Wrapped == String
 {
-    lhs ~~ Field.queryValue(rhs)
+    lhs ~~ Field.queryValue(.init(rhs))
 }
 
-public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
-        Field.Value: CustomStringConvertible
+        Field.Value == String
 {
     lhs =~ Field.queryValue(rhs)
 }
 
-public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: OptionalType,
-        Field.Value.Wrapped: CustomStringConvertible
+        Field.Value.Wrapped == String
 {
-    lhs =~ Field.queryValue(rhs)
+    lhs =~ Field.queryValue(.init(rhs))
 }
 
-public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
-        Field.Value: CustomStringConvertible
+        Field.Value == String
 {
     lhs !~= Field.queryValue(rhs)
 }
 
-public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: OptionalType,
-        Field.Value.Wrapped: CustomStringConvertible
+        Field.Value.Wrapped == String
 {
-    lhs !~= Field.queryValue(rhs)
+    lhs !~= Field.queryValue(.init(rhs))
 }
 
-public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
-        Field.Value: CustomStringConvertible
+        Field.Value == String
 {
     lhs !~ Field.queryValue(rhs)
 }
 
-public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: OptionalType,
-        Field.Value.Wrapped: CustomStringConvertible
+        Field.Value.Wrapped == String
 {
-    lhs !~ Field.queryValue(rhs)
+    lhs !~ Field.queryValue(.init(rhs))
 }
 
-public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
-        Field.Value: CustomStringConvertible
+        Field.Value == String
 {
     lhs !=~ Field.queryValue(rhs)
 }
 
-public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: OptionalType,
-        Field.Value.Wrapped: CustomStringConvertible
+        Field.Value.Wrapped == String
 {
-    lhs !=~ Field.queryValue(rhs)
+    lhs !=~ Field.queryValue(.init(rhs))
 }
 
 // MARK: DatabaseQuery.Value

--- a/Sources/FluentKit/Operators/ValueOperators+String.swift
+++ b/Sources/FluentKit/Operators/ValueOperators+String.swift
@@ -9,11 +9,31 @@ public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> M
     lhs ~= Field.queryValue(rhs)
 }
 
+public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
+{
+    lhs ~= Field.queryValue(rhs)
+}
+
 public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
+{
+    lhs ~~ Field.queryValue(rhs)
+}
+
+public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
 {
     lhs ~~ Field.queryValue(rhs)
 }
@@ -27,11 +47,31 @@ public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> M
     lhs =~ Field.queryValue(rhs)
 }
 
+public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
+{
+    lhs =~ Field.queryValue(rhs)
+}
+
 public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
+{
+    lhs !~= Field.queryValue(rhs)
+}
+
+public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
 {
     lhs !~= Field.queryValue(rhs)
 }
@@ -45,11 +85,31 @@ public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> M
     lhs !~ Field.queryValue(rhs)
 }
 
+public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
+{
+    lhs !~ Field.queryValue(rhs)
+}
+
 public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
+{
+    lhs !=~ Field.queryValue(rhs)
+}
+
+public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: Field.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
 {
     lhs !=~ Field.queryValue(rhs)
 }
@@ -65,11 +125,31 @@ public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
     .init(lhs, .contains(inverse: false, .suffix), rhs)
 }
 
+public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
+{
+    .init(lhs, .contains(inverse: false, .suffix), rhs)
+}
+
 public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
+{
+    .init(lhs, .contains(inverse: false, .anywhere), rhs)
+}
+
+public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
 {
     .init(lhs, .contains(inverse: false, .anywhere), rhs)
 }
@@ -83,11 +163,31 @@ public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
     .init(lhs, .contains(inverse: false, .prefix), rhs)
 }
 
+public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
+{
+    .init(lhs, .contains(inverse: false, .prefix), rhs)
+}
+
 public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
+{
+    .init(lhs, .contains(inverse: true, .suffix), rhs)
+}
+
+public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
 {
     .init(lhs, .contains(inverse: true, .suffix), rhs)
 }
@@ -101,11 +201,31 @@ public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
     .init(lhs, .contains(inverse: true, .anywhere), rhs)
 }
 
+public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
+{
+    .init(lhs, .contains(inverse: true, .anywhere), rhs)
+}
+
 public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
         Model: FluentKit.Model,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
+{
+    .init(lhs, .contains(inverse: true, .prefix), rhs)
+}
+
+public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
+    where
+        Model: FluentKit.Model,
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Value.Wrapped: CustomStringConvertible
 {
     .init(lhs, .contains(inverse: true, .prefix), rhs)
 }

--- a/Sources/FluentKit/Utilities/OptionalType.swift
+++ b/Sources/FluentKit/Utilities/OptionalType.swift
@@ -6,6 +6,7 @@ public protocol AnyOptionalType {
 
 public protocol OptionalType: AnyOptionalType {
     associatedtype Wrapped
+    init(_ wrapped: Wrapped)
 }
 
 extension OptionalType {


### PR DESCRIPTION
Adds missing [string contains](https://docs.vapor.codes/4.0/fluent/query/#contains-filter) operators for `@OptionalField` (#305). 