### PR TITLE
prevent fatalError when bulk inserting optional enum fields

### DIFF
--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -75,7 +75,7 @@ extension EnumProperty: AnyDatabaseProperty {
         self.field.keys
     }
 
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         if let value = self.value {
             input.set(.enumCase(value.rawValue), at: self.field.key)
         }

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -76,9 +76,11 @@ extension OptionalEnumProperty: AnyDatabaseProperty {
         self.field.keys
     }
 
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         if let value = self.value {
             input.set(value.map { .enumCase($0.rawValue) } ?? .null, at: self.field.key)
+        } else if strategy == .bulkInsert {
+            input.set(.null, at: self.field.key)
         }
     }
 

--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -1,7 +1,7 @@
 public protocol Fields: AnyObject, Codable {
     var properties: [AnyProperty] { get }
     init()
-    func input(to input: DatabaseInput)
+    func input(to input: DatabaseInput, strategy: CollectStrategy)
     func output(from output: DatabaseOutput) throws
 }
 
@@ -50,11 +50,12 @@ extension Fields {
         }
     }
 
-    public func input(to input: DatabaseInput) {
+    
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         self.properties.compactMap {
             $0 as? AnyDatabaseProperty
         }.forEach { field in
-            field.input(to: input)
+            field.input(to: input, strategy: strategy)
         }
     }
 
@@ -141,9 +142,9 @@ extension Fields {
 // MARK: Collect Input
 
 extension Fields {
-    internal func collectInput() -> [FieldKey: DatabaseQuery.Value] {
+    internal func collectInput(strategy: CollectStrategy = .default) -> [FieldKey: DatabaseQuery.Value] {
         let input = DictionaryInput()
-        self.input(to: input)
+        self.input(to: input, strategy: strategy)
         return input.storage
     }
 }

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -162,12 +162,12 @@ extension Collection where Element: FluentKit.Model {
             database.configuration.middleware.chainingTo(Element.self) { event, model, db in
                 model._$id.generate()
                 model.touchTimestamps(.create, .update)
-                input.append(model.collectInput())
+                input.append(model.collectInput(strategy: .bulkInsert))
                 return db.eventLoop.makeSucceededFuture(())
             }.create(model, on: database)
         }, on: database.eventLoop).flatMap {
             Element.query(on: database)
-                .set(self.map { $0.collectInput() })
+                .set(self.map { $0.collectInput(strategy: .bulkInsert) })
                 .create()
                 .map
             {

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -112,7 +112,7 @@ extension ChildrenProperty: AnyDatabaseProperty {
         []
     }
 
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         // children never has input
     }
 

--- a/Sources/FluentKit/Properties/Field.swift
+++ b/Sources/FluentKit/Properties/Field.swift
@@ -87,7 +87,7 @@ extension FieldProperty: AnyDatabaseProperty {
         [self.key]
     }
 
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         if let inputValue = self.inputValue {
             input.set(inputValue, at: self.key)
         }

--- a/Sources/FluentKit/Properties/Group.swift
+++ b/Sources/FluentKit/Properties/Group.swift
@@ -67,7 +67,7 @@ extension GroupProperty: AnyDatabaseProperty {
         .prefix(self.key, .string("_"))
     }
 
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         self.value!.input(to: input.prefixed(by: self.prefix))
     }
 

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -149,7 +149,7 @@ extension IDProperty: AnyDatabaseProperty {
         self.field.keys
     }
 
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         self.field.input(to: input)
     }
 

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -97,7 +97,7 @@ extension OptionalChildProperty: AnyDatabaseProperty {
         []
     }
 
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         // child never has input
     }
 

