### PR TITLE
QueryBuilder needs a Field-taking `.field()` overload

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -81,6 +81,11 @@ public final class QueryBuilder<Model>
         self.query.fields.append(.path(Joined.path(for: field), schema: Joined.schema))
         return self
     }
+    
+    public func field(_ field: DatabaseQuery.Field) -> Self {
+        self.query.fields.append(field)
+        return self
+    }
 
     // MARK: Soft Delete
 


### PR DESCRIPTION
Added the missing `QueryBuilder.field(_ field: DatabaseQuery.Field)` overload to `QueryBuilder`. Without it, the `.raw()`, `.raw(sql:)`, and `.raw(embed:)` helpers can not be used with the `.field()` method (e.g. `.field(.raw(sql: "raw SQL"))` would fail to compile). The missing overload should have been added by #400, but was overlooked.