### PR TITLE
Support disabling foreign key checks in benchmarker

### DIFF
--- a/Sources/FluentBenchmark/Tests/SchemaTests.swift
+++ b/Sources/FluentBenchmark/Tests/SchemaTests.swift
@@ -1,10 +1,10 @@
 import FluentSQL
 
 extension FluentBenchmarker {
-    public func testSchema(sql: Bool = true) throws {
+    public func testSchema(foreignKeys: Bool = true) throws {
         try self.testSchema_addConstraint()
         try self.testSchema_addNamedConstraint()
-        if sql {
+        if foreignKeys {
             try self.testSchema_fieldReference()
         }
     }

--- a/Sources/FluentBenchmark/Tests/SchemaTests.swift
+++ b/Sources/FluentBenchmark/Tests/SchemaTests.swift
@@ -1,10 +1,12 @@
 import FluentSQL
 
 extension FluentBenchmarker {
-    public func testSchema() throws {
+    public func testSchema(sql: Bool = true) throws {
         try self.testSchema_addConstraint()
         try self.testSchema_addNamedConstraint()
-        try self.testSchema_fieldReference()
+        if sql {
+            try self.testSchema_fieldReference()
+        }
     }
 
     private func testSchema_addConstraint() throws {


### PR DESCRIPTION
Adds flag for disabling foreign key checks in FluentBenchmarker (#368). 

In #364 `testSchema_fieldReference` has been introduced. Drivers like mongo don't support foreign key constraints which causes the above `FluentBenchmark` test to fail.

Although, an effort has been made to partially supports `Fluent` schema features by using mongo [schema validation](https://docs.mongodb.com/manual/core/schema-validation/#specify-validation-rules) this specific feature it's still not supported.