### PR TITLE
Add async/await APIs to FluentKit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,9 @@ jobs:
           - swiftlang/swift:nightly-5.3-bionic
           - swiftlang/swift:nightly-5.3-focal
           - swiftlang/swift:nightly-5.3-amazonlinux2
+          - swiftlang/swift:nightly-5.4-bionic
+          - swiftlang/swift:nightly-5.4-focal
+          - swiftlang/swift:nightly-5.4-amazonlinux2
     container: ${{ matrix.image }}
     steps:
       - name: Checkout code

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
     targets: [
         .target(name: "FluentKit", dependencies: [
             .product(name: "NIO", package: "swift-nio"),
+            .product(name: "_NIOConcurrency", package: "swift-nio"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "AsyncKit", package: "async-kit"),
         ]),

--- a/Sources/FluentKit/Concurrency/AsyncMigration.swift
+++ b/Sources/FluentKit/Concurrency/AsyncMigration.swift
@@ -15,7 +15,7 @@ public extension AsyncMigration {
         }
         return promise.futureResult
     }
-
+    
     func revert(on database: Database) -> EventLoopFuture<Void> {
         let promise = database.eventLoop.makePromise(of: Void.self)
         promise.completeWithAsync {

--- a/Sources/FluentKit/Concurrency/AsyncMigration.swift
+++ b/Sources/FluentKit/Concurrency/AsyncMigration.swift
@@ -1,0 +1,29 @@
+#if compiler(>=5.5) && $AsyncAwait
+import _NIOConcurrency
+
+public protocol AsyncMigration: Migration {
+    func prepare(on database: Database) async throws
+    func revert(on database: Database) async throws
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension AsyncMigration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        let promise = database.eventLoop.makePromise(of: Void.self)
+        promise.completeWithAsync {
+            try await self.prepare(on: database)
+        }
+        return promise.futureResult
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        let promise = database.eventLoop.makePromise(of: Void.self)
+        promise.completeWithAsync {
+            try await self.revert(on: database)
+        }
+        return promise.futureResult
+    }
+}
+
+#endif
+

--- a/Sources/FluentKit/Concurrency/Children+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Children+Concurrency.swift
@@ -1,20 +1,20 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension ChildrenProperty {
-
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension ChildrenProperty {
+    
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
-
+    
     func create(_ to: To, on database: Database) async throws {
         try await self.create(to, on: database).get()
     }
-
+    
     func create(_ to: [To], on database: Database) async throws {
         try await self.create(to, on: database).get()
     }
- }
+}
 
- #endif
+#endif

--- a/Sources/FluentKit/Concurrency/Children+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Children+Concurrency.swift
@@ -1,0 +1,20 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension ChildrenProperty {
+
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
+
+    func create(_ to: To, on database: Database) async throws {
+        try await self.create(to, on: database).get()
+    }
+
+    func create(_ to: [To], on database: Database) async throws {
+        try await self.create(to, on: database).get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/EnumBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/EnumBuilder+Concurrency.swift
@@ -1,0 +1,23 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension EnumBuilder {
+    func create() async throws -> DatabaseSchema.DataType {
+        try await self.create().get()
+    }
+
+    func read() async throws -> DatabaseSchema.DataType {
+        try await self.read().get()
+    }
+
+    func update() async throws -> DatabaseSchema.DataType {
+        try await self.update().get()
+    }
+
+    func delete() async throws {
+        try await self.delete().get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/EnumBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/EnumBuilder+Concurrency.swift
@@ -1,23 +1,23 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension EnumBuilder {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension EnumBuilder {
     func create() async throws -> DatabaseSchema.DataType {
         try await self.create().get()
     }
-
+    
     func read() async throws -> DatabaseSchema.DataType {
         try await self.read().get()
     }
-
+    
     func update() async throws -> DatabaseSchema.DataType {
         try await self.update().get()
     }
-
+    
     func delete() async throws {
         try await self.delete().get()
     }
- }
+}
 
- #endif
+#endif

--- a/Sources/FluentKit/Concurrency/Model+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Model+Concurrency.swift
@@ -9,6 +9,38 @@
     ) async throws -> Self? {
         try await self.find(id, on: database).get()
     }
+
+    // MARK: - CRUD
+    func save(on database: Database) async throws {
+        try await self.save(on: database).get()
+    }
+
+    func create(on database: Database) async throws {
+        try await self.create(on: database).get()
+    }
+
+    func update(on database: Database) async throws {
+        try await self.update(on: database).get()
+    }
+
+    func delete(force: Bool = false, on database: Database) async throws {
+        try await self.delete(force: force, on: database).get()
+    }
+
+    func restore(on database: Database) async throws {
+        try await self.restore(on: database).get()
+    }
  }
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension Collection where Element: FluentKit.Model {
+    func delete(force: Bool = false, on database: Database) async throws {
+        try await self.delete(force: force, on: database).get()
+    }
+
+    func create(on database: Database) async throws {
+        try await self.create(on: database).get()
+    }
+}
 
  #endif

--- a/Sources/FluentKit/Concurrency/Model+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Model+Concurrency.swift
@@ -9,24 +9,24 @@ public extension Model {
     ) async throws -> Self? {
         try await self.find(id, on: database).get()
     }
-
+    
     // MARK: - CRUD
     func save(on database: Database) async throws {
         try await self.save(on: database).get()
     }
-
+    
     func create(on database: Database) async throws {
         try await self.create(on: database).get()
     }
-
+    
     func update(on database: Database) async throws {
         try await self.update(on: database).get()
     }
-
+    
     func delete(force: Bool = false, on database: Database) async throws {
         try await self.delete(force: force, on: database).get()
     }
-
+    
     func restore(on database: Database) async throws {
         try await self.restore(on: database).get()
     }
@@ -37,7 +37,7 @@ public extension Collection where Element: FluentKit.Model {
     func delete(force: Bool = false, on database: Database) async throws {
         try await self.delete(force: force, on: database).get()
     }
-
+    
     func create(on database: Database) async throws {
         try await self.create(on: database).get()
     }

--- a/Sources/FluentKit/Concurrency/Model+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Model+Concurrency.swift
@@ -1,8 +1,8 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension Model {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension Model {
     static func find(
         _ id: Self.IDValue?,
         on database: Database
@@ -30,7 +30,7 @@
     func restore(on database: Database) async throws {
         try await self.restore(on: database).get()
     }
- }
+}
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public extension Collection where Element: FluentKit.Model {
@@ -43,4 +43,4 @@ public extension Collection where Element: FluentKit.Model {
     }
 }
 
- #endif
+#endif

--- a/Sources/FluentKit/Concurrency/Model+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Model+Concurrency.swift
@@ -1,0 +1,14 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension Model {
+    static func find(
+        _ id: Self.IDValue?,
+        on database: Database
+    ) async throws -> Self? {
+        try await self.find(id, on: database).get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/ModelMiddleware+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/ModelMiddleware+Concurrency.swift
@@ -1,27 +1,27 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension ModelMiddleware {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension ModelMiddleware {
     func create(model: Model, on db: Database, next: AnyModelResponder) async throws {
         try await self.create(model: model, on: db, next: next).get()
     }
-
+    
     func update(model: Model, on db: Database, next: AnyModelResponder) async throws {
         try await self.update(model: model, on: db, next: next).get()
     }
-
+    
     func delete(model: Model, force: Bool, on db: Database, next: AnyModelResponder) async throws {
         try await self.delete(model: model, force: force, on: db, next: next).get()
     }
-
+    
     func softDelete(model: Model, on db: Database, next: AnyModelResponder) async throws {
         try await self.softDelete(model: model, on: db, next: next).get()
     }
-
+    
     func restore(model: Model, on db: Database, next: AnyModelResponder) async throws {
         try await self.restore(model: model, on: db, next: next).get()
     }
- }
+}
 
- #endif
+#endif

--- a/Sources/FluentKit/Concurrency/ModelMiddleware+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/ModelMiddleware+Concurrency.swift
@@ -1,0 +1,27 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension ModelMiddleware {
+    func create(model: Model, on db: Database, next: AnyModelResponder) async throws {
+        try await self.create(model: model, on: db, next: next).get()
+    }
+
+    func update(model: Model, on db: Database, next: AnyModelResponder) async throws {
+        try await self.update(model: model, on: db, next: next).get()
+    }
+
+    func delete(model: Model, force: Bool, on db: Database, next: AnyModelResponder) async throws {
+        try await self.delete(model: model, force: force, on: db, next: next).get()
+    }
+
+    func softDelete(model: Model, on db: Database, next: AnyModelResponder) async throws {
+        try await self.softDelete(model: model, on: db, next: next).get()
+    }
+
+    func restore(model: Model, on db: Database, next: AnyModelResponder) async throws {
+        try await self.restore(model: model, on: db, next: next).get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
@@ -1,16 +1,16 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension OptionalChildProperty {
-
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension OptionalChildProperty {
+    
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
-
+    
     func create(_ to: To, on database: Database) async throws {
         try await self.create(to, on: database).get()
     }
- }
+}
 
- #endif
+#endif

--- a/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
@@ -1,0 +1,16 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension OptionalChildProperty {
+
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
+
+    func create(_ to: To, on database: Database) async throws {
+        try await self.create(to, on: database).get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/OptionalParent+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalParent+Concurrency.swift
@@ -1,12 +1,12 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public extension OptionalParentProperty {
-   func load(on database: Database) async throws {
-       try await self.load(on: database).get()
-   }
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
 }
 
- #endif
+#endif
 

--- a/Sources/FluentKit/Concurrency/OptionalParent+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalParent+Concurrency.swift
@@ -1,0 +1,12 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension OptionalParentProperty {
+   func load(on database: Database) async throws {
+       try await self.load(on: database).get()
+   }
+}
+
+ #endif
+

--- a/Sources/FluentKit/Concurrency/Parent+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Parent+Concurrency.swift
@@ -1,12 +1,12 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension ParentProperty {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension ParentProperty {
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
- }
+}
 
- #endif
+#endif
 

--- a/Sources/FluentKit/Concurrency/Parent+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Parent+Concurrency.swift
@@ -1,0 +1,12 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension ParentProperty {
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
+ }
+
+ #endif
+

--- a/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
@@ -176,6 +176,13 @@
     {
         try await self.aggregate(method, path, as: type).get()
     }
+
+    // MARK: - Paginate
+    func paginate(
+        _ request: PageRequest
+    ) async throws -> Page<Model> {
+        try await self.paginate(request).get()
+    }
  }
 
  #endif

--- a/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
@@ -1,188 +1,188 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension QueryBuilder {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension QueryBuilder {
     // MARK: - Actions
     func create() async throws {
         try await self.create().get()
     }
-
+    
     func update() async throws {
         try await self.update().get()
     }
-
+    
     func delete(force: Bool = false) async throws {
         try await self.delete(force: force).get()
     }
-
+    
     // MARK: - Fetch
-
+    
     func chunk(max: Int, closure: @escaping ([Result<Model, Error>]) -> ()) async throws {
         try await self.chunk(max: max, closure: closure).get()
     }
-
+    
     func first() async throws -> Model? {
         try await self.first().get()
     }
-
+    
     func all<Field>(_ key: KeyPath<Model, Field>) async throws -> [Field.Value]
-        where
-            Field: QueryableProperty,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Model == Model
     {
         try await self.all(key).get()
     }
-
+    
     func all<Joined, Field>(
         _ joined: Joined.Type,
         _ field: KeyPath<Joined, Field>
     ) async throws -> [Field.Value]
-        where
-            Joined: Schema,
-            Field: QueryableProperty,
-            Field.Model == Joined
+    where
+        Joined: Schema,
+        Field: QueryableProperty,
+        Field.Model == Joined
     {
         try await self.all(joined, field).get()
     }
-
+    
     func all() async throws -> [Model] {
         try await self.all().get()
     }
-
+    
     func run() async throws {
         try await self.run().get()
     }
-
+    
     func all(_ onOutput: @escaping (Result<Model, Error>) -> ()) async throws {
         try await self.all(onOutput).get()
     }
-
+    
     func run(_ onOutput: @escaping (DatabaseOutput) -> ()) async throws {
         try await self.run(onOutput).get()
     }
-
+    
     // MARK: - Aggregate
     func count() async throws -> Int {
         try await self.count().get()
     }
-
+    
     func count<Field>(_ key: KeyPath<Model, Field>) async throws  -> Int
-        where
-            Field: QueryableProperty,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Model == Model
     {
         try await self.count(key).get()
     }
-
+    
     func sum<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value?
-        where
-            Field: QueryableProperty,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Model == Model
     {
         try await self.sum(key).get()
     }
-
+    
     func sum<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value
-        where
-            Field: QueryableProperty,
-            Field.Value: OptionalType,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Model == Model
     {
         try await self.sum(key).get()
     }
-
+    
     func average<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value?
-        where
-            Field: QueryableProperty,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Model == Model
     {
         try await self.average(key).get()
     }
-
+    
     func average<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value
-        where
-            Field: QueryableProperty,
-            Field.Value: OptionalType,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Model == Model
     {
         try await self.average(key).get()
     }
-
+    
     func min<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value?
-        where
-            Field: QueryableProperty,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Model == Model
     {
         try await self.min(key).get()
     }
-
+    
     func min<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value
-        where
-            Field: QueryableProperty,
-            Field.Value: OptionalType,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Model == Model
     {
         try await self.min(key).get()
     }
-
+    
     func max<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value?
-        where
-            Field: QueryableProperty,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Model == Model
     {
         try await self.max(key).get()
     }
-
+    
     func max<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value
-        where
-            Field: QueryableProperty,
-            Field.Value: OptionalType,
-            Field.Model == Model
+    where
+        Field: QueryableProperty,
+        Field.Value: OptionalType,
+        Field.Model == Model
     {
         try await self.max(key).get()
     }
-
+    
     func aggregate<Field, Result>(
         _ method: DatabaseQuery.Aggregate.Method,
         _ field: KeyPath<Model, Field>,
         as type: Result.Type = Result.self
     ) async throws -> Result
-        where
-            Field: QueryableProperty,
-            Field.Model == Model,
-            Result: Codable
+    where
+        Field: QueryableProperty,
+        Field.Model == Model,
+        Result: Codable
     {
         try await self.aggregate(method, field, as: type).get()
     }
-
-
+    
+    
     func aggregate<Result>(
         _ method: DatabaseQuery.Aggregate.Method,
         _ field: FieldKey,
         as type: Result.Type = Result.self
     ) async throws -> Result
-        where Result: Codable
+    where Result: Codable
     {
         try await self.aggregate(method, field, as: type).get()
     }
-
+    
     func aggregate<Result>(
         _ method: DatabaseQuery.Aggregate.Method,
         _ path: [FieldKey],
         as type: Result.Type = Result.self
     ) async throws -> Result
-        where Result: Codable
+    where Result: Codable
     {
         try await self.aggregate(method, path, as: type).get()
     }
-
+    
     // MARK: - Paginate
     func paginate(
         _ request: PageRequest
     ) async throws -> Page<Model> {
         try await self.paginate(request).get()
     }
- }
+}
 
- #endif
+#endif

--- a/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
@@ -1,0 +1,66 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension QueryBuilder {
+    // MARK: - Actions
+    func create() async throws {
+        try await self.create().get()
+    }
+
+    func update() async throws {
+        try await self.update().get()
+    }
+
+    func delete(force: Bool = false) async throws {
+        try await self.delete(force: force).get()
+    }
+
+    // MARK: - Fetch
+
+    func chunk(max: Int, closure: @escaping ([Result<Model, Error>]) -> ()) async throws {
+        try await self.chunk(max: max, closure: closure).get()
+    }
+
+    func first() async throws -> Model? {
+        try await self.first().get()
+    }
+
+    func all<Field>(_ key: KeyPath<Model, Field>) async throws -> [Field.Value]
+        where
+            Field: QueryableProperty,
+            Field.Model == Model
+    {
+        try await self.all(key).get()
+    }
+
+    func all<Joined, Field>(
+        _ joined: Joined.Type,
+        _ field: KeyPath<Joined, Field>
+    ) async throws -> [Field.Value]
+        where
+            Joined: Schema,
+            Field: QueryableProperty,
+            Field.Model == Joined
+    {
+        try await self.all(joined, field).get()
+    }
+
+    func all() async throws -> [Model] {
+        try await self.all().get()
+    }
+
+    func run() async throws {
+        try await self.run().get()
+    }
+
+    func all(_ onOutput: @escaping (Result<Model, Error>) -> ()) async throws {
+        try await self.all(onOutput).get()
+    }
+
+    func run(_ onOutput: @escaping (DatabaseOutput) -> ()) async throws {
+        try await self.run(onOutput).get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
@@ -61,6 +61,121 @@
     func run(_ onOutput: @escaping (DatabaseOutput) -> ()) async throws {
         try await self.run(onOutput).get()
     }
+
+    // MARK: - Aggregate
+    func count() async throws -> Int {
+        try await self.count().get()
+    }
+
+    func count<Field>(_ key: KeyPath<Model, Field>) async throws  -> Int
+        where
+            Field: QueryableProperty,
+            Field.Model == Model
+    {
+        try await self.count(key).get()
+    }
+
+    func sum<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value?
+        where
+            Field: QueryableProperty,
+            Field.Model == Model
+    {
+        try await self.sum(key).get()
+    }
+
+    func sum<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value
+        where
+            Field: QueryableProperty,
+            Field.Value: OptionalType,
+            Field.Model == Model
+    {
+        try await self.sum(key).get()
+    }
+
+    func average<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value?
+        where
+            Field: QueryableProperty,
+            Field.Model == Model
+    {
+        try await self.average(key).get()
+    }
+
+    func average<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value
+        where
+            Field: QueryableProperty,
+            Field.Value: OptionalType,
+            Field.Model == Model
+    {
+        try await self.average(key).get()
+    }
+
+    func min<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value?
+        where
+            Field: QueryableProperty,
+            Field.Model == Model
+    {
+        try await self.min(key).get()
+    }
+
+    func min<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value
+        where
+            Field: QueryableProperty,
+            Field.Value: OptionalType,
+            Field.Model == Model
+    {
+        try await self.min(key).get()
+    }
+
+    func max<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value?
+        where
+            Field: QueryableProperty,
+            Field.Model == Model
+    {
+        try await self.max(key).get()
+    }
+
+    func max<Field>(_ key: KeyPath<Model, Field>) async throws -> Field.Value
+        where
+            Field: QueryableProperty,
+            Field.Value: OptionalType,
+            Field.Model == Model
+    {
+        try await self.max(key).get()
+    }
+
+    func aggregate<Field, Result>(
+        _ method: DatabaseQuery.Aggregate.Method,
+        _ field: KeyPath<Model, Field>,
+        as type: Result.Type = Result.self
+    ) async throws -> Result
+        where
+            Field: QueryableProperty,
+            Field.Model == Model,
+            Result: Codable
+    {
+        try await self.aggregate(method, field, as: type).get()
+    }
+
+
+    func aggregate<Result>(
+        _ method: DatabaseQuery.Aggregate.Method,
+        _ field: FieldKey,
+        as type: Result.Type = Result.self
+    ) async throws -> Result
+        where Result: Codable
+    {
+        try await self.aggregate(method, field, as: type).get()
+    }
+
+    func aggregate<Result>(
+        _ method: DatabaseQuery.Aggregate.Method,
+        _ path: [FieldKey],
+        as type: Result.Type = Result.self
+    ) async throws -> Result
+        where Result: Codable
+    {
+        try await self.aggregate(method, path, as: type).get()
+    }
  }
 
  #endif

--- a/Sources/FluentKit/Concurrency/Relation+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Relation+Concurrency.swift
@@ -1,0 +1,11 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension Relation {
+    func get(reload: Bool = false, on database: Database) async throws -> RelatedValue {
+        try await self.get(reload: reload, on: database).get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/Relation+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Relation+Concurrency.swift
@@ -1,11 +1,11 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension Relation {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension Relation {
     func get(reload: Bool = false, on database: Database) async throws -> RelatedValue {
         try await self.get(reload: reload, on: database).get()
     }
- }
+}
 
- #endif
+#endif

--- a/Sources/FluentKit/Concurrency/SchemaBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/SchemaBuilder+Concurrency.swift
@@ -1,0 +1,19 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension SchemaBuilder {
+    func create() async throws {
+        try await self.create().get()
+    }
+
+    func update() async throws {
+        try await self.update().get()
+    }
+
+    func delete() async throws {
+        try await self.delete().get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/SchemaBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/SchemaBuilder+Concurrency.swift
@@ -1,19 +1,19 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension SchemaBuilder {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension SchemaBuilder {
     func create() async throws {
         try await self.create().get()
     }
-
+    
     func update() async throws {
         try await self.update().get()
     }
-
+    
     func delete() async throws {
         try await self.delete().get()
     }
- }
+}
 
- #endif
+#endif

--- a/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
@@ -1,0 +1,53 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+
+ @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+ public extension SiblingsProperty {
+    // MARK: Checking state
+
+    func isAttached(to: To, on database: Database) async throws -> Bool {
+        try await self.isAttached(to: to, on: database).get()
+    }
+
+    func isAttached(toID: To.IDValue, on database: Database) async throws -> Bool {
+        try await self.isAttached(toID: toID, on: database).get()
+    }
+
+    // MARK: Operations
+
+    func attach(
+        _ tos: [To],
+        on database: Database,
+        _ edit: (Through) -> () = { _ in }
+    ) async throws {
+        try await self.attach(tos, on: database, edit).get()
+    }
+
+    func attach(
+        _ to: To,
+        method: AttachMethod,
+        on database: Database,
+        _ edit: @escaping (Through) -> () = { _ in }
+    ) async throws {
+        try await self.attach(to, method: method, on: database, edit).get()
+    }
+
+    func attach(
+        _ to: To,
+        on database: Database,
+        _ edit: (Through) -> () = { _ in }
+    ) async throws {
+        try await self.attach(to, on: database, edit).get()
+    }
+
+
+    func detach(_ tos: [To], on database: Database) async throws {
+        try await self.detach(tos, on: database).get()
+    }
+
+    func detach(_ to: To, on database: Database) async throws {
+        try await self.detach(to, on: database).get()
+    }
+ }
+
+ #endif

--- a/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
@@ -3,6 +3,11 @@
 
  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
  public extension SiblingsProperty {
+
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
+
     // MARK: Checking state
 
     func isAttached(to: To, on database: Database) async throws -> Bool {

--- a/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
@@ -1,25 +1,25 @@
 #if compiler(>=5.5) && $AsyncAwait
- import _NIOConcurrency
+import _NIOConcurrency
 
- @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
- public extension SiblingsProperty {
-
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public extension SiblingsProperty {
+    
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
-
+    
     // MARK: Checking state
-
+    
     func isAttached(to: To, on database: Database) async throws -> Bool {
         try await self.isAttached(to: to, on: database).get()
     }
-
+    
     func isAttached(toID: To.IDValue, on database: Database) async throws -> Bool {
         try await self.isAttached(toID: toID, on: database).get()
     }
-
+    
     // MARK: Operations
-
+    
     func attach(
         _ tos: [To],
         on database: Database,
@@ -27,7 +27,7 @@
     ) async throws {
         try await self.attach(tos, on: database, edit).get()
     }
-
+    
     func attach(
         _ to: To,
         method: AttachMethod,
@@ -36,7 +36,7 @@
     ) async throws {
         try await self.attach(to, method: method, on: database, edit).get()
     }
-
+    
     func attach(
         _ to: To,
         on database: Database,
@@ -44,15 +44,15 @@
     ) async throws {
         try await self.attach(to, on: database, edit).get()
     }
-
-
+    
+    
     func detach(_ tos: [To], on database: Database) async throws {
         try await self.detach(tos, on: database).get()
     }
-
+    
     func detach(_ to: To, on database: Database) async throws {
         try await self.detach(to, on: database).get()
     }
- }
+}
 
- #endif
+#endif

--- a/Sources/FluentKit/Middleware/ModelMiddleware.swift
+++ b/Sources/FluentKit/Middleware/ModelMiddleware.swift
@@ -1,3 +1,7 @@
+#if compiler(>=5.5) && $AsyncAwait
+ import _NIOConcurrency
+#endif
+
 public protocol AnyModelMiddleware {
     func handle(
         _ event: ModelEvent,
@@ -15,6 +19,19 @@ public protocol ModelMiddleware: AnyModelMiddleware {
     func delete(model: Model, force: Bool, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void>
     func softDelete(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void>
     func restore(model: Model, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void>
+
+    #if compiler(>=5.5) && $AsyncAwait
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    func create(model: Model, on db: Database, next: AnyModelResponder) async throws
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    func update(model: Model, on db: Database, next: AnyModelResponder) async throws
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    func delete(model: Model, force: Bool, on db: Database, next: AnyModelResponder) async throws
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    func softDelete(model: Model, on db: Database, next: AnyModelResponder) async throws
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    func restore(model: Model, on db: Database, next: AnyModelResponder) async throws
+    #endif
 }
 
 extension ModelMiddleware {


### PR DESCRIPTION
Adds support for async/await to FluentKit. This initially adds async APIS most public APIs that return `EventLoopFuture`. This PR also introduces a new `AsyncMigration` to provide an async API for migrations

This PR will be merged when async/await functionality lands in Swift and NIO and will be kept in the branch until then.