### PR TITLE
Add join methods for @Parent, @Children, and @Siblings

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
@@ -12,14 +12,40 @@ extension QueryBuilder {
         self.join(Foreign.self, filter.foreign, to: Local.self, filter.local , method: method)
     }
 
-    func join<From, To>(
+    /// This will join a foreign table based on a `ParentProperty`relation
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     try Planet.query(on: db)
+    ///         .join(parent: \Planet.$star)
+    ///         .filter(Star.self, \Star.$name == "Sun")
+    ///
+    /// - Parameters:
+    ///   - parent: The `ParentProperty` to join
+    ///   - method: The method to use. The default is an inner join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<From, To>(
         parent: KeyPath<From, ParentProperty<From, To>>,
         method: DatabaseQuery.Join.Method = .inner
     ) -> Self {
         join(To.self, on: parent.appending(path: \.$id) == \To._$id, method: method)
     }
 
-    func join<From, To>(
+    /// This will join a foreign table based on a `ChildrenProperty`relation
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     try Star.query(on: db)
+    ///         .join(children: \Planet.$planets)
+    ///         .filter(Planet.self, \Planet.$name == "Earth")
+    ///
+    /// - Parameters:
+    ///   - children: The `ChildrenProperty` to join
+    ///   - method: The method to use. The default is an inner join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<From, To>(
         children: KeyPath<From, ChildrenProperty<From, To>>,
         method: DatabaseQuery.Join.Method = .inner
     ) -> Self {
@@ -29,7 +55,20 @@ extension QueryBuilder {
         }
     }
 
-    func join<From, To, Through>(
+    /// This will join the foreign table based on a `SiblingsProperty`relation
+    /// This will result in joining two tables. The Pivot table and the wanted model table
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     try Star.query(on: db)
+    ///         .join(siblings: \Planet.$tags)
+    ///         .filter(Tag.self, \Tag.$name == "Something")
+    ///
+    /// - Parameters:
+    ///   - siblings: The `SiblingsProperty` to join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<From, To, Through>(
         siblings: KeyPath<From, SiblingsProperty<From, To, Through>>
     ) -> Self
         where From: FluentKit.Model, To: FluentKit.Model, Through: FluentKit.Model

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
@@ -12,12 +12,34 @@ extension QueryBuilder {
         self.join(Foreign.self, filter.foreign, to: Local.self, filter.local , method: method)
     }
 
-    /// This will join a foreign table based on a `ParentProperty`relation
+    /// This will join a foreign table based on a `@Parent` relation
     ///
     /// This will not decode the joined data, but can be used in order to filter.
     ///
-    ///     try Planet.query(on: db)
-    ///         .join(parent: \Planet.$star)
+    ///     Planet.query(on: db)
+    ///         .join(from: Planet.self, parent: \.$star)
+    ///         .filter(Star.self, \Star.$name == "Sun")
+    ///
+    /// - Parameters:
+    ///   - model: The `Model` to join from
+    ///   - parent: The `ParentProperty` to join
+    ///   - method: The method to use. The default is an inner join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<From, To>(
+        from model: From.Type,
+        parent: KeyPath<From, ParentProperty<From, To>>,
+        method: DatabaseQuery.Join.Method = .inner
+    ) -> Self {
+        join(To.self, on: parent.appending(path: \.$id) == \To._$id, method: method)
+    }
+
+    /// This will join a foreign table based on a `@Parent` relation
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     Planet.query(on: db)
+    ///         .join(parent: \.$star)
     ///         .filter(Star.self, \Star.$name == "Sun")
     ///
     /// - Parameters:
