### PR TITLE
Clean up use of EventLoopFutureQueue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push: 
     branches: 
       - main
-      - master
 env:
   LOG_LEVEL: info
 
@@ -43,7 +42,7 @@ jobs:
         image: mongo:latest
       mongo-b:
         image: mongo:latest
-    container: swift:5.3-focal
+    container: swift:5.4-focal
     strategy:
       fail-fast: false
       matrix:
@@ -91,9 +90,12 @@ jobs:
           - swift:5.3-bionic
           - swift:5.3-focal
           - swift:5.3-amazonlinux2
-          - swiftlang/swift:nightly-5.3-bionic
-          - swiftlang/swift:nightly-5.3-focal
-          - swiftlang/swift:nightly-5.3-amazonlinux2
+          - swift:5.4-bionic
+          - swift:5.4-focal
+          - swift:5.4-amazonlinux2
+          - swiftlang/swift:nightly-5.5-bionic
+          - swiftlang/swift:nightly-5.5-focal
+          - swiftlang/swift:nightly-5.5-amazonlinux2
     container: ${{ matrix.image }}
     steps:
       - name: Checkout code

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.1.0"),
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.4.0"),
     ],
     targets: [
         .target(name: "FluentKit", dependencies: [

--- a/Sources/FluentBenchmark/SolarSystem/SolarSystem.swift
+++ b/Sources/FluentBenchmark/SolarSystem/SolarSystem.swift
@@ -34,7 +34,7 @@ public struct SolarSystem: Migration {
             all = migrations
         }
 
-        return EventLoopFutureQueue(eventLoop: database.eventLoop).append(each: all) { $0.prepare(on: database) }
+        return all.sequencedFlatMapEach(on: database.eventLoop) { $0.prepare(on: database) }
     }
 
     public func revert(on database: Database) -> EventLoopFuture<Void> {
@@ -45,6 +45,6 @@ public struct SolarSystem: Migration {
             all = migrations
         }
 
-        return EventLoopFutureQueue(eventLoop: database.eventLoop).append(each: all.reversed()) { $0.revert(on: database) }
+        return all.reversed().sequencedFlatMapEach(on: database.eventLoop) { $0.revert(on: database) }
     }
 }

--- a/Sources/FluentKit/Migration/Migrations.swift
+++ b/Sources/FluentKit/Migration/Migrations.swift
@@ -1,18 +1,12 @@
 public final class Migrations {
-    struct Item {
-        var id: DatabaseID?
-        var migration: Migration
-    }
-    
-    var storage: [Item]
-    var databases: Set<DatabaseID?> { Set(self.storage.map(\.id)) }
+    var storage: [DatabaseID?: [Migration]]
     
     public init() {
-        self.storage = []
+        self.storage = [:]
     }
     
     public func add(_ migration: Migration, to id: DatabaseID? = nil) {
-        self.storage.append(.init(id: id, migration: migration))
+        self.storage[id, default: []].append(migration)
     }
     
     @inlinable
@@ -21,6 +15,6 @@ public final class Migrations {
     }
 
     public func add(_ migrations: [Migration], to id: DatabaseID? = nil) {
-        self.storage.append(contentsOf: migrations.map { .init(id: id, migration: $0) })
+        self.storage[id, default: []].append(contentsOf: migrations)
     }
 }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -234,14 +234,8 @@ public final class QueryBuilder<Model>
                     return self.database.eventLoop.makeSucceededFuture(())
                 }
                 // run eager loads
-                return EventLoopFutureQueue(eventLoop: self.database.eventLoop).append(each: self.eagerLoaders) { loader in
+                return self.eagerLoaders.sequencedFlatMapEach(on: self.database.eventLoop) { loader in
                     return loader.anyRun(models: all, on: self.database)
-                }.flatMapErrorThrowing { error in
-                    if case .previousError(let error) = error as? EventLoopFutureQueue.ContinueError {
-                        throw error
-                    } else {
-                        throw error
-                    }
                 }
             }
         } else {


### PR DESCRIPTION
Should improve performance of migrations when there are a large number of them.