### PR TITLE
Add Public Initializer to PageMetadata

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -58,6 +58,18 @@ public struct PageMetadata: Codable {
 
     /// Total number of items available.
     public let total: Int
+    
+    /// Creates a new `PageMetadata` instance.
+    ///
+    /// - Parameters:
+    ///.  - page: Current page number.
+    ///.  - per: Max items per page.
+    ///.  - total: Total number of items available.
+    public init(page: Int, per: Int, total: Int) {
+        self.page = page
+        self.per = per
+        self.total = total
+    }
 }
 
 /// Represents information needed to generate a `Page` from the full result set.


### PR DESCRIPTION
The `Page` type has a public initializer, but it was rendered nearly useless because it takes in a `PageMetadata` instance which doesn't have a public initializer. `PageMetadata` now has a property initializer along with the synthesized decoder initializer.

Fixes https://github.com/vapor/fluent-kit/issues/390