### PR TITLE
Add extra set method for `DatabaseQuery.Value`

### DIFF
--- a/Sources/FluentBenchmark/Tests/SetTests.swift
+++ b/Sources/FluentBenchmark/Tests/SetTests.swift
@@ -3,6 +3,7 @@ extension FluentBenchmarker {
         try self.testSet_multiple()
         try self.testSet_optional()
         try self.testSet_enum()
+        try self.testSet_queryValue()
     }
     
     private func testSet_multiple() throws {
@@ -40,6 +41,16 @@ extension FluentBenchmarker {
         ]) {
             try Test2.query(on: self.database)
                 .set(\.$foo, to: .bar)
+                .update().wait()
+        }
+    }
+    
+    private func testSet_queryValue() throws {
+        try runTest(#function, [
+            TestMigration(),
+        ]) {
+            try Test.query(on: self.database)
+                .set(\.$intValue, to: .bind(1))
                 .update().wait()
         }
     }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Set.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Set.swift
@@ -25,20 +25,32 @@ extension QueryBuilder {
             Field: QueryableProperty,
             Field.Model == Model
     {
+        return self.set(field, to: Field.queryValue(value))
+    }
+    
+    @discardableResult
+    public func set<Field>(
+        _ field: KeyPath<Model, Field>,
+        to value: DatabaseQuery.Value
+    ) -> Self
+    where
+        Field: QueryableProperty,
+        Field.Model == Model
+    {
         if self.query.input.isEmpty {
             self.query.input = [.dictionary([:])]
         }
-
+        
         switch self.query.input[0] {
         case .dictionary(var existing):
             let path = Model.path(for: field)
             assert(path.count == 1, "Set on nested properties is not yet supported.")
-            existing[path[0]] = Field.queryValue(value)
+            existing[path[0]] = value
             self.query.input[0] = .dictionary(existing)
         default:
             fatalError()
         }
-
+        
         return self
     }
 }


### PR DESCRIPTION
This allows the use `DatabaseQuery.Value` when setting a `@Field` property value. For example you can now use SQL:
```swift
query.set(\.$field, to: .sql(raw: "1"))
```