### PR TITLE
More helpers for embedding raw SQL from the FluentKit layer

### DIFF
--- a/Sources/FluentBenchmark/Tests/FilterTests.swift
+++ b/Sources/FluentBenchmark/Tests/FilterTests.swift
@@ -5,6 +5,9 @@ extension FluentBenchmarker {
         try self.testFilter_field()
         if sql {
             try self.testFilter_sqlValue()
+            try self.testFilter_sqlEmbedValue()
+            try self.testFilter_sqlEmbedField()
+            try self.testFilter_sqlEmbedFilter()
         }
         try self.testFilter_group()
         try self.testFilter_emptyGroup()
@@ -36,6 +39,48 @@ extension FluentBenchmarker {
         ]) {
             let moon = try Moon.query(on: self.database)
                 .filter(\.$name == .sql(raw: "'Moon'"))
+                .first()
+                .wait()
+
+            XCTAssertNotNil(moon)
+            XCTAssertEqual(moon?.name, "Moon")
+        }
+    }
+
+    private func testFilter_sqlEmbedValue() throws {
+        try self.runTest(#function, [
+            SolarSystem()
+        ]) {
+            let moon = try Moon.query(on: self.database)
+                .filter(\.$name == .sql(embed: "\(literal: "Moon")"))
+                .first()
+                .wait()
+
+            XCTAssertNotNil(moon)
+            XCTAssertEqual(moon?.name, "Moon")
+        }
+    }
+
+    private func testFilter_sqlEmbedField() throws {
+        try self.runTest(#function, [
+            SolarSystem()
+        ]) {
+            let moon = try Moon.query(on: self.database)
+                .filter(.sql(embed: "\(ident: "name")"), .equal, .bind("Moon"))
+                .first()
+                .wait()
+
+            XCTAssertNotNil(moon)
+            XCTAssertEqual(moon?.name, "Moon")
+        }
+    }
+
+    private func testFilter_sqlEmbedFilter() throws {
+        try self.runTest(#function, [
+            SolarSystem()
+        ]) {
+            let moon = try Moon.query(on: self.database)
+                .filter(.sql(embed: "\(ident: "name")=\(literal: "Moon")"))
                 .first()
                 .wait()
 

--- a/Sources/FluentBenchmark/Tests/RangeTests.swift
+++ b/Sources/FluentBenchmark/Tests/RangeTests.swift
@@ -1,5 +1,9 @@
 extension FluentBenchmarker {
     public func testRange() throws {
+        try self.testRange_basic()
+    }
+    
+    private func testRange_basic() throws {
         try self.runTest(#function, [
             SolarSystem()
         ]) {

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -58,6 +58,11 @@ public final class SchemaBuilder {
         return self
     }
 
+    public func deleteConstraint(_ constraint: DatabaseSchema.ConstraintDelete) -> Self {
+        self.schema.deleteConstraints.append(constraint)
+        return self
+    }
+
     public func foreignKey(
         _ field: FieldKey,
         references foreignSchema: String,

--- a/Sources/FluentSQL/DatabaseQuery+SQL.swift
+++ b/Sources/FluentSQL/DatabaseQuery+SQL.swift
@@ -2,6 +2,10 @@ extension DatabaseQuery.Value {
     public static func sql(raw: String) -> Self {
         .sql(SQLRaw(raw))
     }
+    
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
 
     public static func sql(_ expression: SQLExpression) -> Self {
         .custom(expression)
@@ -15,6 +19,10 @@ extension DatabaseQuery.Field {
 
     public static func sql(_ identifier: String) -> Self {
         .sql(SQLIdentifier(identifier))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
     }
 
     public static func sql(_ expression: SQLExpression) -> Self {
@@ -51,6 +59,10 @@ extension DatabaseQuery.Filter {
         .sql(SQLBinaryExpression(left: left, op: op, right: right))
     }
 
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
     public static func sql(_ expression: SQLExpression) -> Self {
         .custom(expression)
     }
@@ -83,6 +95,10 @@ extension DatabaseQuery.Sort {
         _ right: SQLExpression
     ) -> Self {
         .sql(SQLBinaryExpression(left: left, op: op, right: right))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
     }
 
     public static func sql(_ expression: SQLExpression) -> Self {

--- a/Sources/FluentSQL/DatabaseSchema+SQL.swift
+++ b/Sources/FluentSQL/DatabaseSchema+SQL.swift
@@ -7,6 +7,10 @@ extension DatabaseSchema.DataType {
         .sql(dataType as SQLExpression)
     }
 
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
     public static func sql(_ expression: SQLExpression) -> Self {
         .custom(expression)
     }
@@ -21,9 +25,26 @@ extension DatabaseSchema.Constraint {
         .sql(constraint as SQLExpression)
     }
 
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
 
     public static func sql(_ expression: SQLExpression) -> Self {
         .custom(expression)
+    }
+}
+
+extension DatabaseSchema.ConstraintAlgorithm {
+    public static func sql(raw: String) -> Self {
+        .sql(SQLRaw(raw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: SQLExpression) -> Self {
+    .custom(expression)
     }
 }
 
@@ -36,6 +57,65 @@ extension DatabaseSchema.FieldConstraint {
         .sql(constraint as SQLExpression)
     }
 
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseSchema.FieldDefinition {
+    public static func sql(raw: String) -> Self {
+        .sql(SQLRaw(raw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseSchema.FieldUpdate {
+    public static func sql(raw: String) -> Self {
+        .sql(SQLRaw(raw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseSchema.FieldName {
+    public static func sql(raw: String) -> Self {
+        .sql(SQLRaw(raw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseSchema.ConstraintDelete {
+    public static func sql(raw: String) -> Self {
+        .sql(SQLRaw(raw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
 
     public static func sql(_ expression: SQLExpression) -> Self {
         .custom(expression)

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -269,7 +269,7 @@ public struct SQLSchemaConverter {
 /// SQL drop constraint expression.
 ///
 ///     `CONSTRAINT/KEY <name>`
-struct SQLDropConstraint: SQLExpression {
+public struct SQLDropConstraint: SQLExpression {
     public var name: SQLExpression
 
     public init(name: SQLExpression) {

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -90,7 +90,7 @@ public struct SQLSchemaConverter {
                     name: SQLIdentifier(name)
                 )
             case .custom(let any):
-                return custom(any)
+                return SQLConstraint(algorithm: any as! SQLExpression, name: customName.map(SQLIdentifier.init(_:)))
             }
         case .custom(let any):
             return custom(any)


### PR DESCRIPTION
Raw SQL can now be embedded in FluentKit-level queries and schema actions, including new helpers accepting `SQLQueryString`, when using:

- Query values (such as on the right-hand side of filter expressions)
- Query fields (such as on the left-hand side of filter expressions)
- Query filters (e.g. `.filter(.sql(embed: "\(ident: "a") IS NOT BORED BY \(literal: "b")"))`)
- Query sorts (e.g. `.sort(.sql(raw: "foo DESC WITH TERIYAKI SAUCE"))`)
- Schema field data types (e.g. `.field(.id, .sql(raw: "PUMPKIN SPICE"), .required, .identifier(auto: false))`)
- Schema field names (e.g. `.field(.definition(name: .sql(raw: "its_a_secret"), dataType: .text, constraints: []))`)
- Schema field definitions (both creates and updates) (e.g. `.field(.sql(raw: "hush TIMESTAMP DEFAULT NOW() REFERENCES Quiet (now) ON UPDATE LAY YOUR SLEEPY HEAD"))`
- Schema field constraints (e.g. `.field(.id, .uuid, .sql(raw: "MULTIVERSALLY UNIQUE, NOT REPETITIVE"))`
- Schema table constraint algorithms (e.g. `.constraint(.constraint(.sql(raw: "REVERSE THE POLARITY"), name: "the_neutron_flow"))`
- Schema table constraints (e.g. `.constraint(.sql(raw: "ITTY BITTY LIVING SPACE"))`)

Tests are included. A small update to `fluent-mongo-driver` is required to make the tests pass there.