### PR TITLE
Add `.dictionary` data type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,25 +32,39 @@ jobs:
           - swiftlang/swift:nightly-master-bionic
           - swiftlang/swift:nightly-master-focal
         include:
-          - depscmd: 'apt-get -q update && apt-get -q install -y postgresql-client libsqlite3-dev'
+          - depscmd: apt-get -q update && apt-get -q install -y libsqlite3-dev
           - image: swiftlang/swift:nightly-master-centos8
-            depscmd: 'dnf install -y postgresql sqlite-devel'
+            depscmd: dnf install -y sqlite-devel
           - image: swiftlang/swift:nightly-master-amazonlinux2
-            depscmd: 'yum install -y postgresql sqlite-devel'
+            depscmd: yum install -y sqlite-devel
     container: ${{ matrix.image }}
     services:
       postgres-a:
         image: postgres:latest
-        env: { POSTGRES_USER: vapor_username, POSTGRES_PASSWORD: vapor_password, POSTGRES_DB: vapor_database }
+        env:
+          POSTGRES_USER: vapor_username
+          POSTGRES_PASSWORD: vapor_password
+          POSTGRES_DB: vapor_database
       postgres-b:
         image: postgres:latest
-        env: { POSTGRES_USER: vapor_username, POSTGRES_PASSWORD: vapor_password, POSTGRES_DB: vapor_database }
+        env: 
+          POSTGRES_USER: vapor_username
+          POSTGRES_PASSWORD: vapor_password
+          POSTGRES_DB: vapor_database
       mysql-a:
         image: mysql:latest
-        env: { MYSQL_ALLOW_EMPTY_PASSWORD: 1, MYSQL_USER: vapor_username, MYSQL_PASSWORD: vapor_password, MYSQL_DATABASE: vapor_database }
+        env: 
+          MYSQL_ALLOW_EMPTY_PASSWORD: 1
+          MYSQL_USER: vapor_username
+          MYSQL_PASSWORD: vapor_password
+          MYSQL_DATABASE: vapor_database
       mysql-b:
         image: mysql:latest
-        env: { MYSQL_ALLOW_EMPTY_PASSWORD: 1, MYSQL_USER: vapor_username, MYSQL_PASSWORD: vapor_password, MYSQL_DATABASE: vapor_database }
+        env: 
+          MYSQL_ALLOW_EMPTY_PASSWORD: 1
+          MYSQL_USER: vapor_username
+          MYSQL_PASSWORD: vapor_password
+          MYSQL_DATABASE: vapor_database
       mongo-a:
         image: mongo:latest
       mongo-b:
@@ -76,14 +90,15 @@ jobs:
           export CFLAGS="-DSQLITE_DISABLE_DIRSYNC=1 -DSQLITE_SECURE_DELETE=1"
           ./configure --prefix=/usr --libdir=/usr/lib64 --with-tcl=/usr/lib64 --enable-all && make all install
           printf '#!/bin/bash\nexec psql "$@" </dev/null\n' >/usr/bin/pg_isready && chmod 0755 /usr/bin/pg_isready
-      - name: Wait for all database servers to be ready
-        # Actually we just wait for Postgres, because it's the easiest to install on all the various runners
-        # and because it usually takes the longest to start.
-        run: until pg_isready -hpostgres-a && pg_isready -hpostgres-b; do sleep 1; done
+      # - name: Wait for all database servers to be ready
+      #   # Actually we just wait for Postgres, because it's the easiest to install on all the various runners
+      #   # and because it usually takes the longest to start.
+      #   run: until pg_isready -hpostgres-a && pg_isready -hpostgres-b; do sleep 1; done
         timeout-minutes: 2
-      - name: Checkout fluent-kit
+      - name: Checkout FluentKit
         uses: actions/checkout@v2
-        with: { path: 'fluent-kit' }
+        with: 
+          path: fluent-kit
       - name: Checkout Postgres driver
         uses: actions/checkout@v2
         with:
