### PR TITLE
Fix crash: eager loading properties of an optional parent.

### DIFF
--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -171,7 +171,7 @@ private struct ThroughOptionalParentEagerLoader<From, Through, Loader>: EagerLoa
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let throughs = models.compactMap {
-            $0[keyPath: self.relationKey].value!
+            $0[keyPath: self.relationKey].wrappedValue
         }
         return self.loader.run(models: throughs, on: database)
     }


### PR DESCRIPTION
Fixing crash that caused by eager loading properties of an optional parent.