### PR TITLE
add Database.logging(to:) method

### DIFF
--- a/Sources/FluentKit/Database/Database+Logging.swift
+++ b/Sources/FluentKit/Database/Database+Logging.swift
@@ -1,0 +1,53 @@
+extension Database {
+    public func logging(to logger: Logger) -> Database {
+        LoggingOverrideDatabase(database: self, logger: logger)
+    }
+}
+
+private struct LoggingOverrideDatabase {
+    let database: Database
+    let logger: Logger
+}
+
+extension LoggingOverrideDatabase: Database {
+    var context: DatabaseContext { 
+        .init(
+            configuration: self.database.context.configuration,
+            logger: self.logger,
+            eventLoop: self.database.context.eventLoop,
+            history: self.database.context.history
+        )
+    }
+    
+    func execute(
+        query: DatabaseQuery,
+        onOutput: @escaping (DatabaseOutput) -> ()
+    ) -> EventLoopFuture<Void> {
+        self.database.execute(query: query, onOutput: onOutput)
+    }
+
+    func execute(
+        schema: DatabaseSchema
+    ) -> EventLoopFuture<Void> {
+
+        self.database.execute(schema: schema)
+    }
+
+    func execute(
+        enum: DatabaseEnum
+    ) -> EventLoopFuture<Void> {
+        self.database.execute(enum: `enum`)
+    }
+
+    var inTransaction: Bool {
+        self.database.inTransaction
+    }
+
+    func transaction<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        self.database.transaction(closure)
+    }
+    
+    func withConnection<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        self.database.withConnection(closure)
+    }
+}

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -379,21 +379,30 @@ final class FluentKitTests: XCTestCase {
         }
 
     func testPlanel2FilterPlaceholder4() throws {
-            let db = DummyDatabaseForTestSQLSerializer()
-            _ = try Planet2
-                .query(on: db)
-                .filter(\.$nickName != "first")
-                .filter(\.$nickName != nil)
-                .filter(\.$nickName == "second")
-                .count()
-                .wait()
-            XCTAssertEqual(db.sqlSerializers.count, 1)
-            let result: String = (db.sqlSerializers.first?.sql)!
-            let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" <> $1 AND "planets"."nickname" IS NOT NULL AND "planets"."nickname" = $2"#
-            XCTAssertEqual(result, expected)
-            db.reset()
-        }
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Planet2
+            .query(on: db)
+            .filter(\.$nickName != "first")
+            .filter(\.$nickName != nil)
+            .filter(\.$nickName == "second")
+            .count()
+            .wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        let result: String = (db.sqlSerializers.first?.sql)!
+        let expected = #"SELECT COUNT("planets"."id") AS "aggregate" FROM "planets" WHERE "planets"."nickname" <> $1 AND "planets"."nickname" IS NOT NULL AND "planets"."nickname" = $2"#
+        XCTAssertEqual(result, expected)
+        db.reset()
     }
+
+    func testLoggerOverride() throws {
+        let db: Database = DummyDatabaseForTestSQLSerializer()
+        XCTAssertEqual(db.logger.logLevel, .info)
+        var logger = db.logger
+        logger.logLevel = .critical
+        let new = db.logging(to: logger)
+        XCTAssertEqual(new.logger.logLevel, .critical)
+    }
+}
 
 final class User: Model {
     static let schema = "users"


### PR DESCRIPTION
Adds a new extension to `Database` for overriding its logger (fixes #344, #345).

The example below shows how this API could be used to temporarily prevent errors from being logged. 

```swift
app.post("users") { req in 
    let user: User = ...
    // Make a copy of the request logger
    // and change its log level
    var copy = req.logger
    copy.logLevel = .critical

    // Use the logging(to:) method to create a 
    // temporary Database with the new logger
    return user.save(
        on: req.db.logging(to: copy)
    )
}
```