### PR TITLE
ensure optional enum keys are represented for bulk insert

### DIFF
--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -79,6 +79,8 @@ extension OptionalEnumProperty: AnyDatabaseProperty {
     public func input(to input: DatabaseInput) {
         if let value = self.value {
             input.set(value.map { .enumCase($0.rawValue) } ?? .null, at: self.field.key)
+        } else {
+            input.set(.null, at: self.field.key)
         }
     }
 

--- a/Sources/FluentKit/Properties/OptionalField.swift
+++ b/Sources/FluentKit/Properties/OptionalField.swift
@@ -62,7 +62,7 @@ extension OptionalFieldProperty: Property {
             if let value = newValue {
                 self.inputValue = value.flatMap { .bind($0) } ?? .null
             } else {
-                self.inputValue = nil
+                self.inputValue = .null
             }
         }
     }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -539,6 +539,44 @@ final class FluentKitTests: XCTestCase {
             .paginate(pageRequest2)
             .wait())
     }
+
+    func testBulkInsertWithMixedOptionalsDoesntCrash() throws {
+        enum Effort: String, Codable {
+            case moderate
+            case strenuous
+        }
+
+        final class Workout: Model {
+            static let schema = "workouts"
+
+            @ID var id: UUID?
+
+            @Field(key: "name")
+            var name: String
+
+            @OptionalField(key: "distance")
+            var distance: Double?
+
+            @OptionalEnum(key: "effort")
+            var effort: Effort?
+
+            init() {}
+
+            init(id: UUID? = nil, name: String, distance: Double? = nil, effort: Effort? = nil) {
+                self.id = id
+                self.name = name
+                self.distance = distance
+                self.effort = effort
+            }
+        }
+
+        let db = DummyDatabaseForTestSQLSerializer()
+        let workouts = [
+            Workout(name: "Yoga", distance: nil, effort: .moderate),
+            Workout(name: "Running", distance: 3.1, effort: nil),
+        ]
+        XCTAssertNoThrow(try workouts.create(on: db).wait())
+    }
 }
 
 final class User: Model {

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -541,41 +541,26 @@ final class FluentKitTests: XCTestCase {
     }
 
     func testBulkInsertWithMixedOptionalsDoesntCrash() throws {
-        enum Effort: String, Codable {
-            case moderate
-            case strenuous
-        }
-
-        final class Workout: Model {
-            static let schema = "workouts"
-
-            @ID var id: UUID?
-
-            @Field(key: "name")
-            var name: String
-
-            @OptionalField(key: "distance")
-            var distance: Double?
-
-            @OptionalEnum(key: "effort")
-            var effort: Effort?
-
-            init() {}
-
-            init(id: UUID? = nil, name: String, distance: Double? = nil, effort: Effort? = nil) {
-                self.id = id
-                self.name = name
-                self.distance = distance
-                self.effort = effort
-            }
-        }
-
         let db = DummyDatabaseForTestSQLSerializer()
         let workouts = [
             Workout(name: "Yoga", distance: nil, effort: .moderate),
             Workout(name: "Running", distance: 3.1, effort: nil),
         ]
         XCTAssertNoThrow(try workouts.create(on: db).wait())
+    }
+    
+    func testUpdateOptionalEnumToNil() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        let workout = Workout(name: "Yoga", distance: nil, effort: .moderate)
+        _ = try workout.save(on: db).wait()
+        workout.effort = nil
+        XCTAssertNil(workout.effort)
+        _ = try workout.update(on: db).wait()
+        XCTAssertEqual(db.sqlSerializers.count, 2)
+        XCTAssertEqual(
+            db.sqlSerializers.last?.sql,
+            #"UPDATE "workouts" SET "effort" = NULL WHERE "workouts"."id" = $1"#
+        )
     }
 }
 
@@ -684,5 +669,34 @@ final class Planet2: Model {
         self.id = id
         self.name = name
         self.moonCount = moonCount
+    }
+}
+
+final class Workout: Model {
+    enum Effort: String, Codable {
+        case moderate
+        case strenuous
+    }
+    
+    static let schema = "workouts"
+
+    @ID var id: UUID?
+
+    @Field(key: "name")
+    var name: String
+
+    @OptionalField(key: "distance")
+    var distance: Double?
+
+    @OptionalEnum(key: "effort")
+    var effort: Effort?
+
+    init() {}
+
+    init(id: UUID? = nil, name: String, distance: Double? = nil, effort: Effort? = nil) {
+        self.id = id
+        self.name = name
+        self.distance = distance
+        self.effort = effort
     }
 }


### PR DESCRIPTION
I'm running into the exact issue described in #396. I can't do batch model inserts with certain combinations of optional fields and enums. It's a major blocker for my app -- as far as I can tell, my only workaround would be to create individual insert requests for each model. But this is a big problem, I have hundreds of records to insert at a time (think something like an app that ingests logs).

I'm not sure honestly how to fix the underlying issue, but at least here's a failing test. I'm hoping that might kickstart someone with more knowledge than me to fix the bug if it's straightforward.

Failing that, if someone could give me a decent description of how to go about the fix myself, I'm definitely willing to try.

Thanks so much!  I'm loving Vapor so far! 🙏 

Fixes #396.
Fixes #444.