### PR TITLE
Add @Timestamp(key: "...", on: .none) functionality

### DIFF
--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -9,6 +9,7 @@ public enum TimestampTrigger {
     case create
     case update
     case delete
+    case none
 }
 
 // MARK: Type


### PR DESCRIPTION
Adds new case `.none` to `TimestampTrigger` (#336). 

Using `TimestampTrigger.none` on a `@Timestamp` property makes it act like a normal `@OptionalField`, so that Fluent never updates the timestamp automatically. Such properties retain the ability to take advantage of `TimestampFormat`s for explicitly defining the format of the timestamp value in the database.

_Note: Technically, since this adds an `enum` case, it would be a `semver-major` change, breaking source compatibility for anyone switching over the `TimestampTrigger` type. However, the expectation is doing this would be very rare._