### PR TITLE
Fix @ID generation for nil values

### DIFF
--- a/Sources/FluentBenchmark/Tests/IDTests.swift
+++ b/Sources/FluentBenchmark/Tests/IDTests.swift
@@ -22,7 +22,7 @@ extension FluentBenchmarker {
             let foo1 = Foo()
             try foo1.save(on: self.database).wait()
             XCTAssertNotNil(foo1.id)
-            let foo2 = Foo()
+            let foo2 = Foo(id: nil)
             try foo2.save(on: self.database).wait()
             XCTAssertNotNil(foo2.id)
             XCTAssertNotEqual(foo1.id, foo2.id)
@@ -49,7 +49,7 @@ extension FluentBenchmarker {
             let foo1 = AutoincrementingFoo()
             try foo1.save(on: self.database).wait()
             XCTAssertEqual(foo1.id, 1)
-            let foo2 = AutoincrementingFoo()
+            let foo2 = AutoincrementingFoo(id: nil)
             try foo2.save(on: self.database).wait()
             XCTAssertEqual(foo2.id, 2)
         }
@@ -63,7 +63,7 @@ extension FluentBenchmarker {
             let foo1 = CustomAutoincrementingFoo()
             try foo1.save(on: self.database).wait()
             XCTAssertEqual(foo1.id, 1)
-            let foo2 = CustomAutoincrementingFoo()
+            let foo2 = CustomAutoincrementingFoo(id: nil)
             try foo2.save(on: self.database).wait()
             XCTAssertEqual(foo2.id, 2)
         }

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -81,9 +81,17 @@ public final class IDProperty<Model, Value>
     }
 
     func generate() {
-        guard self.inputValue == nil else {
+        // Check if current value is nil.
+        switch self.inputValue {
+        case .none, .null:
+            break
+        case .bind(let value) where value.isNil:
+            break
+        default:
             return
         }
+
+        // If nil, generate a value.
         switch self.generator {
         case .database:
             self.inputValue = .default
@@ -166,4 +174,15 @@ protocol AnyID {
     func generate()
     var exists: Bool { get set }
     var cachedOutput: DatabaseOutput? { get set }
+}
+
+
+private extension Encodable {
+    var isNil: Bool {
+        if let optional = self as? AnyOptionalType {
+            return optional.wrappedValue == nil
+        } else {
+            return false
+        }
+    }
 }


### PR DESCRIPTION
Fixes an issue causing `.database` generated `@ID`s to not generate values when set to `nil` (#353). 

This issue was caused by changes in 1.3.2 (#352). `FluentBenchmarker` has been updated with a test that should catch this bug going forward. 