### PR TITLE
Add eager loading for pivots on sibling relationships

### DIFF
--- a/Sources/FluentBenchmark/Tests/SiblingsTests.swift
+++ b/Sources/FluentBenchmark/Tests/SiblingsTests.swift
@@ -87,4 +87,17 @@ extension FluentBenchmarker {
             }
         }
     }
+    
+    private func testSiblings_pivotsLoading() throws {
+        try self.runTest(#function, [
+            SolarSystem()
+        ]) {
+            let earth = try Planet.query(on: self.database)
+                .filter(\.&name == "Earth").with(\.$tags).with(\.$tags.$pivots)
+                .first().wait()!
+            
+            // verify tag count
+            try XCTAssertEqual(earth.$tags.pivots.count, 2)
+        }
+    }
 }

--- a/Sources/FluentBenchmark/Tests/SiblingsTests.swift
+++ b/Sources/FluentBenchmark/Tests/SiblingsTests.swift
@@ -2,6 +2,7 @@ extension FluentBenchmarker {
     public func testSiblings() throws {
         try self.testSiblings_attach()
         try self.testSiblings_detachArray()
+        try self.testSiblings_pivotLoading()
     }
 
     private func testSiblings_attach() throws {
@@ -88,16 +89,16 @@ extension FluentBenchmarker {
         }
     }
     
-    private func testSiblings_pivotsLoading() throws {
+    private func testSiblings_pivotLoading() throws {
         try self.runTest(#function, [
             SolarSystem()
         ]) {
             let earth = try Planet.query(on: self.database)
-                .filter(\.&name == "Earth").with(\.$tags).with(\.$tags.$pivots)
+                .filter(\.$name == "Earth").with(\.$tags).with(\.$tags.$pivots)
                 .first().wait()!
             
             // verify tag count
-            try XCTAssertEqual(earth.$tags.pivots.count, 2)
+            XCTAssertEqual(earth.$tags.pivots.count, 2)
         }
     }
 }

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -23,8 +23,7 @@ public final class SiblingsProperty<From, To, Through>
     
     public var value: [To]?
     
-    
-    /// Allows eager loading of pivot objects through the sibling relation without adding them as children of the model.
+    /// Allows eager loading of pivot objects through the sibling relation.
     /// Example:
     ///
     ///     Planet.query(on: db)
@@ -32,7 +31,6 @@ public final class SiblingsProperty<From, To, Through>
     ///             // you can now access the loaded pivots using:
     ///             let pivots = planet.$tags.pivots
     ///         }
-    
     @ChildrenProperty<From, Through>
     public var pivots: [Through]
 

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -22,6 +22,9 @@ public final class SiblingsProperty<From, To, Through>
     var idValue: From.IDValue?
     
     public var value: [To]?
+    
+    @ChildrenProperty<From, Through>
+    public var pivots: [Through]
 
     public init(
         through _: Through.Type,
@@ -30,6 +33,7 @@ public final class SiblingsProperty<From, To, Through>
     ) {
         self.from = from
         self.to = to
+        self._pivots = ChildrenProperty<From, Through>(for: from)
     }
 
     public var wrappedValue: [To] {
@@ -207,6 +211,7 @@ extension SiblingsProperty: AnyDatabaseProperty {
         let key = From()._$id.key
         if output.contains(key) {
             self.idValue = try output.decode(key, as: From.IDValue.self)
+            self._pivots.idValue = self.idValue
         }
     }
 }

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -32,8 +32,7 @@ public final class SiblingsProperty<From, To, Through>
     ///             // you can now access the loaded pivots using:
     ///             let pivots = planet.$tags.pivots
     ///         }
-    ///         .join(from: Planet.self, parent: \.$star)
-    ///         .filter(Star.self, \Star.$name == "Sun")
+    
     @ChildrenProperty<From, Through>
     public var pivots: [Through]
 

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -23,6 +23,17 @@ public final class SiblingsProperty<From, To, Through>
     
     public var value: [To]?
     
+    
+    /// Allows eager loading of pivot objects through the sibling relation without adding them as children of the model.
+    /// Example:
+    ///
+    ///     Planet.query(on: db)
+    ///         .with(\.$tags).with(\.$tags.$pivots).first() { planet in
+    ///             // you can now access the loaded pivots using:
+    ///             let pivots = planet.$tags.pivots
+    ///         }
+    ///         .join(from: Planet.self, parent: \.$star)
+    ///         .filter(Star.self, \Star.$name == "Sun")
     @ChildrenProperty<From, Through>
     public var pivots: [Through]
 


### PR DESCRIPTION
Adds support for eager loading of pivots on sibling relationships.

This is useful if there is extra information stored on the pivot itself that is relevant for the relationship itself instead of the models connected by it. 

Example (using the planet <-> tag relation from the docs):
```swift
Planet.query(on: req.db).with(\.$tags).with(\.$tags.$pivots).first() { planet in 
   // you can now access the loaded pivots using:
   let pivots = planet.$tags.pivots
}
```