### PR TITLE
More helpers for embedding raw SQL from the FluentKit layer

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
@@ -178,6 +178,24 @@ extension QueryBuilder {
         ))
         return self
     }
+    
+    @discardableResult
+    public func join<Foreign>(
+        _ foreign: Foreign.Type,
+        _ join: DatabaseQuery.Join
+    ) -> Self
+        where Foreign: Schema
+    {
+        self.models.append(Foreign.self)
+        self.query.joins.append(join)
+        return self
+    }
+    
+    @discardableResult
+    public func join(_ join: DatabaseQuery.Join) -> Self {
+        self.query.joins.append(join)
+        return self
+    }
 }
 
 // MARK: Local == Foreign

--- a/Sources/FluentSQL/DatabaseQuery+SQL.swift
+++ b/Sources/FluentSQL/DatabaseQuery+SQL.swift
@@ -30,6 +30,24 @@ extension DatabaseQuery.Field {
     }
 }
 
+extension DatabaseQuery.Join {
+    public static func sql(raw: String) -> Self {
+        .sql(SQLRaw(raw))
+    }
+    
+    public static func sql(_ identifier: String) -> Self {
+        .sql(SQLIdentifier(identifier))
+    }
+    
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+    
+    public static func sql(_ expression: SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
 extension DatabaseQuery.Filter {
     public static func sql(raw: String) -> Self {
         .sql(SQLRaw(raw))


### PR DESCRIPTION
This adds on to #400 and #402, allowing raw sql to be embedded in joins as well.
Example:
`query.join(.sql(embed: "LEFT JOIN (...) ON ... = ..."))