@@ -25,27 +47,29 @@ extension QueryBuilder {
     ///   - method: The method to use. The default is an inner join
     /// - Returns: A new `QueryBuilder`
     @discardableResult
-    public func join<From, To>(
-        parent: KeyPath<From, ParentProperty<From, To>>,
+    public func join<To>(
+        parent: KeyPath<Model, ParentProperty<Model, To>>,
         method: DatabaseQuery.Join.Method = .inner
     ) -> Self {
-        join(To.self, on: parent.appending(path: \.$id) == \To._$id, method: method)
+        join(from: Model.self, parent: parent, method: method)
     }
 
-    /// This will join a foreign table based on a `ChildrenProperty`relation
+    /// This will join a foreign table based on a `@Children` relation
     ///
     /// This will not decode the joined data, but can be used in order to filter.
     ///
-    ///     try Star.query(on: db)
-    ///         .join(children: \Planet.$planets)
+    ///     Star.query(on: db)
+    ///         .join(from: Star.self, children: \.$planets)
     ///         .filter(Planet.self, \Planet.$name == "Earth")
     ///
     /// - Parameters:
+    ///   - model: The `Model` to join from
     ///   - children: The `ChildrenProperty` to join
     ///   - method: The method to use. The default is an inner join
     /// - Returns: A new `QueryBuilder`
     @discardableResult
     public func join<From, To>(
+        from model: From.Type,
         children: KeyPath<From, ChildrenProperty<From, To>>,
         method: DatabaseQuery.Join.Method = .inner
     ) -> Self {
@@ -55,20 +79,42 @@ extension QueryBuilder {
         }
     }
 
-    /// This will join the foreign table based on a `SiblingsProperty`relation
+    /// This will join a foreign table based on a `@Children` relation
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     Star.query(on: db)
+    ///         .join(children: \.$planets)
+    ///         .filter(Planet.self, \Planet.$name == "Earth")
+    ///
+    /// - Parameters:
+    ///   - children: The `ChildrenProperty` to join
+    ///   - method: The method to use. The default is an inner join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<To>(
+        children: KeyPath<Model, ChildrenProperty<Model, To>>,
+        method: DatabaseQuery.Join.Method = .inner
+    ) -> Self {
+        join(from: Model.self, children: children, method: method)
+    }
+
+    /// This will join the foreign table based on a `@Siblings`relation
     /// This will result in joining two tables. The Pivot table and the wanted model table
     ///
     /// This will not decode the joined data, but can be used in order to filter.
     ///
-    ///     try Star.query(on: db)
-    ///         .join(siblings: \Planet.$tags)
+    ///     Star.query(on: db)
+    ///         .join(from: Star.self, siblings: \.$tags)
     ///         .filter(Tag.self, \Tag.$name == "Something")
     ///
     /// - Parameters:
+    ///   - model: The `Model` to join form
     ///   - siblings: The `SiblingsProperty` to join
     /// - Returns: A new `QueryBuilder`
     @discardableResult
     public func join<From, To, Through>(
+        from model: From.Type,
         siblings: KeyPath<From, SiblingsProperty<From, To, Through>>
     ) -> Self
         where From: FluentKit.Model, To: FluentKit.Model, Through: FluentKit.Model
@@ -76,6 +122,27 @@ extension QueryBuilder {
         let siblings = From()[keyPath: siblings]
         return join(Through.self, on: siblings.from.appending(path: \.$id) == \From._$id)
             .join(To.self, on: siblings.to.appending(path: \.$id) == \To._$id)
+    }
+
+    /// This will join the foreign table based on a `@Siblings`relation
+    /// This will result in joining two tables. The Pivot table and the wanted model table
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     Star.query(on: db)
+    ///         .join(siblings: \.$tags)
+    ///         .filter(Tag.self, \Tag.$name == "Something")
+    ///
+    /// - Parameters:
+    ///   - siblings: The `SiblingsProperty` to join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<To, Through>(
+        siblings: KeyPath<Model, SiblingsProperty<Model, To, Through>>
+    ) -> Self
+        where To: FluentKit.Model, Through: FluentKit.Model
+    {
+        join(from: Model.self, siblings: siblings)
     }
 
     @discardableResult

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -43,7 +43,7 @@ final class FluentKitTests: XCTestCase {
         db.reset()
         
         _ = try Planet.query(on: db)
-            .join(parent: \Planet.$star)
+            .join(parent: \.$star)
             .sort(Star.self, \.$id, .ascending)
             .all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)


### PR DESCRIPTION
Adds new methods to `QueryBuilder` for easily joining `@Parent`, `@Children`, and `@Siblings` relations. (#338)

```swift
Planet.query(on: db)
   // Joins the Star table
    .join(parent: \.$star)
   // Joins the Galaxy table based based on the joined Star table
    .join(from: Star.self, parent: \.$galaxy)
    .filter(Galaxy.self, \.$id == galaxyID)
    .unique()
   // Returns all Planet's in the galaxy with id `galaxyID`
    .all()
```