### PR TITLE
Add raw query model decode helper

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -45,6 +45,7 @@ public final class FluentBenchmarker {
         try self.testSiblings()
         try self.testSoftDelete()
         try self.testSort()
+        try self.testSQL()
         try self.testTimestamp()
         try self.testTransaction()
         try self.testUnique()

--- a/Sources/FluentBenchmark/Tests/SQLTests.swift
+++ b/Sources/FluentBenchmark/Tests/SQLTests.swift
@@ -1,0 +1,76 @@
+import FluentSQL
+
+extension FluentBenchmarker {
+    public func testSQL() throws {
+        guard let sql = self.database as? SQLDatabase else {
+            return
+        }
+        try self.testSQL_rawDecode(sql)
+    }
+
+    private func testSQL_rawDecode(_ sql: SQLDatabase) throws {
+        try self.runTest(#function, [
+            UserMigration()
+        ]) {
+             let tanner = User(firstName: "Tanner", lastName: "Nelson", parentID: UUID())
+             try tanner.create(on: self.database).wait()
+             print(tanner)
+
+             let users = try sql.raw("SELECT * FROM users").all(decoding: User.self).wait()
+             XCTAssertEqual(users.count, 1)
+             if let user = users.first {
+                XCTAssertEqual(user.id, tanner.id)
+                XCTAssertEqual(user.firstName, tanner.firstName)
+                XCTAssertEqual(user.lastName, tanner.lastName)
+                XCTAssertEqual(user.$parent.id, tanner.$parent.id)
+             }
+        }
+    }
+}
+
+
+private final class User: Model {
+    static let schema = "users"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "first_name")
+    var firstName: String
+
+    @Field(key: "last_name")
+    var lastName: String
+
+    @OptionalParent(key: "parent_id")
+    var parent: User?
+
+    init() { }
+
+    init(
+        id: UUID? = nil, 
+        firstName: String,
+        lastName: String,
+        parentID: UUID? = nil
+    ) {
+        self.id = id
+        self.firstName = firstName
+        self.lastName = lastName
+        self.$parent.id = parentID
+    }
+}
+
+private struct UserMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("users")
+            .id()
+            .field("first_name", .string, .required)
+            .field("last_name", .string, .required)
+            .field("parent_id", .uuid)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.eventLoop.makeSucceededFuture(())
+    }
+}
+

--- a/Sources/FluentBenchmark/Tests/SQLTests.swift
+++ b/Sources/FluentBenchmark/Tests/SQLTests.swift
@@ -16,7 +16,7 @@ extension FluentBenchmarker {
              try tanner.create(on: self.database).wait()
              print(tanner)
 
-             let users = try sql.raw("SELECT * FROM users_sql").all(decoding: User.self).wait()
+             let users = try sql.raw("SELECT * FROM users").all(decoding: User.self).wait()
              XCTAssertEqual(users.count, 1)
              if let user = users.first {
                 XCTAssertEqual(user.id, tanner.id)
@@ -30,7 +30,7 @@ extension FluentBenchmarker {
 
 
 private final class User: Model {
-    static let schema = "users_sql"
+    static let schema = "users"
 
     @ID(key: .id)
     var id: UUID?
@@ -70,7 +70,7 @@ private struct UserMigration: Migration {
     }
 
     func revert(on database: Database) -> EventLoopFuture<Void> {
-        database.eventLoop.makeSucceededFuture(())
+        database.schema("users").delete()
     }
 }
 

--- a/Sources/FluentBenchmark/Tests/SQLTests.swift
+++ b/Sources/FluentBenchmark/Tests/SQLTests.swift
@@ -16,7 +16,7 @@ extension FluentBenchmarker {
              try tanner.create(on: self.database).wait()
              print(tanner)
 
-             let users = try sql.raw("SELECT * FROM users").all(decoding: User.self).wait()
+             let users = try sql.raw("SELECT * FROM users_sql").all(decoding: User.self).wait()
              XCTAssertEqual(users.count, 1)
              if let user = users.first {
                 XCTAssertEqual(user.id, tanner.id)
@@ -30,7 +30,7 @@ extension FluentBenchmarker {
 
 
 private final class User: Model {
-    static let schema = "users"
+    static let schema = "users_sql"
 
     @ID(key: .id)
     var id: UUID?

--- a/Sources/FluentSQL/SQLDatabase+Model.swift
+++ b/Sources/FluentSQL/SQLDatabase+Model.swift
@@ -20,6 +20,16 @@ extension SQLQueryFetcher {
     }
 }
 
+extension SQLRow {
+    public func decode<Model>(model: Model.Type) throws -> Model
+        where Model: FluentKit.Model
+    {
+        let model = Model()
+        try model.output(from: SQLDatabaseOutput(sql: self))
+        return model
+    }
+}
+
 private struct SQLDatabaseOutput: DatabaseOutput {
     let sql: SQLRow
 

--- a/Sources/FluentSQL/SQLDatabase+Model.swift
+++ b/Sources/FluentSQL/SQLDatabase+Model.swift
@@ -1,6 +1,12 @@
 import SQLKit
 
 extension SQLQueryFetcher {
+    public func first<Model>(decoding model: Model.Type) -> EventLoopFuture<Model?> 
+        where Model: FluentKit.Model
+    {
+        self.all(decoding: Model.self).map { $0.first }
+    }
+
     public func all<Model>(decoding model: Model.Type) -> EventLoopFuture<[Model]> 
         where Model: FluentKit.Model
     {

--- a/Sources/FluentSQL/SQLDatabase+Model.swift
+++ b/Sources/FluentSQL/SQLDatabase+Model.swift
@@ -1,0 +1,42 @@
+import SQLKit
+
+extension SQLQueryFetcher {
+    public func all<Model>(decoding model: Model.Type) -> EventLoopFuture<[Model]> 
+        where Model: FluentKit.Model
+    {
+        self.all().flatMapThrowing { rows in 
+            try rows.map { row in
+                let model = Model()
+                try model.output(from: SQLDatabaseOutput(sql: row))
+                return model
+            }
+        }
+    }
+}
+
+private struct SQLDatabaseOutput: DatabaseOutput {
+    let sql: SQLRow
+
+    var description: String {
+        "\(self.sql)"
+    }
+
+    func schema(_ schema: String) -> DatabaseOutput {
+        self
+    }
+
+    func contains(_ key: FieldKey) -> Bool {
+        self.sql.contains(column: key.description)
+    }
+
+    func decodeNil(_ key: FieldKey) throws -> Bool {
+        try self.sql.decodeNil(column: key.description)
+    }
+
+    func decode<T>(_ key: FieldKey, as type: T.Type) throws -> T 
+        where T: Decodable
+    {
+        try self.sql.decode(column: key.description, as: T.self)
+    }
+}
+


### PR DESCRIPTION
Adds helper methods to `SQLRow` and `SQLDatabase` query builders for decoding models (#362, fixes #334).

```swift
guard let sql = req.db as? SQLDatabase else { ... }
let users = sql.raw("SELECT * FROM users").all(decoding: User.self)
```

Both `first` and `all` are available on `SQLDatabase` as well as `decode` on `SQLRow`.

```swift
let row: SQLRow = ...
let user = try row.decode(model: User.self)
```

These overloads work by circumventing model's `Codable` conformance and decoding the SQL row as database output. 

Note: Some features of `Model`, like `model.joined(_:)`, may not work correctly when decoding from SQLKit directly as they rely on specific key naming.