### PR TITLE
Add missing join filter overload

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Filter.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Filter.swift
@@ -13,6 +13,21 @@ extension QueryBuilder {
     }
 
     @discardableResult
+    public func filter<Joined, Field>(
+        _ joined: Joined.Type,
+        _ field: KeyPath<Joined, Field>,
+        _ method: DatabaseQuery.Filter.Method,
+        _ value: Field.Value
+    ) -> Self
+        where Joined: Schema, Field: QueryableProperty, Field.Model == Joined
+    {
+        self.filter(.path(
+            Joined.path(for: field),
+            schema: Joined.schemaOrAlias
+        ), method, .bind(value))
+    }
+
+    @discardableResult
     public func filter<Left, Right>(
         _ lhsField: KeyPath<Model, Left>,
         _ method: DatabaseQuery.Filter.Method,

--- a/Sources/XCTFluent/TestDatabase.swift
+++ b/Sources/XCTFluent/TestDatabase.swift
@@ -51,6 +51,12 @@ public final class ArrayTestDatabase: TestDatabase {
         self.results.append(result)
     }
 
+    public func append<M>(_ result: [M]) 
+        where M: Model
+    {
+        self.results.append(result.map { TestOutput($0) })
+    }
+
     public func execute(query: DatabaseQuery, onOutput: (DatabaseOutput) -> ()) throws {
         guard !self.results.isEmpty else {
             throw TestDatabaseError.ranOutOfResults

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -86,4 +86,44 @@ final class QueryBuilderTests: XCTestCase {
         XCTAssertEqual(db.history?.queries.count, 1)
         XCTAssertEqual(db.history?.queries.first?.schema, Planet.schema)
     }
+
+    // https://github.com/vapor/fluent-kit/issues/310
+    func testJoinOverloads() throws {
+        var query: DatabaseQuery?
+        let test = CallbackTestDatabase {
+            query = $0
+            return []
+        }
+        let planets = try Planet.query(on: test.db)
+            .join(Star.self, on: \Star.$id == \Planet.$star.$id)
+            .filter(\.$name, .custom("ilike"), "earth")
+            .filter(Star.self, \.$name, .custom("ilike"), "sun")
+            .all().wait()
+        XCTAssertEqual(planets.count, 0)
+        XCTAssertNotNil(query?.filters[1])
+        switch query?.filters[1] {
+        case .value(let field, let method, let value):
+            switch field {
+            case .path(let path, let schema):
+                XCTAssertEqual(path, ["name"])
+                XCTAssertEqual(schema, "stars")
+            default: 
+                XCTFail("\(field)")
+            }
+            switch method {
+            case .custom(let any as String):
+                XCTAssertEqual(any, "ilike")
+            default: 
+                XCTFail("\(method)")
+            }
+            switch value {
+            case .bind(let any as String):
+                XCTAssertEqual(any, "sun")
+            default: 
+                XCTFail("\(value)")
+            }
+        default:
+            XCTFail("no query")
+        }
+    }
 }


### PR DESCRIPTION
Adds a missing overload for filtering joined models (#342, fixes #310). 

Adds method for appending models to `ArrayTestDatabase` (#342). 