### PR TITLE
Add query history

### DIFF
--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -41,6 +41,10 @@ extension Database {
     public var eventLoop: EventLoop {
         self.context.eventLoop
     }
+
+    public var history: QueryHistory {
+        self.context.history
+    }
 }
 
 public protocol DatabaseDriver {
@@ -57,15 +61,18 @@ public struct DatabaseContext {
     public let configuration: DatabaseConfiguration
     public let logger: Logger
     public let eventLoop: EventLoop
+    public var history: QueryHistory
     
     public init(
         configuration: DatabaseConfiguration,
         logger: Logger,
-        eventLoop: EventLoop
+        eventLoop: EventLoop,
+        history: QueryHistory = .init()
     ) {
         self.configuration = configuration
         self.logger = logger
         self.eventLoop = eventLoop
+        self.history = history
     }
 }
 

--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -42,7 +42,7 @@ extension Database {
         self.context.eventLoop
     }
 
-    public var history: QueryHistory {
+    public var history: QueryHistory? {
         self.context.history
     }
 }
@@ -61,13 +61,13 @@ public struct DatabaseContext {
     public let configuration: DatabaseConfiguration
     public let logger: Logger
     public let eventLoop: EventLoop
-    public var history: QueryHistory
+    public var history: QueryHistory?
     
     public init(
         configuration: DatabaseConfiguration,
         logger: Logger,
         eventLoop: EventLoop,
-        history: QueryHistory = .init()
+        history: QueryHistory? = nil
     ) {
         self.configuration = configuration
         self.logger = logger

--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -61,7 +61,7 @@ public struct DatabaseContext {
     public let configuration: DatabaseConfiguration
     public let logger: Logger
     public let eventLoop: EventLoop
-    public var history: QueryHistory?
+    public let history: QueryHistory?
     
     public init(
         configuration: DatabaseConfiguration,

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -97,7 +97,8 @@ public final class Databases {
     public func database(
         _ id: DatabaseID? = nil,
         logger: Logger,
-        on eventLoop: EventLoop
+        on eventLoop: EventLoop,
+        history: QueryHistory = .init()
     ) -> Database? {
         self.lock.lock()
         defer { self.lock.unlock() }
@@ -108,7 +109,8 @@ public final class Databases {
         let context = DatabaseContext(
             configuration: configuration,
             logger: logger,
-            eventLoop: eventLoop
+            eventLoop: eventLoop,
+            history: history
         )
         let driver: DatabaseDriver
         if let existing = self.drivers[id] {

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -98,7 +98,7 @@ public final class Databases {
         _ id: DatabaseID? = nil,
         logger: Logger,
         on eventLoop: EventLoop,
-        history: QueryHistory = .init()
+        history: QueryHistory? = nil
     ) -> Database? {
         self.lock.lock()
         defer { self.lock.unlock() }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -17,8 +17,7 @@ public final class QueryBuilder<Model>
         self.init(
             query: .init(schema: Model.schema),
             database: database,
-            models: [Model.self],
-            history: database.history
+            models: [Model.self]
         )
     }
 
@@ -28,8 +27,7 @@ public final class QueryBuilder<Model>
         models: [Schema.Type] = [],
         eagerLoaders: [AnyEagerLoader] = [],
         includeDeleted: Bool = false,
-        shouldForceDelete: Bool = false,
-        history: QueryHistory = .init()
+        shouldForceDelete: Bool = false
     ) {
         self.query = query
         self.database = database
@@ -37,7 +35,7 @@ public final class QueryBuilder<Model>
         self.eagerLoaders = eagerLoaders
         self.includeDeleted = includeDeleted
         self.shouldForceDelete = shouldForceDelete
-        self.history = history
+        self.history = database.history
         // Pass through custom ID key for database if used.
         let idKey = Model()._$id.key
         switch idKey {

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -11,12 +11,14 @@ public final class QueryBuilder<Model>
     internal var shouldForceDelete: Bool
     internal var models: [Schema.Type]
     public var eagerLoaders: [AnyEagerLoader]
+    public var history: QueryHistory
 
     public convenience init(database: Database) {
         self.init(
             query: .init(schema: Model.schema),
             database: database,
-            models: [Model.self]
+            models: [Model.self],
+            history: database.history
         )
     }
 
@@ -26,7 +28,8 @@ public final class QueryBuilder<Model>
         models: [Schema.Type] = [],
         eagerLoaders: [AnyEagerLoader] = [],
         includeDeleted: Bool = false,
-        shouldForceDelete: Bool = false
+        shouldForceDelete: Bool = false,
+        history: QueryHistory = .init()
     ) {
         self.query = query
         self.database = database
@@ -34,6 +37,7 @@ public final class QueryBuilder<Model>
         self.eagerLoaders = eagerLoaders
         self.includeDeleted = includeDeleted
         self.shouldForceDelete = shouldForceDelete
+        self.history = history
         // Pass through custom ID key for database if used.
         let idKey = Model()._$id.key
         switch idKey {
@@ -264,6 +268,7 @@ public final class QueryBuilder<Model>
         }
 
         self.database.logger.debug("\(self.query)")
+        self.history.add(self.query)
 
         let done = self.database.execute(query: query) { output in
             assert(

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -11,7 +11,6 @@ public final class QueryBuilder<Model>
     internal var shouldForceDelete: Bool
     internal var models: [Schema.Type]
     public var eagerLoaders: [AnyEagerLoader]
-    public var history: QueryHistory
 
     public convenience init(database: Database) {
         self.init(
@@ -35,7 +34,6 @@ public final class QueryBuilder<Model>
         self.eagerLoaders = eagerLoaders
         self.includeDeleted = includeDeleted
         self.shouldForceDelete = shouldForceDelete
-        self.history = database.history
         // Pass through custom ID key for database if used.
         let idKey = Model()._$id.key
         switch idKey {
@@ -266,7 +264,7 @@ public final class QueryBuilder<Model>
         }
 
         self.database.logger.debug("\(self.query)")
-        self.history.add(self.query)
+        self.database.history.add(self.query)
 
         let done = self.database.execute(query: query) { output in
             assert(

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -264,7 +264,7 @@ public final class QueryBuilder<Model>
         }
 
         self.database.logger.debug("\(self.query)")
-        self.database.history.add(self.query)
+        self.database.history?.add(self.query)
 
         let done = self.database.execute(query: query) { output in
             assert(

--- a/Sources/FluentKit/Query/QueryHistory.swift
+++ b/Sources/FluentKit/Query/QueryHistory.swift
@@ -1,14 +1,22 @@
+import class NIOConcurrencyHelpers.Lock
+
 /// Holds the history of queries for a database
 public final class QueryHistory {
     /// The queries that were executed over a period of time
     public var queries: [DatabaseQuery]
 
+    /// Protects
+    private var lock: Lock
+
     /// Create a new `QueryHistory` with no existing history
     public init() {
         self.queries = []
+        self.lock = .init()
     }
 
     func add(_ query: DatabaseQuery) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
         queries.append(query)
     }
 }

--- a/Sources/FluentKit/Query/QueryHistory.swift
+++ b/Sources/FluentKit/Query/QueryHistory.swift
@@ -1,0 +1,14 @@
+/// Holds the history of queries for a database
+public final class QueryHistory {
+    /// The queries that were executed over a period of time
+    public var queries: [DatabaseQuery]
+
+    /// Create a new `QueryHistory` with no existing history
+    public init() {
+        self.queries = []
+    }
+
+    func add(_ query: DatabaseQuery) {
+        queries.append(query)
+    }
+}

--- a/Sources/XCTFluent/TestDatabase.swift
+++ b/Sources/XCTFluent/TestDatabase.swift
@@ -91,7 +91,7 @@ extension TestDatabase {
         ))
     }
 
-    func database(context: DatabaseContext) -> Database {
+    public func database(context: DatabaseContext) -> Database {
         _TestDatabase(test: self, context: context)
     }
 }

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -77,10 +77,12 @@ final class QueryBuilderTests: XCTestCase {
             Planet(id: UUID(), name: "P3", starId: starId)
         ]
         let test = ArrayTestDatabase()
+        let db = test.db
         test.append(planets.map(TestOutput.init))
 
-        let retrievedPlanets = try Planet.query(on: test.db).all().wait()
+        let retrievedPlanets = try Planet.query(on: db).all().wait()
         XCTAssertEqual(retrievedPlanets.count, planets.count)
-        XCTAssertEqual(test.db.history.queries.count, 1)
+        XCTAssertEqual(db.history.queries.count, 1)
+        XCTAssertEqual(db.history.queries.first?.schema, Planet.schema)
     }
 }

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -68,4 +68,19 @@ final class QueryBuilderTests: XCTestCase {
         XCTAssertEqual(retrievedPlanets.count, planets.count)
         XCTAssertEqual(retrievedPlanets.map(\.name), planets.map(\.name))
     }
+
+    func testQueryHistory() throws {
+        let starId = UUID()
+        let planets = [
+            Planet(id: UUID(), name: "P1", starId: starId),
+            Planet(id: UUID(), name: "P2", starId: starId),
+            Planet(id: UUID(), name: "P3", starId: starId)
+        ]
+        let test = ArrayTestDatabase()
+        test.append(planets.map(TestOutput.init))
+
+        let retrievedPlanets = try Planet.query(on: test.db).all().wait()
+        XCTAssertEqual(retrievedPlanets.count, planets.count)
+        XCTAssertEqual(test.db.history.queries.count, 1)
+    }
 }

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -3,6 +3,7 @@
 import XCTest
 import Foundation
 import XCTFluent
+import NIO
 
 final class QueryBuilderTests: XCTestCase {
     func testFirstEmptyResult() throws {
@@ -77,12 +78,12 @@ final class QueryBuilderTests: XCTestCase {
             Planet(id: UUID(), name: "P3", starId: starId)
         ]
         let test = ArrayTestDatabase()
-        let db = test.db
+        let db = test.database(context: .init(configuration: test.configuration, logger: test.db.logger, eventLoop: test.db.eventLoop, history: .init()))
         test.append(planets.map(TestOutput.init))
 
         let retrievedPlanets = try Planet.query(on: db).all().wait()
         XCTAssertEqual(retrievedPlanets.count, planets.count)
-        XCTAssertEqual(db.history.queries.count, 1)
-        XCTAssertEqual(db.history.queries.first?.schema, Planet.schema)
+        XCTAssertEqual(db.history?.queries.count, 1)
+        XCTAssertEqual(db.history?.queries.first?.schema, Planet.schema)
     }
 }


### PR DESCRIPTION
Adds a `QueryHistory` object which is used to maintain a history of queries run against a `Database`. 