### PR TITLE
Avoid logging error on first enum migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,9 +104,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
+        uses: maxim-lobanov/setup-xcode@v1
         with: 
-          xcode-version: latest
+          xcode-version: latest-stable
       - name: Check out package
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer

--- a/Sources/FluentKit/Enum/EnumBuilder.swift
+++ b/Sources/FluentKit/Enum/EnumBuilder.swift
@@ -51,7 +51,7 @@ public final class EnumBuilder {
     // MARK: Private
 
     private func generateDatatype() -> EventLoopFuture<DatabaseSchema.DataType> {
-        self.initializeMetadata().flatMap {
+        EnumMetadata.migration.prepare(on: self.database).flatMap {
             self.updateMetadata()
         }.flatMap { _ in
             // Fetch the latest cases.
@@ -62,16 +62,6 @@ public final class EnumBuilder {
                 name: self.enum.name,
                 cases: cases.map { $0.case }
             ))
-        }
-    }
-
-    private func initializeMetadata() -> EventLoopFuture<Void> {
-        // Check to see if the table exists.
-        EnumMetadata.query(on: self.database).count().map { _ in
-            // Ignore count.
-        }.flatMapError { error in
-            // Table does not exist, create it.
-            EnumMetadata.migration.prepare(on: self.database)
         }
     }
 

--- a/Sources/FluentKit/Enum/EnumMetadata.swift
+++ b/Sources/FluentKit/Enum/EnumMetadata.swift
@@ -30,6 +30,7 @@ private struct EnumMetadataMigration: Migration {
             .field("name", .string, .required)
             .field("case", .string, .required)
             .unique(on: "name", "case")
+            .ignoreExisting()
             .create()
     }
 

--- a/Sources/FluentKit/Enum/EnumMetadata.swift
+++ b/Sources/FluentKit/Enum/EnumMetadata.swift
@@ -30,7 +30,7 @@ private struct EnumMetadataMigration: Migration {
             .field("name", .string, .required)
             .field("case", .string, .required)
             .unique(on: "name", "case")
-//            .ignoreExisting() // temporarily removed to see if existing tests catch this
+            .ignoreExisting()
             .create()
     }
 

--- a/Sources/FluentKit/Enum/EnumMetadata.swift
+++ b/Sources/FluentKit/Enum/EnumMetadata.swift
@@ -30,7 +30,7 @@ private struct EnumMetadataMigration: Migration {
             .field("name", .string, .required)
             .field("case", .string, .required)
             .unique(on: "name", "case")
-            .ignoreExisting()
+//            .ignoreExisting() // temporarily removed to see if existing tests catch this
             .create()
     }
 


### PR DESCRIPTION
Avoid logging `[ ERROR ] relation "_fluent_enums" does not exist (parserOpenTable)` the first time an enum is migrated. 

Fixes https://github.com/vapor/fluent/issues/717.