### PR TITLE
Fix crash with negative `page` or `per` values

### DIFF
--- a/Sources/FluentBenchmark/Tests/PaginationTests.swift
+++ b/Sources/FluentBenchmark/Tests/PaginationTests.swift
@@ -46,4 +46,23 @@ extension FluentBenchmarker {
             }
         }
     }
+
+    public func testPaginationDoesntCrashWithInvalidValues() throws {
+        try self.runTest(#function, [
+            SolarSystem()
+        ]) {
+            do {
+                _ = try Planet.query(on: self.database)
+                    .sort(\.$name)
+                    .paginate(PageRequest(page: -1, per: 2))
+                    .wait()
+            }
+            do {
+                _ = try Planet.query(on: self.database)
+                    .sort(\.$name)
+                    .paginate(PageRequest(page: 2, per: -2))
+                    .wait()
+            }
+        }
+    }
 }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -10,10 +10,13 @@ extension QueryBuilder {
         _ request: PageRequest
     ) -> EventLoopFuture<Page<Model>> {
         let trimmedRequest: PageRequest = {
-            guard let pageSizeLimit = database.context.pageSizeLimit else { return request }
+            guard let pageSizeLimit = database.context.pageSizeLimit else {
+                return .init(page: Swift.max(request.page, 1), per: Swift.max(request.per, 1))
+
+            }
             return .init(
-                page: request.page,
-                per: Swift.min(request.per, pageSizeLimit)
+                page: Swift.max(request.page, 1),
+                per: Swift.max(Swift.min(request.per, pageSizeLimit), 1)
             )
         }()
         let count = self.count()
@@ -116,4 +119,8 @@ public struct PageRequest: Decodable {
     var end: Int {
         self.page * self.per
     }
+}
+
+public struct PaginationError: Error {
+    public let message: String
 }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -120,7 +120,3 @@ public struct PageRequest: Decodable {
         self.page * self.per
     }
 }
-
-public struct PaginationError: Error {
-    public let message: String
-}

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -12,7 +12,6 @@ extension QueryBuilder {
         let trimmedRequest: PageRequest = {
             guard let pageSizeLimit = database.context.pageSizeLimit else {
                 return .init(page: Swift.max(request.page, 1), per: Swift.max(request.per, 1))
-
             }
             return .init(
                 page: Swift.max(request.page, 1),

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -524,6 +524,21 @@ final class FluentKitTests: XCTestCase {
         _ = builder.fields(for: User.self)
         XCTAssertEqual(builder.query.fields.count, 9)
     }
+
+    func testPaginationDoesntCrashWithNegativeNumbers() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        let pageRequest1 = PageRequest(page: -1, per: 10)
+        XCTAssertNoThrow(try Planet2
+            .query(on: db)
+            .paginate(pageRequest1)
+            .wait())
+
+        let pageRequest2 = PageRequest(page: 1, per: -10)
+        XCTAssertNoThrow(try Planet2
+            .query(on: db)
+            .paginate(pageRequest2)
+            .wait())
+    }
 }
 
 final class User: Model {


### PR DESCRIPTION
This fixes an issue where specifying a negative page number of number of items in a pagination request caused FluentKit to crash. Resolves #434 