### PR TITLE
Soft deletes updating delete_at key incorrectly

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -102,7 +102,7 @@ public final class QueryBuilder<Model>
     }
 
     public func delete(force: Bool = false) -> EventLoopFuture<Void> {
-        self.includeDeleted = true
+        self.includeDeleted = force
         self.shouldForceDelete = force
         self.query.action = .delete
         return self.run()


### PR DESCRIPTION
Simple change supporting https://github.com/vapor/fluent-kit/issues/388. This certainly fixes my problem, and I believe makes delete() behavior more correct.