### PR TITLE
Don't Re-Delete Soft-Deleted Models

### DIFF
--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -74,21 +74,21 @@ extension FluentBenchmarker {
             // Create soft-deletable model.
             let a = Trash(contents: "A")
             try a.create(on: self.database).wait()
-            XCTAssertEqual(Trash.query(on: self.database).all().wait().map(\.contents), ["A"])
+            try XCTAssertEqual(Trash.query(on: self.database).all().wait().map(\.contents), ["A"])
 
             // Delete model and make sure it still exists, with its `.deletedAt` property set.
             try a.delete(on: self.database).wait()
-            XCTAssertEqual(Trash.query(on: self.database).all().wait().count, 0)
-            XCTAssertEqual(Trash.query(on: self.database).withDeleted().all().wait().map(\.contents), ["A"])
+            try XCTAssertEqual(Trash.query(on: self.database).all().wait().count, 0)
+            try XCTAssertEqual(Trash.query(on: self.database).withDeleted().all().wait().map(\.contents), ["A"])
             let deletedAt = try XCTUnwrap(a.deletedAt)
-            XCTAssertEqual(Trash.query(on: self.database).first().wait()?.deletedAt, deletedAt)
+            try XCTAssertEqual(Trash.query(on: self.database).first().wait()?.deletedAt, deletedAt)
 
             // Delete all models
             sleep(1)
-            Trash.query(on: self.database).delete()
+            try Trash.query(on: self.database).delete().wait()
 
             // Make sure the `.deletedAt` value doesn't change.
-            XCTAssertEqual(Trash.query(on: self.database).first().wait()?.deletedAt, deletedAt)
+            try XCTAssertEqual(Trash.query(on: self.database).first().wait()?.deletedAt, deletedAt)
         }
     }
 

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -80,7 +80,7 @@ extension FluentBenchmarker {
             try a.delete(on: self.database).wait()
             try XCTAssertEqual(Trash.query(on: self.database).all().wait().count, 0)
             try XCTAssertEqual(Trash.query(on: self.database).withDeleted().all().wait().map(\.contents), ["A"])
-            let deletedAt = try Date(timeIntervalSince1970: TimeInterval(Int(XCTUnwrap(a.deletedAt).timeIntervalSince1970)))
+            let deletedAt = try Date(timeIntervalSince1970: XCTUnwrap(a.deletedAt).timeIntervalSince1970.rounded(.down))
             try XCTAssertEqual(Trash.query(on: self.database).withDeleted().first().wait()?.deletedAt, deletedAt)
 
             // Delete all models

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -81,14 +81,14 @@ extension FluentBenchmarker {
             try XCTAssertEqual(Trash.query(on: self.database).all().wait().count, 0)
             try XCTAssertEqual(Trash.query(on: self.database).withDeleted().all().wait().map(\.contents), ["A"])
             let deletedAt = try XCTUnwrap(a.deletedAt)
-            try XCTAssertEqual(Trash.query(on: self.database).first().wait()?.deletedAt, deletedAt)
+            try XCTAssertEqual(Trash.query(on: self.database).withDeleted().first().wait()?.deletedAt, deletedAt)
 
             // Delete all models
             sleep(1)
             try Trash.query(on: self.database).delete().wait()
 
             // Make sure the `.deletedAt` value doesn't change.
-            try XCTAssertEqual(Trash.query(on: self.database).first().wait()?.deletedAt, deletedAt)
+            try XCTAssertEqual(Trash.query(on: self.database).withDeleted().first().wait()?.deletedAt, deletedAt)
         }
     }
 

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -80,15 +80,21 @@ extension FluentBenchmarker {
             try a.delete(on: self.database).wait()
             try XCTAssertEqual(Trash.query(on: self.database).all().wait().count, 0)
             try XCTAssertEqual(Trash.query(on: self.database).withDeleted().all().wait().map(\.contents), ["A"])
-            let deletedAt = try Date(timeIntervalSince1970: XCTUnwrap(a.deletedAt).timeIntervalSince1970.rounded(.down))
-            try XCTAssertEqual(Trash.query(on: self.database).withDeleted().first().wait()?.deletedAt, deletedAt)
+            let deletedAt = try XCTUnwrap(a.deletedAt).timeIntervalSince1970.rounded(.down)
+            try XCTAssertEqual(
+                Trash.query(on: self.database).withDeleted().first().wait()?.deletedAt?.timeIntervalSince1970.rounded(.down),
+                deletedAt
+            )
 
             // Delete all models
             sleep(1)
             try Trash.query(on: self.database).delete().wait()
 
             // Make sure the `.deletedAt` value doesn't change.
-            try XCTAssertEqual(Trash.query(on: self.database).withDeleted().first().wait()?.deletedAt, deletedAt)
+            try XCTAssertEqual(
+                Trash.query(on: self.database).withDeleted().first().wait()?.deletedAt?.timeIntervalSince1970.rounded(.down),
+                deletedAt
+            )
         }
     }
 

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -80,7 +80,7 @@ extension FluentBenchmarker {
             try a.delete(on: self.database).wait()
             try XCTAssertEqual(Trash.query(on: self.database).all().wait().count, 0)
             try XCTAssertEqual(Trash.query(on: self.database).withDeleted().all().wait().map(\.contents), ["A"])
-            let deletedAt = try XCTUnwrap(a.deletedAt)
+            let deletedAt = try Date(timeIntervalSince1970: TimeInterval(Int(XCTUnwrap(a.deletedAt).timeIntervalSince1970)))
             try XCTAssertEqual(Trash.query(on: self.database).withDeleted().first().wait()?.deletedAt, deletedAt)
 
             // Delete all models

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -102,7 +102,7 @@ public final class QueryBuilder<Model>
     }
 
     public func delete(force: Bool = false) -> EventLoopFuture<Void> {
-        self.includeDeleted = true
+        self.includeDeleted = force
         self.shouldForceDelete = force
         self.query.action = .delete
         return self.run()


### PR DESCRIPTION
Soft-deleted models will no longer be re-deleted (have their `.deleteAt` values updated), when they are included in a `DELETE` query.

Closes https://github.com/vapor/fluent-kit/issues/388
Closes https://github.com/vapor/fluent-kit/pull/389