### PR TITLE
Make very slow `Migration.defaultName` accessor twice as fast

### DIFF
--- a/Sources/FluentKit/Migration/Migration.swift
+++ b/Sources/FluentKit/Migration/Migration.swift
@@ -26,6 +26,20 @@ extension Migration {
     }
 
     internal var defaultName: String {
+#if compiler(>=5.3) && compiler(<6)
+        /// `String.init(reflecting:)` creates a `Mirror` unconditionally, but
+        /// when the parameter is a metatype (such as is the case here), that
+        /// mirror is never actually used for anything. Unfortunately, just
+        /// creating it slows this accessor down by at least 30% at best, and
+        /// as much as 50% in some cases. Given that it's already incorrect to
+        /// be depending on the stability of `String(reflecting:)`'s output
+        /// anyway, it seems to make more sense to just call the underlying
+        /// runtime function directly instead of taking the huge speed hit just
+        /// because the leading underscore makes it harder to ignore the
+        /// fragility of the usage.
+        return Swift._typeName(Self.self, qualified: true)
+#else
         return String(reflecting: Self.self)
+#endif
     }
 }


### PR DESCRIPTION
`Migration.defaultName` is currently implemented using `String.init(reflecting: Self.self)`, whose implementation invokes `Mirror` and is thus very slow. And to add insult to injury, in the case of a metatype such as `Self.self`, the `Mirror` never even gets used for anything. This performance penalty tends to show up in the unit tests of large projects, where configuring a large number of migrations before every test is a common pattern - and the migrations don't have to actually execute for the penalty to be felt.

The runtime function `_typeName(_:qualified:)` is what performs the actual conversion of the metatype to string form.  Replacing `String(reflecting:)` with a direct call to `_typeName()` does not change the resulting names whatsoever, and makes the accessor as much as 50% faster in some cases - specifically, that result was observed on Linux, using a 5.5 toolchain snapshot and building with `-O`. The improvement is somewhat lesser on macOS (around 35% with the Xcode 13 beta 5 toolchain), but still significant.