### PR TITLE
Fix warnings from Swift 5.4 compiler

### DIFF
--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -1,4 +1,4 @@
-public protocol Fields: class, Codable {
+public protocol Fields: AnyObject, Codable {
     var properties: [AnyProperty] { get }
     init()
     func input(to input: DatabaseInput)

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -1,4 +1,4 @@
-public protocol AnyProperty: class {
+public protocol AnyProperty: AnyObject {
     static var anyValueType: Any.Type { get }
     var anyValue: Any? { get }
 }


### PR DESCRIPTION
Fixes the following warnings now produced by the Swift 5.4 compiler:

```
warning: using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead
public protocol Fields: class, Codable {
                        ^~~~~
                        AnyObject
```
