### PR TITLE
Test benchmark updates

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -52,12 +52,18 @@ public final class FluentBenchmarker {
 
     // MARK: Utilities
 
-    internal func runTest(_ name: String, _ migrations: [Migration], _ test: () throws -> ()) throws {
+    internal func runTest(
+        _ name: String, 
+        _ migrations: [Migration], 
+        on database: Database? = nil,
+        _ test: () throws -> ()
+    ) throws {
         self.log("Running \(name)...")
+        let database = database ?? self.database
 
         // Prepare migrations.
         for migration in migrations {
-            try migration.prepare(on: self.database).wait()
+            try migration.prepare(on: database).wait()
         }
 
         var e: Error?
@@ -69,7 +75,7 @@ public final class FluentBenchmarker {
 
         // Revert migrations
         for migration in migrations.reversed() {
-            try migration.revert(on: self.database).wait()
+            try migration.revert(on: database).wait()
         }
 
         if let error = e {
@@ -78,6 +84,6 @@ public final class FluentBenchmarker {
     }
     
     private func log(_ message: String) {
-        self.database.logger.info("[FluentBenchmark] \(message)")
+        self.database.logger.notice("[FluentBenchmark] \(message)")
     }
 }

--- a/Sources/FluentBenchmark/Tests/PerformanceTests+Siblings.swift
+++ b/Sources/FluentBenchmark/Tests/PerformanceTests+Siblings.swift
@@ -2,6 +2,9 @@ import XCTest
 
 extension FluentBenchmarker {
     internal func testPerformance_siblings() throws {
+        let database = try self.database.withConnection { 
+            $0.eventLoop.makeSucceededFuture($0)
+        }.wait()
         try self.runTest(#function, [
             PersonMigration(),
             ExpeditionMigration(),
@@ -11,7 +14,7 @@ extension FluentBenchmarker {
             PersonSeed(),
             ExpeditionSeed(),
             ExpeditionPeopleSeed(),
-        ]) {
+        ], on: database) {
             let start = Date()
             let expeditions = try Expedition.query(on: self.database)
                 .with(\.$officers)


### PR DESCRIPTION
`FluentBenchmarker` now logs test names at `.notice` and siblings performance tests use a single connection (#356). 