### PR TITLE
Pagination max per

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.2.1
+        uses: maxim-lobanov/setup-xcode@v1.2.1
         with:
           xcode-version: latest
       - name: Check out package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,8 +104,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
-        with: 
+        uses: maxim-lobanov/setup-xcode@1
+        with:
           xcode-version: latest
       - name: Check out package
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1
+        uses: maxim-lobanov/setup-xcode@1.2.1
         with:
           xcode-version: latest
       - name: Check out package

--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -45,6 +45,10 @@ extension Database {
     public var history: QueryHistory? {
         self.context.history
     }
+
+    public var maxPerPage: Int? {
+        self.context.maxPerPage
+    }
 }
 
 public protocol DatabaseDriver {
@@ -62,17 +66,20 @@ public struct DatabaseContext {
     public let logger: Logger
     public let eventLoop: EventLoop
     public let history: QueryHistory?
+    public let maxPerPage: Int?
     
     public init(
         configuration: DatabaseConfiguration,
         logger: Logger,
         eventLoop: EventLoop,
-        history: QueryHistory? = nil
+        history: QueryHistory? = nil,
+        maxPerPage: Int? = nil
     ) {
         self.configuration = configuration
         self.logger = logger
         self.eventLoop = eventLoop
         self.history = history
+        self.maxPerPage = maxPerPage
     }
 }
 

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -98,7 +98,8 @@ public final class Databases {
         _ id: DatabaseID? = nil,
         logger: Logger,
         on eventLoop: EventLoop,
-        history: QueryHistory? = nil
+        history: QueryHistory? = nil,
+        maxPerPage: Int? = nil
     ) -> Database? {
         self.lock.lock()
         defer { self.lock.unlock() }
@@ -110,7 +111,8 @@ public final class Databases {
             configuration: configuration,
             logger: logger,
             eventLoop: eventLoop,
-            history: history
+            history: history,
+            maxPerPage: maxPerPage
         )
         let driver: DatabaseDriver
         if let existing = self.drivers[id] {

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -7,7 +7,6 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
     case relationNotLoaded(name: String)
     case missingParent
     case noResults
-    case maxPerPageValueExceeded
 
     public var description: String {
         switch self {
@@ -23,8 +22,6 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
             return "invalid field: \(name) type: \(valueType) error: \(error)"
         case .noResults:
             return "Query returned no results"
-        case .maxPerPageValueExceeded:
-            return "max allowed value exceeded for parameter: per"
         }
     }
 

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -7,6 +7,7 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
     case relationNotLoaded(name: String)
     case missingParent
     case noResults
+    case maxPerValueExceeded
 
     public var description: String {
         switch self {
@@ -22,6 +23,8 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
             return "invalid field: \(name) type: \(valueType) error: \(error)"
         case .noResults:
             return "Query returned no results"
+        case .maxPerValueExceeded:
+            return "max allowed value exceeded for parameter: per"
         }
     }
 

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -7,7 +7,7 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
     case relationNotLoaded(name: String)
     case missingParent
     case noResults
-    case maxPerValueExceeded
+    case maxPerPageValueExceeded
 
     public var description: String {
         switch self {
@@ -23,7 +23,7 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
             return "invalid field: \(name) type: \(valueType) error: \(error)"
         case .noResults:
             return "Query returned no results"
-        case .maxPerValueExceeded:
+        case .maxPerPageValueExceeded:
             return "max allowed value exceeded for parameter: per"
         }
     }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -9,11 +9,12 @@ extension QueryBuilder {
     ///     
     /// - Returns: A single `Page` of the result set containing the requested items and page metadata.
     public func paginate(
-        _ request: PageRequest,
-        maxPer: Int = 100
+        _ request: PageRequest
     ) -> EventLoopFuture<Page<Model>> {
-        guard request.per <= maxPer else {
-            return database.eventLoop.makeFailedFuture(FluentError.maxPerValueExceeded)
+        if let maxPerPage = database.context.maxPerPage {
+            guard request.per <= maxPerPage else {
+                return database.eventLoop.makeFailedFuture(FluentError.maxPerPageValueExceeded)
+            }
         }
         let count = self.count()
         let items = self.copy().range(request.start..<request.end).all()

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -6,6 +6,7 @@ extension QueryBuilder {
     /// - Parameters:
     ///     - request: Describes which page should be fetched.
     ///     - maxPer: If `per` value of supplied `PageRequest` exceeds this value an error will be thrown. Default is 100.
+    ///     
     /// - Returns: A single `Page` of the result set containing the requested items and page metadata.
     public func paginate(
         _ request: PageRequest,

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -5,8 +5,6 @@ extension QueryBuilder {
     ///
     /// - Parameters:
     ///     - request: Describes which page should be fetched.
-    ///     - maxPer: If `per` value of supplied `PageRequest` exceeds this value an error will be thrown. Default is 100.
-    ///     
     /// - Returns: A single `Page` of the result set containing the requested items and page metadata.
     public func paginate(
         _ request: PageRequest

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -109,10 +109,8 @@ final class QueryBuilderTests: XCTestCase {
         test.append(planets.map(TestOutput.init))
 
         let pageRequest = PageRequest(page: 1, per: 4)
-        let retrievedPlanets = Planet.query(on: db).paginate(pageRequest)
-        XCTAssertThrowsError(try retrievedPlanets.wait(), "Should throw error") { error in
-            XCTAssertEqual("\(error)", FluentError.maxPerPageValueExceeded.description)
-        }
+        let retrievedPlanets = try Planet.query(on: db).paginate(pageRequest).wait()
+        XCTAssertEqual(retrievedPlanets.items.count, 3)
     }
 
     // https://github.com/vapor/fluent-kit/issues/310


### PR DESCRIPTION
**Objective:** 
Implement a maximum `per` value for pagination in order to prevent the possibility of overloading the server by requesting very large datasets.

**Discussion:**
The simplest solution I have been able to come up with is overloading the `paginate` function on QueryBuilder:

```
extension QueryBuilder {
    /// Returns a single `Page` out of the complete result set according to the supplied `PageRequest`.
    ///
    /// This method will first `count()` the result set, then request a subset of the results using `range()` and `all()`.
    ///
    /// - Parameters:
    ///     - request: Describes which page should be fetched.
    ///     - maxPer: If `per` value of supplied `PageRequest` exceeds this value an error will be thrown. Default is 100.
    ///
    /// - Returns: A single `Page` of the result set containing the requested items and page metadata.
    public func paginate(
        _ request: PageRequest,
        maxPer: Int = 100
    ) -> EventLoopFuture<Page<Model>> {
        guard request.per <= maxPer else {
            return database.eventLoop.makeFailedFuture(FluentError.maxPerValueExceeded)
        }
        let count = self.count()
        let items = self.copy().range(request.start..<request.end).all()
        return items.and(count).map { (models, total) in
            Page(
                items: models,
                metadata: .init(
                    page: request.page,
                    per: request.per,
                    total: total
                )
            )
        }
    }
}
```

However, right now the limit is hardcoded and I am yet to find a good solution for making it globally configurable. Considerations:
- I would like to keep it in fluent-kit and not introduce any new dependencies
- fluent-kit is not dependent on Vapor and thus I can’t use any of the features offered by Vapor for setting global state
- Database has Context.Configuration that potentially could hold this value but it doesn’t really sit well with me to put it there