### PR TITLE
Minimum iOS version is 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "fluent-kit",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v10)
+        .iOS(.v13)
     ],
     products: [
         .library(name: "FluentKit", targets: ["FluentKit"]),


### PR DESCRIPTION
The minimum iOS version supported by this package is now iOS 13 since `ISO8601DateFormatter` requires it to be version 10 and 13 matches the Catalina requirement.