### PR TITLE
Fix invalid @Enum value decode

### DIFF
--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -90,10 +90,12 @@ extension EnumProperty: AnyDatabaseProperty {
 
 extension EnumProperty: AnyCodableProperty {
     public func encode(to encoder: Encoder) throws {
-        try self.field.encode(to: encoder)
+        var container = encoder.singleValueContainer()
+        try container.encode(self.wrappedValue)
     }
 
     public func decode(from decoder: Decoder) throws {
-        try self.field.decode(from: decoder)
+        let container = try decoder.singleValueContainer()
+        self.value = try container.decode(Value.self)
     }
 }

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -91,11 +91,17 @@ extension OptionalEnumProperty: AnyDatabaseProperty {
 
 extension OptionalEnumProperty: AnyCodableProperty {
     public func encode(to encoder: Encoder) throws {
-        try self.field.encode(to: encoder)
+        var container = encoder.singleValueContainer()
+        try container.encode(self.wrappedValue)
     }
 
     public func decode(from decoder: Decoder) throws {
-        try self.field.decode(from: decoder)
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self.value = nil
+        } else {
+            self.value = try container.decode(Value.self)
+        }
     }
 }
 


### PR DESCRIPTION
Decoding a model with invalid `@Enum` or `@OptionalEnum` values now throws an error instead of crashing (#351, fixes #350).