### PR TITLE
Allow generated @IDs to be overridden 

### DIFF
--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -25,7 +25,7 @@ extension Model {
             .cascadeFailure(to: promise)
         return promise.futureResult.flatMapThrowing { output in
             var input = self.collectInput()
-            if self._$id.generator == .database {
+            if case .default = self._$id.inputValue {
                 let idKey = Self()._$id.key
                 input[idKey] = try .bind(output.decode(idKey, as: Self.IDValue.self))
             }

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -81,31 +81,15 @@ public final class IDProperty<Model, Value>
     }
 
     func generate() {
+        guard self.inputValue == nil else {
+            return
+        }
         switch self.generator {
         case .database:
             self.inputValue = .default
         case .random:
-            // only generate an id if none is set
-            let generate: Bool
-
-            // check to see if an id has been set
-            switch inputValue {
-            case .some(let value):
-                switch value {
-                case .bind(let value):
-                    generate = (value as? Value) == nil
-                default:
-                    generate = true
-                }
-            case .none:
-                generate = true
-            }
-
-            // if no id set, generate the value
-            if generate {
-                let generatable = Value.self as! (RandomGeneratable & Encodable).Type
-                self.inputValue = .bind(generatable.generateRandom())
-            }
+            let generatable = Value.self as! (RandomGeneratable & Encodable).Type
+            self.inputValue = .bind(generatable.generateRandom())
         case .user:
             // do nothing
             break


### PR DESCRIPTION
Fixes a bug preventing `@ID` properties generated by `.database` (i.e., `Int` type) from being overridden (#352, fixes #332). 