### PR TITLE
optional query tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - main
 env:
   LOG_LEVEL: info
+  SWIFT_DETERMINISTIC_HASHING: 1
 
 jobs:
 

--- a/Tests/FluentKitTests/OptionalEnumQueryTests.swift
+++ b/Tests/FluentKitTests/OptionalEnumQueryTests.swift
@@ -1,0 +1,97 @@
+@testable import FluentKit
+import FluentSQL
+import Foundation
+import XCTest
+
+final class OptionalEnumQueryTests: DbQueryTestCase {
+    func testInsertNonNull() throws {
+        _ = try Thing(id: 1, fb: .fizz).create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("fb", "id") VALUES ('fizz', $1)"#)
+    }
+    
+    func testInsertNull() throws {
+        _ = try Thing(id: 1, fb: nil).create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("id") VALUES ($1)"#)
+    }
+    
+    func testInsertAfterMutatingNullableField() throws {
+        let thing = Thing(id: 1, fb: nil)
+        thing.fb = .fizz
+        _ = try thing.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("fb", "id") VALUES ('fizz', $1)"#)
+        
+        db.reset()
+        
+        let thing2 = Thing(id: 1, fb: .buzz)
+        thing2.fb = nil
+        _ = try thing2.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("id") VALUES ($1)"#)
+    }
+    
+    func testSaveReplacingNonNull() throws {
+        let thing = Thing(id: 1, fb: .fizz)
+        _ = try thing.create(on: db).wait()
+        thing.fb = .buzz
+        _ = try thing.save(on: db).wait()
+        assertLastQuery(db, #"UPDATE "things" SET "fb" = 'buzz' WHERE "things"."id" = $1"#)
+    }
+    
+    func testSaveReplacingNull() throws {
+        let thing = Thing(id: 1, fb: nil)
+        _ = try thing.create(on: db).wait()
+        thing.fb = .fizz
+        _ = try thing.save(on: db).wait()
+        assertLastQuery(db, #"UPDATE "things" SET "fb" = 'fizz' WHERE "things"."id" = $1"#)
+    }
+    
+    // @see https://github.com/vapor/fluent-kit/issues/444
+    func SKIP_EXPECTED_FAILURE_testSaveNullReplacingNonNull() throws {
+        let thing = Thing(id: 1, fb: .fizz)
+        _ = try thing.create(on: db).wait()
+        thing.fb = nil
+        _ = try thing.save(on: db).wait()
+        XCTAssertNil(thing.fb)
+        assertLastQuery(db, #"UPDATE "things" SET "fb" = NULL WHERE "things"."id" = $1"#)
+    }
+    
+    func testBulkInsertWithoutNulls() throws {
+        let things = [Thing(id: 1, fb: .fizz), Thing(id: 2, fb: .buzz)]
+        _ = try things.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("fb", "id") VALUES ('fizz', $1), ('buzz', $2)"#)
+    }
+    
+    func testBulkInsertWithOnlyNulls() throws {
+        let things = [Thing(id: 1, fb: nil), Thing(id: 2, fb: nil)]
+        _ = try things.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("id") VALUES ($1), ($2)"#)
+    }
+    
+    // @see https://github.com/vapor/fluent-kit/issues/396
+    func SKIP_EXPECTED_FAILURE_testBulkInsertWithMixedNulls() throws {
+        let things = [Thing(id: 1, fb: nil), Thing(id: 2, fb: .fizz)]
+        _ = try things.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("fb", "id") VALUES (NULL, $1), ('fizz', $2)"#)
+    }
+}
+
+private final class Thing: Model {
+    enum FizzBuzz: String, Codable {
+        case fizz
+        case buzz
+    }
+
+    static let schema = "things"
+    
+    @ID(custom: "id", generatedBy: .user)
+    var id: Int?
+    
+    @OptionalEnum(key: "fb")
+    var fb: FizzBuzz?
+    
+    init() {}
+    
+    init(id: Int, fb: FizzBuzz? = nil) {
+        self.id = id
+        self.fb = fb
+    }
+}

--- a/Tests/FluentKitTests/OptionalFieldQueryTests.swift
+++ b/Tests/FluentKitTests/OptionalFieldQueryTests.swift
@@ -1,0 +1,90 @@
+@testable import FluentKit
+import FluentSQL
+import Foundation
+import XCTest
+
+final class OptionalFieldQueryTests: DbQueryTestCase {
+    
+    func testInsertNonNull() throws {
+        _ = try Thing(id: 1, name: "Jared").create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("name", "id") VALUES ($1, $2)"#)
+    }
+    
+    func testInsertNull() throws {
+        _ = try Thing(id: 1, name: nil).create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("name", "id") VALUES (NULL, $1)"#)
+    }
+    
+    func testInsertAfterMutatingNullableField() throws {
+        let thing = Thing(id: 1, name: nil)
+        thing.name = "Jared"
+        _ = try thing.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("name", "id") VALUES ($1, $2)"#)
+        
+        db.reset()
+        
+        let thing2 = Thing(id: 1, name: "Jared")
+        thing2.name = nil
+        _ = try thing2.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("name", "id") VALUES (NULL, $1)"#)
+    }
+    
+    func testSaveReplacingNonNull() throws {
+        let thing = Thing(id: 1, name: "Jared")
+        _ = try thing.create(on: db).wait()
+        thing.name = "Bob"
+        _ = try thing.save(on: db).wait()
+        assertLastQuery(db, #"UPDATE "things" SET "name" = $1 WHERE "things"."id" = $2"#)
+    }
+    
+    func testSaveReplacingNull() throws {
+        let thing = Thing(id: 1, name: nil)
+        _ = try thing.create(on: db).wait()
+        thing.name = "Bob"
+        _ = try thing.save(on: db).wait()
+        assertLastQuery(db, #"UPDATE "things" SET "name" = $1 WHERE "things"."id" = $2"#)
+    }
+    
+    func testSaveNullReplacingNonNull() throws {
+        let thing = Thing(id: 1, name: "Jared")
+        _ = try thing.create(on: db).wait()
+        thing.name = nil
+        _ = try thing.save(on: db).wait()
+        assertLastQuery(db, #"UPDATE "things" SET "name" = NULL WHERE "things"."id" = $1"#)
+    }
+    
+    func testBulkInsertWithoutNulls() throws {
+        let things = [Thing(id: 1, name: "Jared"), Thing(id: 2, name: "Bob")]
+        _ = try things.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("name", "id") VALUES ($1, $2), ($3, $4)"#)
+    }
+    
+    func testBulkInsertWithOnlyNulls() throws {
+        let things = [Thing(id: 1, name: nil), Thing(id: 2, name: nil)]
+        _ = try things.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("name", "id") VALUES (NULL, $1), (NULL, $2)"#)
+    }
+    
+    func testBulkInsertWithMixedNulls() throws {
+        let things = [Thing(id: 1, name: "Jared"), Thing(id: 2, name: nil)]
+        _ = try things.create(on: db).wait()
+        assertQuery(db, #"INSERT INTO "things" ("name", "id") VALUES ($1, $2), (NULL, $3)"#)
+    }
+}
+
+private final class Thing: Model {
+    static let schema = "things"
+
+    @ID(custom: "id", generatedBy: .user)
+    var id: Int?
+
+    @OptionalField(key: "name")
+    var name: String?
+
+    init() {}
+
+    init(id: Int, name: String? = nil) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/Tests/FluentKitTests/TestUtilities.swift
+++ b/Tests/FluentKitTests/TestUtilities.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+class DbQueryTestCase: XCTestCase {
+    var db = DummyDatabaseForTestSQLSerializer()
+    
+    override func setUp() {
+        db = DummyDatabaseForTestSQLSerializer()
+    }
+    
+    override func tearDown() {
+        db.reset()
+    }
+}
+
+func assertQuery(
+    _ db: DummyDatabaseForTestSQLSerializer,
+    _ query: String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTAssertEqual(db.sqlSerializers.count, 1, file: file, line: line)
+    XCTAssertEqual(db.sqlSerializers.first?.sql, query, file: file, line: line)
+}
+
+func assertLastQuery(
+    _ db: DummyDatabaseForTestSQLSerializer,
+    _ query: String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTAssertEqual(db.sqlSerializers.last?.sql, query, file: file, line: line)
+}


### PR DESCRIPTION
I mentioned in #448 that I was thinking of writing some exploratory tests to document and understand the behavior around SQL generation for nullable fields and nullable enums.

I started a branch today to start adding some simple tests, and ran into an issue I wanted some input on before I went further.  The issue is that to make assertions about the SQL strings generated by certain queries, I need to enable _deterministic hashing_  with `SWIFT_DETERMINISTIC_HASHING=1` to get reliable ordering of fields.

Unit tests are exactly the use case that this env variable seems to have been created to support, so I don't see any issue using it for the tests.  I added it to the github workflow files, as you can see in the PR. I think my hesitation stems from the fact that, if someone wants to run the tests in Xcode (I personally prefer running tests from the command line, where it's easy to set the env var) then they'll see intermittent failures with this type of test, unless they edit the scheme to add the environment variable to to the test target.  I hoped that somehow setting that variable would produce some sort check-in-able artifact in the code like I think it does in a a non-SPM Xcode project, but it doesn't seem to.

Can someone comment on whether this is acceptable? Or is there a workaround for setting the env var in code somewhere that would not require the editing of the scheme?  It seems like being able to assert on SQL generated from insert statements is pretty important.