### PR TITLE
Make `ModelValueFilter.init` and `ModelFieldFilter.init` public

### DIFF
--- a/Sources/FluentKit/Operators/FieldOperators.swift
+++ b/Sources/FluentKit/Operators/FieldOperators.swift
@@ -179,7 +179,7 @@ public func !=~ <Left, Right, LeftField, RightField>(
 public struct ModelFieldFilter<Left, Right>
     where Left: FluentKit.Model, Right: FluentKit.Model
 {
-    init<LeftField, RightField>(
+    public init<LeftField, RightField>(
         _ lhs: KeyPath<Left, LeftField>,
         _ method: DatabaseQuery.Filter.Method,
         _ rhs: KeyPath<Right, RightField>

--- a/Sources/FluentKit/Operators/ValueOperators.swift
+++ b/Sources/FluentKit/Operators/ValueOperators.swift
@@ -96,7 +96,7 @@ public func <= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 }
 
 public struct ModelValueFilter<Model> where Model: Fields {
-    init<Field>(
+    public init<Field>(
         _ lhs: KeyPath<Model, Field>,
         _ method: DatabaseQuery.Filter.Method,
         _ rhs: DatabaseQuery.Value


### PR DESCRIPTION
Make `ModelValueFilter.init` and `ModelFieldFilter.init` public (#426)

Resolves #425.