### PR TITLE
add discardable result to similar calls to where it already exists

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -55,7 +55,8 @@ public final class QueryBuilder<Model>
     }
 
     // MARK: Fields
-
+    
+    @discardableResult
     public func fields<Joined>(for model: Joined.Type) -> Self 
         where Joined: Schema & Fields
     {
@@ -69,12 +70,14 @@ public final class QueryBuilder<Model>
         }
     }
 
+    @discardableResult
     public func field<Field>(_ field: KeyPath<Model, Field>) -> Self
         where Field: QueryableProperty, Field.Model == Model
     {
         self.field(Model.self, field)
     }
 
+    @discardableResult
     public func field<Joined, Field>(_ joined: Joined.Type, _ field: KeyPath<Joined, Field>) -> Self
         where Joined: Schema, Field: QueryableProperty, Field.Model == Joined
     {
@@ -82,6 +85,7 @@ public final class QueryBuilder<Model>
         return self
     }
     
+    @discardableResult
     public func field(_ field: DatabaseQuery.Field) -> Self {
         self.query.fields.append(field)
         return self
@@ -89,6 +93,7 @@ public final class QueryBuilder<Model>
 
     // MARK: Soft Delete
 
+    @discardableResult
     public func withDeleted() -> Self {
         self.includeDeleted = true
         return self
@@ -114,7 +119,8 @@ public final class QueryBuilder<Model>
     }
 
     // MARK: Limit
-
+    
+    @discardableResult
     public func limit(_ count: Int) -> Self {
         self.query.limits.append(.count(count))
         return self
@@ -122,6 +128,7 @@ public final class QueryBuilder<Model>
 
     // MARK: Offset
 
+    @discardableResult
     public func offset(_ count: Int) -> Self {
         self.query.offsets.append(.count(count))
         return self
@@ -129,6 +136,7 @@ public final class QueryBuilder<Model>
 
     // MARK: Unqiue
 
+    @discardableResult
     public func unique() -> Self {
         self.query.isUnique = true
         return self
@@ -241,6 +249,7 @@ public final class QueryBuilder<Model>
         }
     }
 
+    @discardableResult
     internal func action(_ action: DatabaseQuery.Action) -> Self {
         self.query.action = action
         return self


### PR DESCRIPTION
Added some `@discardableResult` attributes to `QueryBuilder` functions that return `Self` but also mutate `self`. This prevents Xcode from generating some unused result warnings when making queries over multiple lines of logic.

Before a query like below would give an unused result warning for line calling `query.limit(:)`, this is now no longer the case for a handful of methods that were missing the appropriate attribute. This was mostly the case when applying intermediate logic on longer queries.

```swift
let planetFilter = ["Earth", "Mars"]
let query = Planet.query(on: db)
if !planetFilter.isEmpty {
   query.filter(/.$name ~~ planetFilter)
}
query.limit(10)
let result = query.all()
```