### PR TITLE
Bypass Mirror when possible for a 100% speedup in model properties lookup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,13 @@ jobs:
         image: mongo:latest
       mongo-b:
         image: mongo:latest
-    container: swift:5.4-focal
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
+        container:
+          - swift:5.4-focal
+          - swift:5.5-focal
         dependent:
           - fluent-sqlite-driver
           - fluent-postgres-driver
@@ -93,9 +96,12 @@ jobs:
           - swift:5.4-bionic
           - swift:5.4-focal
           - swift:5.4-amazonlinux2
-          - swiftlang/swift:nightly-5.5-bionic
-          - swiftlang/swift:nightly-5.5-focal
-          - swiftlang/swift:nightly-5.5-amazonlinux2
+          - swift:5.5-bionic
+          - swift:5.5-focal
+          - swift:5.5-amazonlinux2
+          - swiftlang/swift:nightly-main-bionic
+          - swiftlang/swift:nightly-main-focal
+          - swiftlang/swift:nightly-main-amazonlinux2
     container: ${{ matrix.image }}
     steps:
       - name: Checkout code

--- a/Sources/FluentKit/Model/Fields+Codable.swift
+++ b/Sources/FluentKit/Model/Fields+Codable.swift
@@ -2,9 +2,7 @@ extension Fields {
     public init(from decoder: Decoder) throws {
         self.init()
         let container = try decoder.container(keyedBy: ModelCodingKey.self)
-        try self.labeledProperties.compactMapValues {
-            $0 as? AnyCodableProperty
-        }.forEach { label, property in
+        try self.labeledProperties.forEach { label, property in
             do {
                 let decoder = ContainerDecoder(container: container, key: .string(label))
                 try property.decode(from: decoder)
@@ -23,9 +21,7 @@ extension Fields {
 
     public func encode(to encoder: Encoder) throws {
         let container = encoder.container(keyedBy: ModelCodingKey.self)
-        try self.labeledProperties.compactMapValues {
-            $0 as? AnyCodableProperty
-        }.forEach { label, property in
+        try self.labeledProperties.forEach { label, property in
             do {
                 let encoder = ContainerEncoder(container: container, key: .string(label))
                 try property.encode(to: encoder)

--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -87,7 +87,7 @@ internal func _getChild<T>(
 extension Fields {
     public var properties: [AnyProperty] {
 #if compiler(<5.6) && compiler(>=5.2) && swift(>=5.2)
-        let type = _getNormalizedType(self, type: type(of: self))
+        let type = _getNormalizedType(self, type: Swift.type(of: self))
         let childCount = _getChildCount(self, type: type)
         return (0 ..< childCount).compactMap({
             var nameC: UnsafePointer<CChar>? = nil
@@ -104,7 +104,7 @@ extension Fields {
 
     internal var labeledProperties: [String: AnyCodableProperty] {
 #if compiler(<5.6) && compiler(>=5.2) && swift(>=5.2)
-        let type = _getNormalizedType(self, type: type(of: self))
+        let type = _getNormalizedType(self, type: Swift.type(of: self))
         let childCount = _getChildCount(self, type: type)
 
         return .init(uniqueKeysWithValues:

--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -127,7 +127,7 @@ extension Fields {
                 guard let label = child.label else {
                     return nil
                 }
-                guard let field = child.value as? AnyProperty else {
+                guard let field = child.value as? AnyCodableProperty else {
                     return nil
                 }
                 // remove underscore

--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -69,14 +69,59 @@ extension Fields {
 
 // MARK: Properties
 
+#if compiler(<5.6) && compiler(>=5.2)
+@_silgen_name("swift_reflectionMirror_normalizedType")
+internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
+
+@_silgen_name("swift_reflectionMirror_count")
+internal func _getChildCount<T>(_: T, type: Any.Type) -> Int
+
+@_silgen_name("swift_reflectionMirror_subscript")
+internal func _getChild<T>(
+  of: T, type: Any.Type, index: Int,
+  outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
+  outFreeFunc: UnsafeMutablePointer<(@convention(c) (UnsafePointer<CChar>?) -> Void)?>
+) -> Any
+#endif
+
 extension Fields {
     public var properties: [AnyProperty] {
+#if compiler(<5.6) && compiler(>=5.2) && swift(>=5.2)
+        let type = _getNormalizedType(self, type: type(of: self))
+        let childCount = _getChildCount(self, type: type)
+        return (0 ..< childCount).compactMap({
+            var nameC: UnsafePointer<CChar>? = nil
+            var freeFunc: (@convention(c) (UnsafePointer<CChar>?) -> Void)? = nil
+            defer { freeFunc?(nameC) }
+            return _getChild(of: self, type: Self.self, index: $0, outName: &nameC, outFreeFunc: &freeFunc) as? AnyProperty
+        })
+#else
         Mirror(reflecting: self).children.compactMap {
             $0.value as? AnyProperty
         }
+#endif
     }
 
-    internal var labeledProperties: [String: AnyProperty] {
+    internal var labeledProperties: [String: AnyCodableProperty] {
+#if compiler(<5.6) && compiler(>=5.2) && swift(>=5.2)
+        let type = _getNormalizedType(self, type: type(of: self))
+        let childCount = _getChildCount(self, type: type)
+
+        return .init(uniqueKeysWithValues:
+            (0 ..< childCount).compactMap({
+                var nameC: UnsafePointer<CChar>? = nil
+                var freeFunc: (@convention(c) (UnsafePointer<CChar>?) -> Void)? = nil
+                defer { freeFunc?(nameC) }
+                guard let value = _getChild(
+                        of: self, type: Self.self, index: $0, outName: &nameC, outFreeFunc: &freeFunc
+                      ) as? AnyCodableProperty,
+                      let nameCC = nameC, nameCC.pointee != 0, nameCC.advanced(by: 1).pointee != 0,
+                      let name = String(validatingUTF8: nameCC.advanced(by: 1))
+                else { return nil }
+                return (name, value)
+            })
+        )
+#else
         .init(uniqueKeysWithValues:
             Mirror(reflecting: self).children.compactMap { child in
                 guard let label = child.label else {
@@ -89,6 +134,7 @@ extension Fields {
                 return (String(label.dropFirst()), field)
             }
         )
+#endif
     }
 }
 

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -541,10 +541,7 @@ final class FluentKitTests: XCTestCase {
     }
     
     func testFieldsPropertiesPerformance() throws {
-        let options = XCTMeasureOptions()
-        options.iterationCount = 10
-        
-        self.measure(metrics: [XCTCPUMetric()], options: options) {
+        measure {
             for _ in 1 ... 10_000 {
                 XCTAssertEqual(LotsOfFields().properties.count, 21)
             }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -539,6 +539,17 @@ final class FluentKitTests: XCTestCase {
             .paginate(pageRequest2)
             .wait())
     }
+    
+    func testFieldsPropertiesPerformance() throws {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 10
+        
+        self.measure(metrics: [XCTCPUMetric()], options: options) {
+            for _ in 1 ... 10_000 {
+                XCTAssertEqual(LotsOfFields().properties.count, 21)
+            }
+        }
+    }
 }
 
 final class User: Model {
@@ -647,4 +658,71 @@ final class Planet2: Model {
         self.name = name
         self.moonCount = moonCount
     }
+}
+
+final class LotsOfFields: Model {
+    static let schema = "never_used"
+    
+    @ID(custom: "id")
+    var id: Int?
+    
+    @Field(key: "field1")
+    var field1: String
+    
+    @Field(key: "field2")
+    var field2: String
+    
+    @Field(key: "field3")
+    var field3: String
+    
+    @Field(key: "field4")
+    var field4: String
+    
+    @Field(key: "field5")
+    var field5: String
+    
+    @Field(key: "field6")
+    var field6: String
+    
+    @Field(key: "field7")
+    var field7: String
+    
+    @Field(key: "field8")
+    var field8: String
+    
+    @Field(key: "field9")
+    var field9: String
+    
+    @Field(key: "field10")
+    var field10: String
+    
+    @Field(key: "field11")
+    var field11: String
+    
+    @Field(key: "field12")
+    var field12: String
+    
+    @Field(key: "field13")
+    var field13: String
+    
+    @Field(key: "field14")
+    var field14: String
+    
+    @Field(key: "field15")
+    var field15: String
+    
+    @Field(key: "field16")
+    var field16: String
+    
+    @Field(key: "field17")
+    var field17: String
+    
+    @Field(key: "field18")
+    var field18: String
+    
+    @Field(key: "field19")
+    var field19: String
+    
+    @Field(key: "field20")
+    var field20: String
 }


### PR DESCRIPTION
Uses some very evil underscored runtime function call hackery to accomplish this result. Limited by conditionals to only compiler versions where it is known to work.