### PR TITLE
Fix nil @Parent / @OptionalParent eager load

### DIFF
--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -166,9 +166,8 @@ private struct ThroughOptionalParentEagerLoader<From, Through, Loader>: EagerLoa
     let loader: Loader
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
-        let throughs: [Through] = models.compactMap {
-            print($0)
-            return $0[keyPath: self.relationKey].value!
+        let throughs = models.compactMap {
+            $0[keyPath: self.relationKey].value!
         }
         return self.loader.run(models: throughs, on: database)
     }

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -144,11 +144,7 @@ private struct OptionalParentEagerLoader<From, To>: EagerLoader
         let ids = models.compactMap {
             $0[keyPath: self.relationKey].id
         }
-
-        guard !ids.isEmpty else {
-            return database.eventLoop.makeSucceededFuture(())
-        }
-
+        
         return To.query(on: database)
             .filter(\._$id ~~ Set(ids))
             .all()
@@ -170,8 +166,9 @@ private struct ThroughOptionalParentEagerLoader<From, Through, Loader>: EagerLoa
     let loader: Loader
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
-        let throughs = models.compactMap {
-            $0[keyPath: self.relationKey].value!
+        let throughs: [Through] = models.compactMap {
+            print($0)
+            return $0[keyPath: self.relationKey].value!
         }
         return self.loader.run(models: throughs, on: database)
     }

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -140,10 +140,6 @@ private struct ParentEagerLoader<From, To>: EagerLoader
             $0[keyPath: self.relationKey].id
         }
 
-        guard !ids.isEmpty else {
-            return database.eventLoop.makeSucceededFuture(())
-        }
-
         return To.query(on: database)
             .filter(\._$id ~~ Set(ids))
             .all()


### PR DESCRIPTION
Fixes an issue causing nested eager loading through an `@Parent` or `@OptionalParent` relation with _all_ `nil` values to crash (#337, fixes #308).