### PR TITLE
Use new concurrency verbage

### DIFF
--- a/Sources/FluentKit/Concurrency/AsyncMigration.swift
+++ b/Sources/FluentKit/Concurrency/AsyncMigration.swift
@@ -11,7 +11,7 @@ public protocol AsyncMigration: Migration {
 public extension AsyncMigration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         let promise = database.eventLoop.makePromise(of: Void.self)
-        promise.completeWithAsync {
+        promise.completeWithTask {
             try await self.prepare(on: database)
         }
         return promise.futureResult
@@ -19,7 +19,7 @@ public extension AsyncMigration {
     
     func revert(on database: Database) -> EventLoopFuture<Void> {
         let promise = database.eventLoop.makePromise(of: Void.self)
-        promise.completeWithAsync {
+        promise.completeWithTask {
             try await self.revert(on: database)
         }
         return promise.futureResult

--- a/Sources/FluentKit/Concurrency/Database+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Database+Concurrency.swift
@@ -6,7 +6,7 @@ public extension Database {
     func transaction<T>(_ closure: @escaping (Database) async throws -> T) async throws -> T {
         try await self.transaction { db -> EventLoopFuture<T> in
             let promise = self.eventLoop.makePromise(of: T.self)
-            promise.completeWithAsync{ try await closure(db) }
+            promise.completeWithTask{ try await closure(db) }
             return promise.futureResult
         }.get()
     }
@@ -14,7 +14,7 @@ public extension Database {
     func withConnection<T>(_ closure: @escaping (Database) async throws -> T) async throws -> T {
         try await self.withConnection { db -> EventLoopFuture<T> in
             let promise = self.eventLoop.makePromise(of: T.self)
-            promise.completeWithAsync{ try await closure(db) }
+            promise.completeWithTask{ try await closure(db) }
             return promise.futureResult
         }.get()
     }


### PR DESCRIPTION
Very similar to https://github.com/vapor/vapor/pull/2672: this just updates the `async-await` branch to use the new name `completeWithTask` rather than the old `completeWithAsync`.