### PR TITLE
Require value for @Parent when eager loaded

### DIFF
--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -97,7 +97,7 @@ extension FluentBenchmarker {
     // Tests eager load of @Parent relation that has been soft-deleted.
     private func testSoftDelete_parent() throws {
         final class Foo: Model {
-            static let schema = "foo"
+            static let schema = "foos"
 
             @ID(key: .id)
             var id: UUID?
@@ -110,19 +110,19 @@ extension FluentBenchmarker {
 
         struct FooMigration: Migration {
             func prepare(on database: Database) -> EventLoopFuture<Void> {
-                database.schema("foo")
+                database.schema("foos")
                     .id()
                     .field("bar", .uuid, .required)
                     .create()
             }
 
             func revert(on database: Database) -> EventLoopFuture<Void> {
-                database.schema("foo").delete()
+                database.schema("foos").delete()
             }
         }
 
         final class Bar: Model {
-            static let schema = "bar"
+            static let schema = "bars"
 
             @ID(key: .id)
             var id: UUID?
@@ -135,14 +135,14 @@ extension FluentBenchmarker {
 
         struct BarMigration: Migration {
             func prepare(on database: Database) -> EventLoopFuture<Void> {
-                database.schema("bar")
+                database.schema("bars")
                     .id()
                     .field("deleted_at", .datetime)
                     .create()
             }
 
             func revert(on database: Database) -> EventLoopFuture<Void> {
-                database.schema("bar").delete()
+                database.schema("bars").delete()
             }
         }
 

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -1,9 +1,10 @@
 extension FluentBenchmarker {
     public func testSoftDelete() throws {
-        try self.testSoftDelete_model()
-        try self.testSoftDelete_query()
-        try self.testSoftDelete_onBulkDelete()
-        try self.testSoftDelete_forceOnQuery()
+//        try self.testSoftDelete_model()
+//        try self.testSoftDelete_query()
+//        try self.testSoftDelete_onBulkDelete()
+//        try self.testSoftDelete_forceOnQuery()
+        try self.testSoftDelete_parent()
     }
     
     private func testCounts(
@@ -90,6 +91,93 @@ extension FluentBenchmarker {
 
             try Trash.query(on: self.database).delete(force: true).wait()
             try testCounts(allCount: 0, realCount: 0)
+        }
+    }
+
+    // Tests eager load of @Parent relation that has been soft-deleted.
+    private func testSoftDelete_parent() throws {
+        final class Foo: Model {
+            static let schema = "foo"
+
+            @ID(key: .id)
+            var id: UUID?
+
+            @Parent(key: "bar")
+            var bar: Bar
+
+            init() { }
+        }
+
+        struct FooMigration: Migration {
+            func prepare(on database: Database) -> EventLoopFuture<Void> {
+                database.schema("foo")
+                    .id()
+                    .field("bar", .uuid, .required)
+                    .create()
+            }
+
+            func revert(on database: Database) -> EventLoopFuture<Void> {
+                database.schema("foo").delete()
+            }
+        }
+
+        final class Bar: Model {
+            static let schema = "bar"
+
+            @ID(key: .id)
+            var id: UUID?
+
+            @Timestamp(key: "deleted_at", on: .delete)
+            var deletedAt: Date?
+
+            init() { }
+        }
+
+        struct BarMigration: Migration {
+            func prepare(on database: Database) -> EventLoopFuture<Void> {
+                database.schema("bar")
+                    .id()
+                    .field("deleted_at", .datetime)
+                    .create()
+            }
+
+            func revert(on database: Database) -> EventLoopFuture<Void> {
+                database.schema("bar").delete()
+            }
+        }
+
+        try self.runTest(#function, [
+            FooMigration(),
+            BarMigration(),
+        ]) {
+            let bar1 = Bar()
+            try bar1.create(on: self.database).wait()
+            let bar2 = Bar()
+            try bar2.create(on: self.database).wait()
+
+            let foo1 = Foo()
+            foo1.$bar.id = bar1.id!
+            try foo1.create(on: self.database).wait()
+
+            let foo2 = Foo()
+            foo2.$bar.id = bar2.id!
+            try foo2.create(on: self.database).wait()
+
+            // test fetch
+            let foos = try Foo.query(on: self.database).with(\.$bar).all().wait()
+            XCTAssertEqual(foos.count, 2)
+            XCTAssertNotNil(foos[0].$bar.value)
+            XCTAssertNotNil(foos[1].$bar.value)
+
+            // soft-delete bar 1
+            try bar1.delete(on: self.database).wait()
+
+            // test fetch again
+            // this should throw an error now because one of the
+            // parents is missing and the results cannot be loaded
+            XCTAssertThrowsError(try Foo.query(on: self.database).with(\.$bar).all().wait()) { error in
+                XCTAssertEqual("\(error)", FluentError.missingParent.description)
+            }
         }
     }
 }

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -1,9 +1,9 @@
 extension FluentBenchmarker {
     public func testSoftDelete() throws {
-//        try self.testSoftDelete_model()
-//        try self.testSoftDelete_query()
-//        try self.testSoftDelete_onBulkDelete()
-//        try self.testSoftDelete_forceOnQuery()
+        try self.testSoftDelete_model()
+        try self.testSoftDelete_query()
+        try self.testSoftDelete_onBulkDelete()
+        try self.testSoftDelete_forceOnQuery()
         try self.testSoftDelete_parent()
     }
     

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -143,12 +143,16 @@ private struct ParentEagerLoader<From, To>: EagerLoader
         return To.query(on: database)
             .filter(\._$id ~~ Set(ids))
             .all()
-            .map
+            .flatMapThrowing
         {
             for model in models {
-                model[keyPath: self.relationKey].value = $0.filter {
+                guard let parent = $0.filter({
                     $0.id == model[keyPath: self.relationKey].id
-                }.first
+                }).first else {
+                    database.logger.debug("No parent '\(To.self)' with id '\(model[keyPath: self.relationKey].id)' was found in eager-load results.")
+                    throw FluentError.missingParent
+                }
+                model[keyPath: self.relationKey].value = parent
             }
         }
     }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -223,6 +223,12 @@ public final class QueryBuilder<Model>
                 // run eager loads
                 return EventLoopFutureQueue(eventLoop: self.database.eventLoop).append(each: self.eagerLoaders) { loader in
                     return loader.anyRun(models: all, on: self.database)
+                }.flatMapErrorThrowing { error in
+                    if case .previousError(let error) = error as? EventLoopFutureQueue.ContinueError {
+                        throw error
+                    } else {
+                        throw error
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Queries that fail to eager-load a value for a `@Parent` relation will now throw an error (#380).

This change helps prevent unintended access of uninitialized `@Parent` properties in cases where no parent is found. For example, if the parent is deleted (including soft-deletion) or the reference was set to an invalid identifier. 