@@ -92,14 +107,20 @@ jobs:
           ref: tn-dict-datatype
       - name: Checkout MySQL driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-mysql-driver', path: 'fluent-mysql-driver' }
+        with: 
+          repository: vapor/fluent-mysql-driver
+          path: fluent-mysql-driver
       - name: Checkout SQLite driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-sqlite-driver', path: 'fluent-sqlite-driver' }
+        with: 
+          repository: vapor/fluent-sqlite-driver
+          path: fluent-sqlite-driver
       - name: Checkout Mongo driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-mongo-driver', path: 'fluent-mongo-driver' }
-      - name: Link drivers to local fluent-kit
+        with: 
+          repository: vapor/fluent-mongo-driver
+          path: fluent-mongo-driver
+      - name: Link drivers to local FluentKit
         run: |
           swift package --package-path fluent-postgres-driver edit fluent-kit --path fluent-kit
           swift package --package-path fluent-mysql-driver edit fluent-kit --path fluent-kit
@@ -136,7 +157,8 @@ jobs:
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@1.0
-        with: { 'xcode-version': 'latest' }
+        with:
+          xcode-version: latest
       - name: Replace Postgres install, add MySQL and Mongo installs
         run: |
           brew uninstall --force postgresql php && rm -rf /usr/local/{etc,var}/{postgres,pg}*
@@ -160,21 +182,31 @@ jobs:
             psql $db <<<"ALTER SCHEMA public OWNER TO vapor_username;"
             mysql -uroot --batch <<<"CREATE DATABASE $db; GRANT ALL PRIVILEGES ON $db.* TO vapor_username@localhost;"
           done
-      - name: Checkout fluent-kit
+      - name: Checkout FluentKit
         uses: actions/checkout@v2
-        with: { path: 'fluent-kit' }
+        with:
+          path: fluent-kit
       - name: Checkout Postgres driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-postgres-driver', path: 'fluent-postgres-driver' }
+        with:
+          repository: vapor/fluent-postgres-driver
+          path: fluent-postgres-driver
+          ref: tn-dict-datatype
       - name: Checkout MySQL driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-mysql-driver', path: 'fluent-mysql-driver' }
+        with:
+          repository: vapor/fluent-mysql-driver
+          path: fluent-mysql-driver
       - name: Checkout SQLite driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-sqlite-driver', path: 'fluent-sqlite-driver' }
+        with: 
+          repository: vapor/fluent-sqlite-driver
+          path: fluent-sqlite-driver
       - name: Checkout Mongo driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-mongo-driver', path: 'fluent-mongo-driver' }
+        with:
+          repository: vapor/fluent-mongo-driver
+          path: fluent-mongo-driver
       - name: Link drivers to local fluent-kit
         run: |
           swift package --package-path fluent-postgres-driver edit fluent-kit --path fluent-kit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,17 @@
 # TODO: When we get the ability to reference workflows from other repos, this one should pull in the ones from
 # each driver instead of this incomplete reimplementation of each one.
 # See https://github.community/t/is-it-possible-to-use-the-same-workflow-in-different-repositories/17719/6
-
 name: Test Matrix
-
 on:
   pull_request:
   push:
     branches:
     - master
-
 defaults:
   run:
     shell: bash
-
 jobs:
-
-  Linux:
+  linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,11 +27,11 @@ jobs:
           - swiftlang/swift:nightly-master-bionic
           - swiftlang/swift:nightly-master-focal
         include:
-          - depscmd: apt-get -q update && apt-get -q install -y libsqlite3-dev
-          - image: swiftlang/swift:nightly-master-centos8
-            depscmd: dnf install -y sqlite-devel
-          - image: swiftlang/swift:nightly-master-amazonlinux2
-            depscmd: yum install -y sqlite-devel
+          - install_dependencies: apt-get -q update && apt-get -q install -y libsqlite3-dev
+          - install_dependencies: dnf install -y sqlite-devel
+            image: swiftlang/swift:nightly-master-centos8
+          - install_dependencies: yum install -y sqlite-devel
+            image: swiftlang/swift:nightly-master-amazonlinux2
     container: ${{ matrix.image }}
     services:
       postgres-a:
