### PR TITLE
update swift-nio for compat with Xcode 13 GM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "XCTFluent", targets: ["XCTFluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.1.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.4.0"),


### PR DESCRIPTION
fluent-kit `main` branch doesn't currently build with Xcode 13 GM.  This updates the `swift-nio` to include [this release](https://github.com/apple/swift-nio/releases/tag/2.31.2) which allows it to build.
