### PR TITLE
Remove `Codable` restriction on `Page.map`

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -48,9 +48,7 @@ public struct Page<T> {
     }
 
     /// Maps a page's items to a different type using the supplied closure.
-    public func map<U>(_ transform: (T) throws -> (U)) rethrows -> Page<U>
-        where U: Codable
-    {
+    public func map<U>(_ transform: (T) throws -> (U)) rethrows -> Page<U> {
         try .init(
             items: self.items.map(transform),
             metadata: self.metadata


### PR DESCRIPTION
Allow `map`ing items in a `Page` to non-Codable types (#440).

Since https://github.com/vapor/fluent-kit/pull/435 this restriction is no longer necessary.
