### PR TITLE
Fix optional string contains operator

### DIFF
--- a/Sources/FluentBenchmark/Tests/FilterTests.swift
+++ b/Sources/FluentBenchmark/Tests/FilterTests.swift
@@ -115,6 +115,7 @@ private final class Foo: Model {
     static let schema = "foos"
     @ID var id: UUID?
     @OptionalField(key: "bar") var bar: String?
+    init() { }
     init(bar: String? = nil) {
         self.bar = bar
     }

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -245,7 +245,15 @@ public struct SQLQueryConverter {
                     right: SQLLiteral.null
                 )
             case (.contains(let inverse, let method), .bind(let bind)):
-                guard let string = bind as? CustomStringConvertible else {
+                let maybeString: String?
+                if let string = bind as? String {
+                    maybeString = string
+                } else if let convertible = bind as? CustomStringConvertible {
+                    maybeString = convertible.description
+                } else {
+                    maybeString = nil
+                }
+                guard let string = maybeString else {
                     fatalError("Only string binds are supported with contains")
                 }
                 let right: SQLExpression


### PR DESCRIPTION
Fixes SQL conversion for the `~~` operator when used with optional fields (fixes #329).