### PR TITLE
Reduce query logging level

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -263,7 +263,7 @@ public final class QueryBuilder<Model>
             break
         }
 
-        self.database.logger.info("\(self.query)")
+        self.database.logger.debug("\(self.query)")
 
         let done = self.database.execute(query: query) { output in
             assert(


### PR DESCRIPTION
### `QueryBuilder` now logs queries at `debug` logging level (#311).

Previously queries were logged at `info` which crowded the log level. 