### PR TITLE
Disallows private-scoped migrations with default names.

### DIFF
--- a/Sources/FluentBenchmark/Tests/MigratorTests.swift
+++ b/Sources/FluentBenchmark/Tests/MigratorTests.swift
@@ -164,7 +164,7 @@ extension FluentBenchmarker {
     }
 }
 
-private struct ErrorMigration: Migration {
+internal struct ErrorMigration: Migration {
     init() { }
 
     struct Error: Swift.Error { }

--- a/Sources/FluentKit/Migration/Migration.swift
+++ b/Sources/FluentKit/Migration/Migration.swift
@@ -6,6 +6,10 @@ public protocol Migration {
 
 extension Migration {
     public var name: String {
+        return defaultName
+    }
+
+    internal var defaultName: String {
         return String(reflecting: Self.self)
     }
 }

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -139,6 +139,11 @@ private final class DatabaseMigrator {
             .flatMap(self.fixPrereleaseMigrationNames)
     }
 
+    /// An unstable name is a name that is not the same every time migrations
+    /// are run.
+    ///
+    /// For example, the default name for `Migrations` in private contexts
+    /// will include an identifier that can change from one execution to the next.
     private func preventUnstableNames() -> EventLoopFuture<Void> {
         for migration in self.migrations {
             let migrationName = migration.name


### PR DESCRIPTION
### Migrations with unstable names can no longer be applied (fixes #327). 

Migrations with `private` scope and a default name will result in a fatal error now. If you run into this fatal error, there are two solutions:
1. Make the migration `public` or `internal`.
2. Give the migration an explicit name:
```swift
struct example: Migration {
    let name: String = "SomeUniqueNameHere"
    ...
}
``` 