### PR TITLE
Add async for closure in `Database.transaction async`

### DIFF
--- a/Sources/FluentKit/Concurrency/Database+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Database+Concurrency.swift
@@ -3,12 +3,20 @@ import _NIOConcurrency
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public extension Database {
-    func transaction<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) async throws -> T {
-        try await self.transaction(closure).get()
+    func transaction<T>(_ closure: @escaping (Database) async throws -> T) async throws -> T {
+        try await self.transaction { db -> EventLoopFuture<T> in
+            let promise = self.eventLoop.makePromise(of: T.self)
+            promise.completeWithAsync{ try await closure(db) }
+            return promise.futureResult
+        }.get()
     }
 
-    func withConnection<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) async throws -> T {
-        try await self.withConnection(closure).get()
+    func withConnection<T>(_ closure: @escaping (Database) async throws -> T) async throws -> T {
+        try await self.withConnection { db -> EventLoopFuture<T> in
+            let promise = self.eventLoop.makePromise(of: T.self)
+            promise.completeWithAsync{ try await closure(db) }
+            return promise.futureResult
+        }.get()
     }
 }
 


### PR DESCRIPTION
Probably this is what we want. If so, I can update the other function in this file too.

To be clear this allows:

```swift
let model = try await db.transaction { db -> Model in
     let foo = try await Model.query(on: db).first()
     foo.bar = 1
    try await foo.update(on: db)
}
```

Rather than:

```swift
let model = try await db.transaction { db in
     Model.query(on: db).first().flatMap { … }
}
```
