### PR TITLE
Add SQLConverterDelegate.beforeConvert method

### DIFF
--- a/Sources/FluentBenchmark/Tests/SchemaTests.swift
+++ b/Sources/FluentBenchmark/Tests/SchemaTests.swift
@@ -4,6 +4,7 @@ extension FluentBenchmarker {
     public func testSchema() throws {
         try self.testSchema_addConstraint()
         try self.testSchema_addNamedConstraint()
+        try self.testSchema_fieldReference()
     }
 
     private func testSchema_addConstraint() throws {
@@ -55,6 +56,18 @@ extension FluentBenchmarker {
             // Remove unique constraint
             try AddNamedUniqueConstraintToCategories().revert(on: self.database).wait()
             try Category(name: "a").create(on: self.database).wait()
+        }
+    }
+    
+    private func testSchema_fieldReference() throws {
+        try self.runTest(#function, [
+            SolarSystem()
+        ]) {
+            XCTAssertThrowsError(
+                try Star.query(on: self.database)
+                    .filter(\.$name == "Sun")
+                    .delete().wait()
+            )
         }
     }
 }

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -1,6 +1,13 @@
 public protocol SQLConverterDelegate {
     func customDataType(_ dataType: DatabaseSchema.DataType) -> SQLExpression?
     func nestedFieldExpression(_ column: String, _ path: [String]) -> SQLExpression
+    func beforeConvert(_ schema: DatabaseSchema) -> DatabaseSchema
+}
+
+extension SQLConverterDelegate {
+    public func beforeConvert(_ schema: DatabaseSchema) -> DatabaseSchema {
+        schema
+    }
 }
 
 public struct SQLSchemaConverter {
@@ -10,6 +17,7 @@ public struct SQLSchemaConverter {
     }
     
     public func convert(_ schema: DatabaseSchema) -> SQLExpression {
+        let schema = self.delegate.beforeConvert(schema)
         switch schema.action {
         case .create:
             return self.create(schema)


### PR DESCRIPTION
Adds `SQLConverterDelegate.beforeConvert` method (#364). 

This is mostly an internal change and allows for `SQLConverterDelegate` conformers to alter the `DatabaseSchema` before it is converted to SQLKit expressions. 

Additionally, a `FluentBenchmarker` test has been added to ensure that the `.references` field constraint is being enforced by drivers. 