### PR TITLE
Add QueryBuilder.fields(for: Model)

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -56,6 +56,19 @@ public final class QueryBuilder<Model>
 
     // MARK: Fields
 
+    public func fields<Joined>(for model: Joined.Type) -> Self 
+        where Joined: Schema & Fields
+    {
+        self.addFields(for: Joined.self, to: &self.query)
+        return self
+    }
+
+    internal func addFields(for model: (Schema & Fields).Type, to query: inout DatabaseQuery) {
+        query.fields += model.keys.map { path in
+            .path([path], schema: model.schemaOrAlias)
+        }
+    }
+
     public func field<Field>(_ field: KeyPath<Model, Field>) -> Self
         where Field: QueryableProperty, Field.Model == Model
     {
@@ -231,9 +244,7 @@ public final class QueryBuilder<Model>
         // add fields from all models being queried.
         if query.fields.isEmpty {
             for model in self.models {
-                query.fields += model.keys.map { path in
-                    .path([path], schema: model.schemaOrAlias)
-                }
+                self.addFields(for: model, to: &query)
             }
         }
 

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -491,6 +491,15 @@ final class FluentKitTests: XCTestCase {
         try foo.create(on: test.db).wait()
         XCTAssertEqual(foo.id, 1)
     }
+
+
+    func testQueryBuilderFieldsFor() throws {
+        let test = ArrayTestDatabase()
+        let builder = User.query(on: test.db)
+        XCTAssertEqual(builder.query.fields.count, 0)
+        _ = builder.fields(for: User.self)
+        XCTAssertEqual(builder.query.fields.count, 9)
+    }
 }
 
 final class User: Model {


### PR DESCRIPTION
Adds a new method to `QueryBuilder` for fetching all fields from a given model (#354, fixes #346). 

```swift
// Fetch all Planets with Star named "Sun"
let planets = Planet.query(on: req.db)
    // Only fetch fields for Planet, even though
    // Star is being joined. 
    .fields(for: Planet.self)
    // Join Star model and use it to filter results.
    .join(Star.self, on: \Planet.$star.$id == \Star.$id)
    .filter(Star.self, \.$name == "Sun")
    .all()
```