@@ -54,14 +49,14 @@ jobs:
       mysql-a:
         image: mysql:latest
         env: 
-          MYSQL_ALLOW_EMPTY_PASSWORD: 1
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_USER: vapor_username
           MYSQL_PASSWORD: vapor_password
           MYSQL_DATABASE: vapor_database
       mysql-b:
         image: mysql:latest
         env: 
-          MYSQL_ALLOW_EMPTY_PASSWORD: 1
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_USER: vapor_username
           MYSQL_PASSWORD: vapor_password
           MYSQL_DATABASE: vapor_database
@@ -76,25 +71,10 @@ jobs:
       MYSQL_HOSTNAME_B: mysql-b
       MONGO_HOSTNAME_A: mongo-a
       MONGO_HOSTNAME_B: mongo-b
-      PGUSER: 'vapor_username'
-      PGPASSWORD: 'vapor_password'
-      PGDATABASE: 'vapor_database'
+      LOG_LEVEL: info
     steps:
       - name: Install dependencies
-        run: ${{ matrix.depscmd }}
-      - name: Update AmazonLinux2's too-old SQLite and compensate for its Postgres
-        if: ${{ endsWith(matrix.image, 'amazonlinux2') }}
-        run: |
-          yum install -y file tcl-devel make
-          curl -L 'https://www.sqlite.org/src/tarball/sqlite.tar.gz?r=release' | tar xz && cd sqlite
-          export CFLAGS="-DSQLITE_DISABLE_DIRSYNC=1 -DSQLITE_SECURE_DELETE=1"
-          ./configure --prefix=/usr --libdir=/usr/lib64 --with-tcl=/usr/lib64 --enable-all && make all install
-          printf '#!/bin/bash\nexec psql "$@" </dev/null\n' >/usr/bin/pg_isready && chmod 0755 /usr/bin/pg_isready
-      # - name: Wait for all database servers to be ready
-      #   # Actually we just wait for Postgres, because it's the easiest to install on all the various runners
-      #   # and because it usually takes the longest to start.
-      #   run: until pg_isready -hpostgres-a && pg_isready -hpostgres-b; do sleep 1; done
-        timeout-minutes: 2
+        run: ${{ matrix.install_dependencies }}
       - name: Checkout FluentKit
         uses: actions/checkout@v2
         with: 
@@ -136,7 +116,6 @@ jobs:
         run: swift test --package-path fluent-sqlite-driver --enable-test-discovery --sanitize=thread
       - name: Run Mongo driver tests with Thread Sanitizer
         run: swift test --package-path fluent-mongo-driver --enable-test-discovery --sanitize=thread
-
   macOS:
     env:
       POSTGRES_HOSTNAME_A: '127.0.0.1'
@@ -207,7 +186,7 @@ jobs:
         with:
           repository: vapor/fluent-mongo-driver
           path: fluent-mongo-driver
-      - name: Link drivers to local fluent-kit
+      - name: Link drivers to local FluentKit
         run: |
           swift package --package-path fluent-postgres-driver edit fluent-kit --path fluent-kit
           swift package --package-path fluent-mysql-driver edit fluent-kit --path fluent-kit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,10 @@ jobs:
         with: { path: 'fluent-kit' }
       - name: Checkout Postgres driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-postgres-driver', path: 'fluent-postgres-driver', branch: 'tn-dict-datatype' }
+        with:
+          repository: vapor/fluent-postgres-driver
+          path: fluent-postgres-driver
+          ref: tn-dict-datatype
       - name: Checkout MySQL driver
         uses: actions/checkout@v2
         with: { repository: 'vapor/fluent-mysql-driver', path: 'fluent-mysql-driver' }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         with: { path: 'fluent-kit' }
       - name: Checkout Postgres driver
         uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-postgres-driver', path: 'fluent-postgres-driver' }
