### PR TITLE
Enable interpolation of FieldKey in SQLQueryString.

### DIFF
--- a/Sources/FluentSQL/SQLQueryString+FieldKey.swift
+++ b/Sources/FluentSQL/SQLQueryString+FieldKey.swift
@@ -1,0 +1,8 @@
+import FluentKit
+import SQLKit
+
+public extension SQLQueryString.StringInterpolation {
+    mutating func appendInterpolation(_ fieldKey: FieldKey) {
+        appendLiteral(fieldKey.description)
+    }
+}

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -393,7 +393,16 @@ final class FluentKitTests: XCTestCase {
             XCTAssertEqual(result, expected)
             db.reset()
         }
+
+    func testSQLQueryStringFieldKeyInterpolation() {
+        let fieldKey = FieldKey("test")
+        let db = DummyDatabaseForTestSQLSerializer()
+        let rawQuery = db.raw("\(fieldKey)")
+        var serializer = SQLSerializer(database: db)
+        rawQuery.query.serialize(to: &serializer)
+        XCTAssertEqual(serializer.sql, "test")
     }
+}
 
 final class User: Model {
     static let schema = "users"


### PR DESCRIPTION
Enable interpolation of `FieldKey` instances in `SQLQueryString`. This allows for building more succinct raw query strings, as the explicit call to `description` is no longer necessary. For example:

```swift
final class MyModel: Model {
    static var schema = "test"

    struct FieldKeys {
        static var id: FieldKey { "id" }
    }
}
```

```swift
sqlDb.raw("SELECT \(MyModel.FieldKeys.id) FROM \(MyModel.schema)")
```