--- a/Sources/FluentKit/Properties/OptionalField.swift
+++ b/Sources/FluentKit/Properties/OptionalField.swift
@@ -85,7 +85,7 @@ extension OptionalFieldProperty: AnyDatabaseProperty {
         [self.key]
     }
 
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         if let inputValue = self.inputValue {
             input.set(inputValue, at: self.key)
         }

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -78,7 +78,7 @@ extension OptionalParentProperty: AnyDatabaseProperty {
         self.$id.keys
     }
     
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         self.$id.input(to: input)
     }
 

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -74,7 +74,7 @@ extension ParentProperty: AnyDatabaseProperty {
         self.$id.keys
     }
     
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         self.$id.input(to: input)
     }
 

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -19,9 +19,14 @@ extension AnyProperty where Self: Property {
     }
 }
 
+public enum CollectStrategy {
+    case `default`
+    case bulkInsert
+}
+
 public protocol AnyDatabaseProperty: AnyProperty {
     var keys: [FieldKey] { get }
-    func input(to input: DatabaseInput)
+    func input(to input: DatabaseInput, strategy: CollectStrategy)
     func output(from output: DatabaseOutput) throws
 }
 

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -261,7 +261,7 @@ extension SiblingsProperty: AnyDatabaseProperty {
         []
     }
     
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         // siblings never has input
     }
 

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -104,7 +104,7 @@ extension TimestampProperty: AnyDatabaseProperty {
         self.$timestamp.keys
     }
     
-    public func input(to input: DatabaseInput) {
+    public func input(to input: DatabaseInput, strategy: CollectStrategy = .default) {
         self.$timestamp.input(to: input)
     }
 

--- a/Tests/FluentKitTests/OptionalEnumQueryTests.swift
+++ b/Tests/FluentKitTests/OptionalEnumQueryTests.swift
@@ -63,11 +63,11 @@ final class OptionalEnumQueryTests: DbQueryTestCase {
     func testBulkInsertWithOnlyNulls() throws {
         let things = [Thing(id: 1, fb: nil), Thing(id: 2, fb: nil)]
         _ = try things.create(on: db).wait()
-        assertQuery(db, #"INSERT INTO "things" ("id") VALUES ($1), ($2)"#)
+        assertQuery(db, #"INSERT INTO "things" ("fb", "id") VALUES (NULL, $1), (NULL, $2)"#)
     }
     
     // @see https://github.com/vapor/fluent-kit/issues/396
-    func SKIP_EXPECTED_FAILURE_testBulkInsertWithMixedNulls() throws {
+    func testBulkInsertWithMixedNulls() throws {
         let things = [Thing(id: 1, fb: nil), Thing(id: 2, fb: .fizz)]
         _ = try things.create(on: db).wait()
         assertQuery(db, #"INSERT INTO "things" ("fb", "id") VALUES (NULL, $1), ('fizz', $2)"#)


### PR DESCRIPTION
This is a hopefully more correct approach to fixing #396, which I first attempted in #448.

The main issue here is that Fluent _omits_ optional NULL values for enums in insert operations. However, when performing a bulk insert, this results in arrays of different lengths being collected if there is at least one model containing `nil` for an optional enum, and one model with a value.  In that case, the app will [trap here](https://github.com/vapor/fluent-kit/blob/main/Sources/FluentSQL/SQLQueryConverter.swift#L119). For example, this seemingly innocuous bit of code currently traps in production:

```swift
let things = [Thing(id: 1, fizzBuzz: nil), Thing(id: 2, fizzBuzz: .fizz)]
try things.create(on: db)
```

My first naive attempt to fix this just made sure that optional enum input values always collected a NULL/nil value. But @gwynne pointed out that this broke some very serious assumptions (which were not covered by any test cases). The tests I added in #455 were an attempt to increase the test coverage around some of these assumptions, and to lay the groundwork for this PR.

In this PR, I am trying to fix it in a more correct (hopefully) way, by introducing the concept of a "collection strategy" -- i.e., a strategy for collecting input.  It's an enum that defaults to the existing behavior of skipping optional enums.  But, in the case of bulk-inserting models, I explicitly set the strategy to `.bulkInsert`, which then causes NULL values to be explicitly set, preventing the problem of non-uniform query input.

I'm not sure about the naming or placement of the new type, but at least would love some input on whether this feels more safe and correct to some of the folks with a deeper knowledge of the library.