+        with: { repository: 'vapor/fluent-postgres-driver', path: 'fluent-postgres-driver', branch: 'tn-dict-datatype' }
       - name: Checkout MySQL driver
         uses: actions/checkout@v2
         with: { repository: 'vapor/fluent-mysql-driver', path: 'fluent-mysql-driver' }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
           # - swiftlang/swift:nightly-master-xenial
           # - swiftlang/swift:nightly-master-bionic
           # - swiftlang/swift:nightly-master-focal
-          # - image: swiftlang/swift:nightly-master-centos8
-          - image: swiftlang/swift:nightly-master-amazonlinux2
+          # - swiftlang/swift:nightly-master-centos8
+          - swiftlang/swift:nightly-master-amazonlinux2
     container: ${{ matrix.image }}
     services:
       postgres-a:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # TODO: When we get the ability to reference workflows from other repos, this one should pull in the ones from
 # each driver instead of this incomplete reimplementation of each one.
 # See https://github.community/t/is-it-possible-to-use-the-same-workflow-in-different-repositories/17719/6
-name: Test Matrix
+name: test
 on:
   pull_request:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,21 +17,21 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swift:5.2-xenial
-          - swift:5.2-bionic
-          - swiftlang/swift:nightly-5.2-xenial
-          - swiftlang/swift:nightly-5.2-bionic
-          - swiftlang/swift:nightly-5.3-xenial
-          - swiftlang/swift:nightly-5.3-bionic
-          - swiftlang/swift:nightly-master-xenial
-          - swiftlang/swift:nightly-master-bionic
-          - swiftlang/swift:nightly-master-focal
+          # - swift:5.2-xenial
+          # - swift:5.2-bionic
+          # - swiftlang/swift:nightly-5.2-xenial
+          # - swiftlang/swift:nightly-5.2-bionic
+          # - swiftlang/swift:nightly-5.3-xenial
+          # - swiftlang/swift:nightly-5.3-bionic
+          # - swiftlang/swift:nightly-master-xenial
+          # - swiftlang/swift:nightly-master-bionic
+          # - swiftlang/swift:nightly-master-focal
         include:
-          - install_dependencies: apt-get -q update && apt-get -q install -y libsqlite3-dev
-          - install_dependencies: dnf install -y sqlite-devel
-            image: swiftlang/swift:nightly-master-centos8
-          - install_dependencies: yum install -y sqlite-devel
-            image: swiftlang/swift:nightly-master-amazonlinux2
+          # - install_dependencies: apt-get -q update && apt-get -q install -y libsqlite3-dev
+          # - image: swiftlang/swift:nightly-master-centos8
+          #   install_dependencies: dnf install -y sqlite-devel
+          - image: swiftlang/swift:nightly-master-amazonlinux2
+            install_dependencies: yum install -y libsqlite3-dev
     container: ${{ matrix.image }}
     services:
       postgres-a:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swift:5.2-xenial
+          # - swift:5.2-xenial
           # - swift:5.2-bionic
           # - swiftlang/swift:nightly-5.2-xenial
           # - swiftlang/swift:nightly-5.2-bionic
@@ -26,12 +26,8 @@ jobs:
           # - swiftlang/swift:nightly-master-xenial
           # - swiftlang/swift:nightly-master-bionic
           # - swiftlang/swift:nightly-master-focal
-        include:
-          - install_dependencies: apt-get -q update && apt-get -q install -y libsqlite3-dev
           # - image: swiftlang/swift:nightly-master-centos8
-          #   install_dependencies: dnf install -y sqlite-devel
           - image: swiftlang/swift:nightly-master-amazonlinux2
-            install_dependencies: yum install -y libsqlite3-dev
     container: ${{ matrix.image }}
     services:
       postgres-a:
@@ -72,9 +68,16 @@ jobs:
       MONGO_HOSTNAME_A: mongo-a
       MONGO_HOSTNAME_B: mongo-b
       LOG_LEVEL: info
