### PR TITLE
Fully qualified Migration names

### DIFF
--- a/Sources/FluentBenchmark/Tests/MigratorTests.swift
+++ b/Sources/FluentBenchmark/Tests/MigratorTests.swift
@@ -93,7 +93,7 @@ extension FluentBenchmarker {
             let logs1 = try MigrationLog.query(on: database1).all().wait()
             XCTAssertEqual(logs1.count, 1)
             XCTAssertEqual(logs1.first?.batch, 1)
-            XCTAssertEqual(logs1.first?.name, "\(GalaxyMigration.self)")
+            XCTAssertEqual(logs1.first?.name, String(reflecting: GalaxyMigration.self))
 
             do {
                 let count = try MigrationLog.query(on: database2).count().wait()
@@ -117,7 +117,7 @@ extension FluentBenchmarker {
             let logs2 = try MigrationLog.query(on: database2).all().wait()
             XCTAssertEqual(logs2.count, 1)
             XCTAssertEqual(logs2.first?.batch, 1)
-            XCTAssertEqual(logs2.first?.name, "\(GalaxyMigration.self)")
+            XCTAssertEqual(logs2.first?.name, String(reflecting: GalaxyMigration.self))
 
             try XCTAssertEqual(MigrationLog.query(on: database1).count().wait(), 1)
 

--- a/Sources/FluentKit/Migration/Migration.swift
+++ b/Sources/FluentKit/Migration/Migration.swift
@@ -6,6 +6,6 @@ public protocol Migration {
 
 extension Migration {
     public var name: String {
-        return "\(Self.self)"
+        return String(reflecting: Self.self)
     }
 }

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -58,17 +58,34 @@ struct V4NameMigration: Migration {
     let nameMapping: [String: String]
 
     init(allMigrations: [Migration]) {
+        // map from old style default names
+        // to new style default names
         var migrationNameMap = [String: String]()
+
+        // a set of names that are manually
+        // chosen by migration author.
+        var nameOverrides = Set<String>()
 
         for migration in allMigrations {
             let releaseCandidateDefaultName = "\(type(of: migration))"
             let v4DefaultName = String(reflecting:type(of: migration))
 
             // if the migration does not override the default name
+            // NOTE we use the _current_ style of default, not the
+            // release candidate style of default name.
             if migration.name == v4DefaultName {
                 migrationNameMap[releaseCandidateDefaultName] = v4DefaultName
+            } else {
+                nameOverrides.insert(migration.name)
             }
         }
+        // we must not rename anything that has an overridden
+        // name that happens to be the same as the old-style
+        // of default name.
+        for overriddenName in nameOverrides {
+            migrationNameMap.removeValue(forKey: overriddenName)
+        }
+
         nameMapping = migrationNameMap
     }
 

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -70,9 +70,9 @@ struct V4NameMigration: Migration {
             let releaseCandidateDefaultName = "\(type(of: migration))"
             let v4DefaultName = String(reflecting:type(of: migration))
 
-            // if the migration does not override the default name
-            // NOTE we use the _current_ style of default, not the
-            // release candidate style of default name.
+            // if the migration does not override the default name.
+            // NOTE we compare to the _current_ style of default, not
+            // the release candidate style of default name.
             if migration.name == v4DefaultName {
                 migrationNameMap[releaseCandidateDefaultName] = v4DefaultName
             } else {

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -51,10 +51,10 @@ private struct MigrationLogMigration: Migration {
 }
 
 // This migration just exists to smooth the gap between
-// how migrations were named between the first Vapor 4
-// alpha and the Vapor 4.0.0 release.
-@available(*, deprecated, message: "Remove in Vapor 5")
-struct V4NameMigration: Migration {
+// how migrations were named between the first FluentKit 1
+// alpha and the FluentKit 1.0.0 release.
+@available(*, deprecated, message: "Remove in FluentKit 2")
+struct V1NameMigration: Migration {
     let nameMapping: [String: String]
 
     init(allMigrations: [Migration]) {

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -49,3 +49,41 @@ private struct MigrationLogMigration: Migration {
         database.schema("_fluent_migrations").delete()
     }
 }
+
+// This migration just exists to smooth the gap between
+// how migrations were named between the first Vapor 4
+// alpha and the Vapor 4.0.0 release.
+@available(*, deprecated, message: "Remove in Vapor 5")
+struct V4NameMigration: Migration {
+    let nameMapping: [String: String]
+
+    init(allMigrations: [Migration]) {
+        var migrationNameMap = [String: String]()
+
+        for migration in allMigrations {
+            let releaseCandidateDefaultName = "\(type(of: migration))"
+            let v4DefaultName = String(reflecting:type(of: migration))
+
+            // if the migration does not override the default name
+            if migration.name == v4DefaultName {
+                migrationNameMap[releaseCandidateDefaultName] = v4DefaultName
+            }
+        }
+        nameMapping = migrationNameMap
+    }
+
+    public func prepare(on database: Database) -> EventLoopFuture<Void> {
+        let queries = nameMapping.map { oldName, newName in
+            MigrationLog.query(on: database)
+                .filter(\.$name == oldName)
+                .set(\.$name, to: newName)
+                .update()
+        }
+        return database.eventLoop.flatten(queries)
+    }
+
+    public func revert(on database: Database) -> EventLoopFuture<Void> {
+        // must we revert this migration?
+        return database.eventLoop.makeSucceededFuture(())
+    }
+}

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -134,7 +134,9 @@ private final class DatabaseMigrator {
     // MARK: Setup
 
     func setupIfNeeded() -> EventLoopFuture<Void> {
-        return MigrationLog.migration.prepare(on: self.database)
+        return MigrationLog.migration.prepare(on: self.database).flatMap {
+            V4NameMigration(allMigrations: self.migrations).prepare(on: self.database)
+        }
     }
 
     // MARK: Prepare

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -135,7 +135,7 @@ private final class DatabaseMigrator {
 
     func setupIfNeeded() -> EventLoopFuture<Void> {
         return MigrationLog.migration.prepare(on: self.database).flatMap {
-            V4NameMigration(allMigrations: self.migrations).prepare(on: self.database)
+            V1NameMigration(allMigrations: self.migrations).prepare(on: self.database)
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/vapor/fluent-kit/issues/318

The migration logs now use fully qualified Swift type names. This means they are distinct from each other even if they only live nested under different scopes in the program.

This introduces the ability to write migrations under model types, as an example.
```swift
final class Widget: Model { ... }

extension Widget {
  enum Migrations {
    struct Create: Migration {
      ...
    }
  }
}
```
Migration Log:
```
                  id                  |             name              | batch |          created_at           |          updated_at           
--------------------------------------+-------------------------------+-------+-------------------------------+-------------------------------
 4ee38b8e-de45-42ff-a949-42f5407f063a | App.Widget.Migrations.Create  |     1 | 2020-06-11 01:32:13.959996+00 | 2020-06-11 01:32:45.131512+00
```

It also adds a migration that quietly migrates log entries created during the Vapor 4 alpha/beta/rc releases into entries with fully qualified names.

Open questions:
- To deprecated, or not to deprecate? Makes it easy to spot and remove during preparation for next major release, but it's arguably pretty annoying to have a perpetual warning until then.
- To roll back or not to roll back? Doesn't make much sense to me to offer a rollback on this, but maybe?

------
### A bit of manual testing
Prior to new naming:
```shell
local:~/staging/tmp/migration_test (master)$ .build/debug/Run migrate
Migrate Command: Prepare
The following migration(s) will be prepared:
+ Create on default
+ Change on default
+ Destiny on default
Would you like to continue?
y/n> y
Migration successful
```
```
                  id                  |  name   | batch |          created_at           |          updated_at           
--------------------------------------+---------+-------+-------------------------------+-------------------------------
 4ee38b8e-de45-42ff-a949-42f5407f063a | Create  |     1 | 2020-06-11 01:32:13.959996+00 | 2020-06-11 01:32:13.959996+00
 5fbd8fdc-a893-40fa-ab19-ec560826521f | Change  |     1 | 2020-06-11 01:32:13.963647+00 | 2020-06-11 01:32:13.963647+00
 423ae249-a9c8-4f56-a877-ecaa2b8c300b | Destiny |     1 | 2020-06-11 01:32:13.966667+00 | 2020-06-11 01:32:13.966667+00
```

Introduce new naming and add 1 migration concurrently:
```shell
local:~/staging/tmp/migration_test (master)$ .build/debug/Run migrate
Migrate Command: Prepare
[ NOTICE ] relation "_fluent_migrations" already exists, skipping (transformCreateStmt)
The following migration(s) will be prepared:
+ App.A.B.Todo.LateAddition on default
Would you like to continue?
y/n> y
Migration successful
```
```
                  id                  |           name            | batch |          created_at           |          updated_at           
--------------------------------------+---------------------------+-------+-------------------------------+-------------------------------
 4ee38b8e-de45-42ff-a949-42f5407f063a | App.A.B.Todo.Create       |     1 | 2020-06-11 01:32:13.959996+00 | 2020-06-11 01:32:45.131512+00
 5fbd8fdc-a893-40fa-ab19-ec560826521f | App.A.B.Todo.Change       |     1 | 2020-06-11 01:32:13.963647+00 | 2020-06-11 01:32:45.13294+00
 423ae249-a9c8-4f56-a877-ecaa2b8c300b | App.A.B.Todo.Destiny      |     1 | 2020-06-11 01:32:13.966667+00 | 2020-06-11 01:32:45.132604+00
 c2585635-3269-4447-bc91-d3a0f001fa34 | App.A.B.Todo.LateAddition |     2 | 2020-06-11 01:32:51.024992+00 | 2020-06-11 01:32:51.024992+00
```

Custom name for newer migration:
```shell
local:~/staging/tmp/migration_test (master)$ .build/debug/Run migrate
Migrate Command: Prepare
[ NOTICE ] relation "_fluent_migrations" already exists, skipping (transformCreateStmt)
The following migration(s) will be prepared:
+ NameyNameName on default
Would you like to continue?
y/n> y
Migration successful
```
```
                  id                  |           name            | batch |          created_at           |          updated_at           
--------------------------------------+---------------------------+-------+-------------------------------+-------------------------------
 4ee38b8e-de45-42ff-a949-42f5407f063a | App.A.B.Todo.Create       |     1 | 2020-06-11 01:32:13.959996+00 | 2020-06-11 01:32:45.131512+00
 5fbd8fdc-a893-40fa-ab19-ec560826521f | App.A.B.Todo.Change       |     1 | 2020-06-11 01:32:13.963647+00 | 2020-06-11 01:32:45.13294+00
 423ae249-a9c8-4f56-a877-ecaa2b8c300b | App.A.B.Todo.Destiny      |     1 | 2020-06-11 01:32:13.966667+00 | 2020-06-11 01:32:45.132604+00
 c2585635-3269-4447-bc91-d3a0f001fa34 | App.A.B.Todo.LateAddition |     2 | 2020-06-11 01:32:51.024992+00 | 2020-06-11 01:32:51.024992+00
 811c3933-bc94-4ef3-94e1-614232619b02 | NameyNameName             |     3 | 2020-06-11 01:38:33.812253+00 | 2020-06-11 01:38:33.812253+00
```