### PR TITLE
Set method for group fields + tests

### DIFF
--- a/Sources/FluentBenchmark/SolarSystem/Galaxy.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Galaxy.swift
@@ -8,6 +8,9 @@ public final class Galaxy: Model {
 
     @Field(key: "name")
     public var name: String
+    
+    @Group(key: "area")
+    public var size: Size
 
     @Children(for: \.$galaxy)
     public var stars: [Star]
@@ -20,6 +23,16 @@ public final class Galaxy: Model {
     }
 }
 
+public final class Size: Fields {
+    @Field(key: "km")
+    var km: Double
+    
+    @Field(key: "light_year")
+    var lightYear: Double
+    
+    public init() { }
+}
+
 public struct GalaxyMigration: Migration {
     public init() {}
 
@@ -27,6 +40,8 @@ public struct GalaxyMigration: Migration {
         database.schema("galaxies")
             .field("id", .uuid, .identifier(auto: false))
             .field("name", .string, .required)
+            .field("area_km", .double, .required, .sql(.default(0.0)))
+            .field("area_light_year", .double, .required, .sql(.default(0.0)))
             .create()
     }
 

--- a/Sources/FluentBenchmark/Tests/BatchTests.swift
+++ b/Sources/FluentBenchmark/Tests/BatchTests.swift
@@ -2,6 +2,7 @@ extension FluentBenchmarker {
     public func testBatch() throws {
         try self.testBatch_create()
         try self.testBatch_update()
+        try self.testGroupBatch_update()
         try self.testBatch_delete()
     }
 
@@ -30,6 +31,28 @@ extension FluentBenchmarker {
             let galaxies = try Galaxy.query(on: self.database).all().wait()
             for galaxy in galaxies {
                 XCTAssertEqual(galaxy.name, "Foo")
+            }
+        }
+    }
+    
+    private func testGroupBatch_update() throws {
+        try runTest(#function, [
+            GalaxyMigration(),
+            GalaxySeed()
+        ]) {
+            let oneLightYearInKm: Double = 9460528400000
+            let countOfLightYears: Double = 1
+            try Galaxy
+                .query(on: self.database)
+                .set(\.$size.$km, to: oneLightYearInKm)
+                .set(\.$size.$lightYear, to: countOfLightYears)
+                .update()
+                .wait()
+
+            let galaxies = try Galaxy.query(on: self.database).all().wait()
+            for galaxy in galaxies {
+                XCTAssertEqual(galaxy.size.km, oneLightYearInKm)
+                XCTAssertEqual(galaxy.size.lightYear, countOfLightYears)
             }
         }
     }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Set.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Set.swift
@@ -25,15 +25,32 @@ extension QueryBuilder {
             Field: QueryableProperty,
             Field.Model == Model
     {
+        return prepareSelf(by: Model.path(for: field), queryValue: Field.queryValue(value))
+    }
+    
+    // MARK: Set
+
+    @discardableResult
+    public func set<Field>(
+        _ field: KeyPath<Model, Field>,
+        to value: Field.Value
+    ) -> Self
+        where
+            Field: QueryableProperty,
+            Field.Model == GroupPropertyPath<Model, QueryableProperty>.Model
+    {
+        return prepareSelf(by: Model.path(for: field), queryValue: Field.queryValue(value))
+    }
+    
+    private func prepareSelf(by path: [FieldKey], queryValue: DatabaseQuery.Value) -> Self {
         if self.query.input.isEmpty {
             self.query.input = [.dictionary([:])]
         }
 
         switch self.query.input[0] {
         case .dictionary(var existing):
-            let path = Model.path(for: field)
             assert(path.count == 1, "Set on nested properties is not yet supported.")
-            existing[path[0]] = Field.queryValue(value)
+            existing[path[0]] = queryValue
             self.query.input[0] = .dictionary(existing)
         default:
             fatalError()


### PR DESCRIPTION
Since in current version I didn't find how to use similar way to setting values for fields marked like Group, I propose my small improvement. 

Example:

```swift
try Galaxy
    .query(on: self.database)
    .set(\.$size.$km, to: oneLightYearInKm)
    .set(\.$size.$lightYear, to: 1)
    .update()
``` 
where $size is Group fields in a model

```swift
    @Group(key: "area")
    public var size: Size
```

```swift
public final class Size: Fields {
    @Field(key: "km")
    var km: Double
    
    @Field(key: "light_year")
    var lightYear: Double
    
    public init() { }
}
```

If I misunderstood something, please, let me know :) 