### PR TITLE
Add input and output methods to Fields protocol

### DIFF
--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -1,6 +1,8 @@
 public protocol Fields: class, Codable {
     var properties: [AnyProperty] { get }
     init()
+    func input(to input: DatabaseInput)
+    func output(from output: DatabaseOutput) throws
 }
 
 // MARK: Has Changes


### PR DESCRIPTION
Adds `input(to:)` and `output(from:)` methods to the `Fields` protocol (extended by `Model`) which allows them to be overridden (#320).

The `input(to:)` method is called when a model is being saved to the database. The `output(from:)` method is called when a model is being initialized from database output.

All model properties have `input(to:)` and `output(from:)` methods as a part of the `AnyDatabaseProperty` protocol. 

```swift
final class Planet: Model {
    @ID(key: .id)
    var id: UUID?

    @Field(key: "name") 
    var name: String

    // Override output method.
    func output(from output: DatabaseOutput) throws {
        try self.$id.output(from: output)
        try self.$name.output(from: output)
        self.name = self.name.capitalized()
    }
}
```