-    steps:
-      - name: Install dependencies
-        run: ${{ matrix.install_dependencies }}
+    steps:  
+      - name: Install AmazonLinux dependencies
+        if: ${{ endsWith(matrix.image, 'amazonlinux2') }}
+        run: yum install -y libsqlite3-dev
+      - name: Install CentOS dependencies
+        if: ${{ endsWith(matrix.image, 'centos8') }}
+        run: dnf install -y sqlite-devel
+      - name: Install Ubuntu dependencies
+        if: ${{ endsWith(matrix.image, 'xenial') || endsWith(matrix.image, 'bionic') || endsWith(matrix.image, 'focal') }}
+        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
       - name: Checkout FluentKit
         uses: actions/checkout@v2
         with: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          # - swift:5.2-xenial
+          - swift:5.2-xenial
           # - swift:5.2-bionic
           # - swiftlang/swift:nightly-5.2-xenial
           # - swiftlang/swift:nightly-5.2-bionic
@@ -27,7 +27,7 @@ jobs:
           # - swiftlang/swift:nightly-master-bionic
           # - swiftlang/swift:nightly-master-focal
         include:
-          # - install_dependencies: apt-get -q update && apt-get -q install -y libsqlite3-dev
+          - install_dependencies: apt-get -q update && apt-get -q install -y libsqlite3-dev
           # - image: swiftlang/swift:nightly-master-centos8
           #   install_dependencies: dnf install -y sqlite-devel
           - image: swiftlang/swift:nightly-master-amazonlinux2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
-defaults:
-  run:
-    shell: bash
+      - master
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -17,16 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          # - swift:5.2-xenial
-          # - swift:5.2-bionic
-          # - swiftlang/swift:nightly-5.2-xenial
-          # - swiftlang/swift:nightly-5.2-bionic
-          # - swiftlang/swift:nightly-5.3-xenial
-          # - swiftlang/swift:nightly-5.3-bionic
-          # - swiftlang/swift:nightly-master-xenial
-          # - swiftlang/swift:nightly-master-bionic
-          # - swiftlang/swift:nightly-master-focal
-          # - swiftlang/swift:nightly-master-centos8
+          - swift:5.2-xenial
+          - swift:5.2-bionic
+          - swiftlang/swift:nightly-5.2-xenial
+          - swiftlang/swift:nightly-5.2-bionic
+          - swiftlang/swift:nightly-5.3-xenial
+          - swiftlang/swift:nightly-5.3-bionic
+          - swiftlang/swift:nightly-master-xenial
+          - swiftlang/swift:nightly-master-bionic
+          - swiftlang/swift:nightly-master-focal
+          - swiftlang/swift:nightly-master-centos8
           - swiftlang/swift:nightly-master-amazonlinux2
     container: ${{ matrix.image }}
     services:
@@ -71,7 +68,7 @@ jobs:
     steps:  
       - name: Install AmazonLinux dependencies
         if: ${{ endsWith(matrix.image, 'amazonlinux2') }}
-        run: yum install -y libsqlite3-dev
+        run: yum install -y sqlite-devel
       - name: Install CentOS dependencies
         if: ${{ endsWith(matrix.image, 'centos8') }}
         run: dnf install -y sqlite-devel
@@ -116,6 +113,7 @@ jobs:
       - name: Run MySQL driver tests with Thread Sanitizer
         run: swift test --package-path fluent-mysql-driver --enable-test-discovery --sanitize=thread
       - name: Run SQLite driver tests with Thread Sanitizer
+        if: ${{ !endsWith(matrix.image, 'amazonlinux2') }}
         run: swift test --package-path fluent-sqlite-driver --enable-test-discovery --sanitize=thread
       - name: Run Mongo driver tests with Thread Sanitizer
         run: swift test --package-path fluent-mongo-driver --enable-test-discovery --sanitize=thread

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -78,6 +78,6 @@ public final class FluentBenchmarker {
     }
     
     private func log(_ message: String) {
-        print("[FluentBenchmark] \(message)")
+        self.database.logger.info("[FluentBenchmark] \(message)")
     }
 }

