### PR TITLE
add support for decoding an optional child

### DIFF
--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -120,7 +120,12 @@ extension OptionalChildProperty: AnyCodableProperty {
     }
 
     public func decode(from decoder: Decoder) throws {
-        // don't decode
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self.value = nil
+        } else {
+            self.value = try container.decode(Value.self)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Add support to decode an `@OptionalChild` this can be useful when decoding models from json eg: redis.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
