### PR TITLE
Conform FieldKey to SQLExpression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ Package.resolved
 DerivedData/
 .swiftpm
 Tests/LinuxMain.swift
+.vscode
 

--- a/Sources/FluentSQL/DatabaseQuery+SQL.swift
+++ b/Sources/FluentSQL/DatabaseQuery+SQL.swift
@@ -102,7 +102,7 @@ extension FieldKey: SQLExpression {
     // `.description` is not used here since that isn't
     // _necessarily_ a SQL compatible value.
     //
-    // SQLSerializer is passed in case a different dialect may
+    // SQLDialect is passed in case a specific dialect may
     // need to have special values for id / aggregate.
     private func string(for dialect: SQLDialect) -> String {
         switch self {

--- a/Sources/FluentSQL/DatabaseQuery+SQL.swift
+++ b/Sources/FluentSQL/DatabaseQuery+SQL.swift
@@ -89,3 +89,19 @@ extension DatabaseQuery.Sort {
         .custom(expression)
     }
 }
+
+extension FieldKey: SQLExpression {
+    public func serialize(to serializer: inout SQLSerializer) {
+        switch self {
+        case .id:
+            serializer.write("id")
+        case .aggregate:
+            serializer.write("aggregate")
+        case .prefix(let prefix, let key):
+            prefix.serialize(to: &serializer)
+            key.serialize(to: &serializer)
+        case .string(let string):
+            serializer.write(string)
+        }
+    }
+}

--- a/Sources/FluentSQL/DatabaseQuery+SQL.swift
+++ b/Sources/FluentSQL/DatabaseQuery+SQL.swift
@@ -91,17 +91,29 @@ extension DatabaseQuery.Sort {
 }
 
 extension FieldKey: SQLExpression {
+    /// See `SQLExpression`.
     public func serialize(to serializer: inout SQLSerializer) {
+        SQLIdentifier(self.string(for: serializer.dialect))
+            .serialize(to: &serializer)
+    }
+
+    // Converts `FieldKey` to a string.
+    // 
+    // `.description` is not used here since that isn't
+    // _necessarily_ a SQL compatible value.
+    //
+    // SQLSerializer is passed in case a different dialect may
+    // need to have special values for id / aggregate.
+    private func string(for dialect: SQLDialect) -> String {
         switch self {
         case .id:
-            serializer.write("id")
+            return "id"
         case .aggregate:
-            serializer.write("aggregate")
+            return "aggregate"
         case .prefix(let prefix, let key):
-            prefix.serialize(to: &serializer)
-            key.serialize(to: &serializer)
+            return prefix.string(for: dialect) + key.string(for: dialect)
         case .string(let string):
-            serializer.write(string)
+            return string
         }
     }
 }


### PR DESCRIPTION
Adds `SQLExpression` conformance to `FieldKey` (#343). 

This allows field keys to be interpolated easily into `SQLQueryString`.

```swift
(req.db as! SQLDatabase).raw("SELECT \(FieldKey.id), \(FieldKey.name) FROM users ...")
```