--- a/Sources/FluentBenchmark/Tests/EagerLoadTests.swift
+++ b/Sources/FluentBenchmark/Tests/EagerLoadTests.swift
@@ -22,8 +22,7 @@ extension FluentBenchmarker {
                     }
                 }
                 .all().wait()
-
-            try print(prettyJSON(galaxies))
+            self.database.logger.debug(prettyJSON(galaxies))
         }
     }
 
@@ -105,8 +104,7 @@ extension FluentBenchmarker {
             let planets = try Planet.query(on: self.database)
                 .with(\.$star)
                 .all().wait()
-
-            try print(prettyJSON(planets))
+            self.database.logger.debug(prettyJSON(planets))
         }
     }
 
@@ -117,7 +115,7 @@ extension FluentBenchmarker {
             let galaxies = try Galaxy.query(on: self.database)
                 .with(\.$stars)
                 .all().wait()
-            try print(prettyJSON(galaxies))
+            self.database.logger.debug(prettyJSON(galaxies))
         }
     }
 
@@ -224,10 +222,10 @@ private struct ABCMigration: Migration {
     }
 }
 
-func prettyJSON<T>(_ value: T) throws -> String
+func prettyJSON<T>(_ value: T) -> Logger.Message
     where T: Encodable
 {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .prettyPrinted
-    return try String(decoding: encoder.encode(value), as: UTF8.self)
+    return try! .init(stringLiteral: String(decoding: encoder.encode(value), as: UTF8.self))
 }

--- a/Sources/FluentBenchmark/Tests/GroupTests.swift
+++ b/Sources/FluentBenchmark/Tests/GroupTests.swift
@@ -17,7 +17,6 @@ extension FluentBenchmarker {
             guard let moon = moons.first else {
                 return
             }
-            print(moon)
 
             XCTAssertEqual(moon.name, "Moon")
             XCTAssertEqual(moon.planet.name, "Earth")
@@ -26,10 +25,9 @@ extension FluentBenchmarker {
             XCTAssertEqual(moon.planet.star.galaxy.name, "Milky Way")
 
             // Test JSON
-            let json = try prettyJSON(moon)
-            print(json)
-            let decoded = try JSONDecoder().decode(FlatMoon.self, from: Data(json.utf8))
-            print(decoded)
+            let json = prettyJSON(moon)
+            self.database.logger.debug(json)
+            let decoded = try JSONDecoder().decode(FlatMoon.self, from: Data(json.description.utf8))
             XCTAssertEqual(decoded.name, "Moon")
             XCTAssertEqual(decoded.planet.name, "Earth")
             XCTAssertEqual(decoded.planet.type, .smallRocky)
@@ -59,7 +57,6 @@ extension FluentBenchmarker {
 //            guard let moon = moons.first else {
 //                return
 //            }
-//            print(moon)
 //
 //            XCTAssertEqual(moon.name, "Moon")
 //            XCTAssertEqual(moon.planet.name, "Earth")
@@ -69,9 +66,7 @@ extension FluentBenchmarker {
 //
 //            // Test JSON
 //            let json = try prettyJSON(moon)
-//            print(json)
 //            let decoded = try JSONDecoder().decode(NestedMoon.self, from: Data(json.utf8))
-//            print(decoded)
 //            XCTAssertEqual(decoded.name, "Moon")
 //            XCTAssertEqual(decoded.planet.name, "Earth")
 //            XCTAssertEqual(decoded.planet.type, .smallRocky)

--- a/Sources/FluentBenchmark/Tests/JoinTests.swift
+++ b/Sources/FluentBenchmark/Tests/JoinTests.swift
@@ -101,10 +101,9 @@ extension FluentBenchmarker {
 
                 for match in matches {
                     let home = try match.joined(HomeTeam.self)
+                    self.database.logger.debug("home: \(home)")
                     let away = try match.joined(AwayTeam.self)
-                    print(match.name)
-                    print("home: \(home.name)")
-                    print("away: \(away.name)")
+                    self.database.logger.debug("away: \(away)")
                 }
             }
         }

--- a/Sources/FluentBenchmark/Tests/ParentTests.swift
+++ b/Sources/FluentBenchmark/Tests/ParentTests.swift
@@ -13,8 +13,7 @@ extension FluentBenchmarker {
                 .all().wait()
 
             let encoded = try JSONEncoder().encode(galaxies)
-            print(String(decoding: encoded, as: UTF8.self))
-
+            self.database.logger.debug("\(String(decoding: encoded, as: UTF8.self)))")
             let decoded = try JSONDecoder().decode([GalaxyJSON].self, from: encoded)
             XCTAssertEqual(galaxies.map { $0.id }, decoded.map { $0.id })
             XCTAssertEqual(galaxies.map { $0.name }, decoded.map { $0.name })

--- a/Sources/FluentBenchmark/Tests/PerformanceTests+Siblings.swift
+++ b/Sources/FluentBenchmark/Tests/PerformanceTests+Siblings.swift
@@ -21,7 +21,7 @@ extension FluentBenchmarker {
             let time = Date().timeIntervalSince(start)
             // Run took 24.121525049209595 seconds.
             // Run took 0.33231091499328613 seconds.
-            print("Run took \(time) seconds.")
+            self.database.logger.info("Run took \(time) seconds.")
             XCTAssertEqual(expeditions.count, 300)
         }
     }

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -43,8 +43,3 @@ extension QueryableProperty {
         .bind(value)
     }
 }
-
-//#warning("TODO: better name? this is a 'top-level' / settable property")
-//public protocol AnyFieldProperty: AnyProperty {
-//    var key: FieldKey { get }
-//}

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -9,8 +9,6 @@ public struct DatabaseSchema {
     }
     
     public indirect enum DataType {
-        case json
-        
         public static var int: DataType {
             return .int64
         }
@@ -51,7 +49,18 @@ public struct DatabaseSchema {
         case data
         case uuid
 
-        case array(of: DataType)
+        public static var json: DataType {
+            .dictionary
+        }
+        public static var dictionary: DataType {
+            .dictionary(of: nil)
+        }
+        case dictionary(of: DataType?)
+
+        public static var array: DataType {
+            .array(of: nil)
+        }
+        case array(of: DataType?)
         case custom(Any)
     }
 

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -195,7 +195,7 @@ public struct SQLSchemaConverter {
             return SQLRaw("BIGINT")
         case .string:
             return SQLDataType.text
-        case .json:
+        case .dictionary, .array:
             return SQLRaw("JSON")
         case .uuid:
             return SQLRaw("UUID")
@@ -221,8 +221,6 @@ public struct SQLSchemaConverter {
             return SQLRaw("FLOAT")
         case .double:
             return SQLRaw("DOUBLE")
-        case .array(of: let type):
-            return SQLArrayDataType(type: self.dataType(type))
         case .custom(let any):
             return custom(any)
         }
@@ -257,14 +255,6 @@ public struct SQLSchemaConverter {
         case .prefix(let prefix, let key):
             return self.key(prefix) + self.key(key)
         }
-    }
-}
-
-struct SQLArrayDataType: SQLExpression {
-    let type: SQLExpression
-    func serialize(to serializer: inout SQLSerializer) {
-        self.type.serialize(to: &serializer)
-        serializer.write("[]")
     }
 }
 


### PR DESCRIPTION
### Replaces the `.json` data type with `.dictionary(of:)` (#314) 

This change more closely resembles existing `.array` type. The `.json` data type will continue to exist and forward to `.dictionary`. The dictionary data type now supports a value type for homogenous dictionaries. For example, `[String: Int]` would be `.dictionary(of: .int)`. 