### PR TITLE
Fix `AsyncModelMiddleware`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
 
-  dependents:
+  linux-integration:
     runs-on: ubuntu-latest
     services:
       mysql-a:
@@ -43,18 +43,20 @@ jobs:
         image: mongo:latest
       mongo-b:
         image: mongo:latest
-    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
-        container:
-          - swift:5.4-focal
-          - swift:5.5-focal
+        swiftver:
+          - swift:5.2
+          - swift:5.5
+        swiftos:
+          - focal
         dependent:
           - fluent-sqlite-driver
           - fluent-postgres-driver
           - fluent-mysql-driver
           - fluent-mongo-driver
+    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
     steps:
       - name: Install SQLite dependencies
         run: apt-get -q update && apt-get -q install -y libsqlite3-dev
@@ -76,51 +78,52 @@ jobs:
         working-directory: dependent
         env:
           POSTGRES_HOSTNAME_A: postgres-a
+          POSTGRES_USERNAME_A: vapor_username
+          POSTGRES_PASSWORD_A: vapor_password
+          POSTGRES_DATABASE_A: vapor_database
           POSTGRES_HOSTNAME_B: postgres-b
+          POSTGRES_USERNAME_B: vapor_username
+          POSTGRES_PASSWORD_B: vapor_password
+          POSTGRES_DATABASE_B: vapor_database
           MYSQL_HOSTNAME_A: mysql-a
+          MYSQL_USERNAME_A: vapor_username
+          MYSQL_PASSWORD_A: vapor_password
+          MYSQL_DATABASE_A: vapor_database
           MYSQL_HOSTNAME_B: mysql-b
+          MYSQL_USERNAME_B: vapor_username
+          MYSQL_PASSWORD_B: vapor_password
+          MYSQL_DATABASE_B: vapor_database
           MONGO_HOSTNAME_A: mongo-a
           MONGO_HOSTNAME_B: mongo-b
 
-  linux:
+  linux-unit:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - swift:5.2-bionic
-          - swift:5.2-focal
-          - swift:5.2-amazonlinux2
-          - swift:5.3-bionic
-          - swift:5.3-focal
-          - swift:5.3-amazonlinux2
-          - swift:5.4-bionic
-          - swift:5.4-focal
-          - swift:5.4-amazonlinux2
-          - swift:5.5-bionic
-          - swift:5.5-focal
-          - swift:5.5-amazonlinux2
-          - swiftlang/swift:nightly-main-bionic
-          - swiftlang/swift:nightly-main-focal
-          - swiftlang/swift:nightly-main-amazonlinux2
-    container: ${{ matrix.image }}
+        swiftver:
+          - swift:5.2
+          - swift:5.3
+          - swift:5.4
+          - swift:5.5
+          - swiftlang/swift:nightly-main
+        swiftos:
+          - focal
+    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread
 
-  macos:
+  macos-unit:
     strategy:
       fail-fast: false
       matrix:
         xcode:
           - latest
           - latest-stable
-        macos:
-          - latest
-          #- 11.0
-    runs-on: macos-${{ matrix.macos }}
+    runs-on: macos-11
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -129,4 +132,6 @@ jobs:
       - name: Check out package
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: |
+          swift test --sanitize=thread -Xlinker -rpath \
+                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx

--- a/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
+++ b/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
@@ -1,7 +1,13 @@
 extension FluentBenchmarker {
+
     public func testMiddleware() throws {
         try self.testMiddleware_methods()
         try self.testMiddleware_batchCreationFail()
+        #if compiler(>=5.5) && canImport(_Concurrency)
+        if #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) {
+            try self.testAsyncMiddleware_methods()
+        }
+        #endif
     }
     
     public func testMiddleware_methods() throws {

--- a/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
+++ b/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
@@ -114,6 +114,23 @@ private struct UserBatchMiddleware: ModelMiddleware {
     }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+private struct AsyncUserBatchMiddleware: AsyncModelMiddleware {
+    func create(model: User, on db: Database, next: AnyAsyncModelResponder) async throws {
+        if model.name == "A" {
+            model.name = "AA"
+            return try await next.create(model, on: db)
+        } else if model.name == "C" {
+            model.name = "CC"
+            return try await next.create(model, on: db)
+        } else {
+            throw TestError(string: "cancelCreation")
+        }
+    }
+}
+#endif
+
 private struct UserMiddleware: ModelMiddleware {
     func create(model: User, on db: Database, next: AnyModelResponder) -> EventLoopFuture<Void> {
         model.name = "B"

--- a/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
+++ b/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
@@ -53,6 +53,59 @@ extension FluentBenchmarker {
             XCTAssertEqual(user.name, "G")
         }
     }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    public func testAsyncMiddleware_methods() throws {
+        try self.runTest(#function, [
+            UserMigration(),
+        ]) {
+            self.databases.middleware.use(AsyncUserMiddleware())
+
+            let user = User(name: "A")
+            // create
+            do {
+                try user.create(on: self.database).wait()
+            } catch let error as TestError {
+                XCTAssertEqual(error.string, "didCreate")
+            }
+            XCTAssertEqual(user.name, "B")
+
+            // update
+            user.name = "C"
+            do {
+                try user.update(on: self.database).wait()
+            } catch let error as TestError {
+                XCTAssertEqual(error.string, "didUpdate")
+            }
+            XCTAssertEqual(user.name, "D")
+
+            // soft delete
+            do {
+                try user.delete(on: self.database).wait()
+            } catch let error as TestError {
+                XCTAssertEqual(error.string, "didSoftDelete")
+            }
+            XCTAssertEqual(user.name, "E")
+
+            // restore
+            do {
+                try user.restore(on: self.database).wait()
+            } catch let error as TestError {
+                XCTAssertEqual(error.string, "didRestore")
+            }
+            XCTAssertEqual(user.name, "F")
+
+            // force delete
+            do {
+                try user.delete(force: true, on: self.database).wait()
+            } catch let error as TestError {
+                XCTAssertEqual(error.string, "didDelete")
+            }
+            XCTAssertEqual(user.name, "G")
+        }
+    }
+#endif
     
     public func testMiddleware_batchCreationFail() throws {
         try self.runTest(#function, [
@@ -116,17 +169,40 @@ private struct UserBatchMiddleware: ModelMiddleware {
 
 #if compiler(>=5.5) && canImport(_Concurrency)
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
-private struct AsyncUserBatchMiddleware: AsyncModelMiddleware {
+private struct AsyncUserMiddleware: AsyncModelMiddleware {
     func create(model: User, on db: Database, next: AnyAsyncModelResponder) async throws {
-        if model.name == "A" {
-            model.name = "AA"
-            return try await next.create(model, on: db)
-        } else if model.name == "C" {
-            model.name = "CC"
-            return try await next.create(model, on: db)
-        } else {
-            throw TestError(string: "cancelCreation")
-        }
+        model.name = "B"
+
+        try await next.create(model, on: db)
+        throw TestError(string: "didCreate")
+    }
+
+    func update(model: User, on db: Database, next: AnyAsyncModelResponder) async throws {
+        model.name = "D"
+
+        try await next.update(model, on: db)
+        throw TestError(string: "didUpdate")
+    }
+
+    func softDelete(model: User, on db: Database, next: AnyAsyncModelResponder) async throws {
+        model.name = "E"
+
+        try await next.softDelete(model, on: db)
+        throw TestError(string: "didSoftDelete")
+    }
+
+    func restore(model: User, on db: Database, next: AnyAsyncModelResponder) async throws {
+        model.name = "F"
+
+        try await next.restore(model , on: db)
+        throw TestError(string: "didRestore")
+    }
+
+    func delete(model: User, force: Bool, on db: Database, next: AnyAsyncModelResponder) async throws {
+        model.name = "G"
+
+        try await next.delete(model, force: force, on: db)
+        throw TestError(string: "didDelete")
     }
 }
 #endif

--- a/Sources/FluentBenchmark/Tests/UniqueTests.swift
+++ b/Sources/FluentBenchmark/Tests/UniqueTests.swift
@@ -13,7 +13,7 @@ extension FluentBenchmarker {
             do {
                 try Foo(bar: "a", baz: 1).save(on: self.database).wait()
                 XCTFail("should have failed")
-            } catch _ as DatabaseError {
+            } catch let error where error is DatabaseError {
                 // pass
             }
         }

--- a/Sources/FluentKit/Concurrency/ModelResponder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/ModelResponder+Concurrency.swift
@@ -44,4 +44,17 @@ extension AnyAsyncModelResponder {
     }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+internal struct AsyncBasicModelResponder: AnyAsyncModelResponder {
+    private let _handle: (ModelEvent, AnyModel, Database) async throws -> Void
+
+    internal func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) async throws {
+        return try await _handle(event, model, db)
+    }
+
+    init(handle: @escaping (ModelEvent, AnyModel, Database) async throws -> Void) {
+        self._handle = handle
+    }
+}
+
 #endif

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -128,7 +128,7 @@ extension Collection where Element: FluentKit.Model {
             return database.eventLoop.makeSucceededFuture(())
         }
 
-        precondition(self.allSatisfy { !$0._$id.exists })
+        precondition(self.allSatisfy { $0._$id.exists })
 
         return EventLoopFuture<Void>.andAllSucceed(self.map { model in
             database.configuration.middleware.chainingTo(Element.self) { event, model, db in


### PR DESCRIPTION
Fixes an issue where creating a middleware that conforms to `AsyncModelMiddleware` would require you to manually implement the `EventLoopFuture`-based `handle(_:_:on:)` which was almost impossible.

This makes `AsyncModelMiddleware` seamless and how it should have been when implemented. Also adds tests to ensure it actually works.

Also fixes a data race and incorrect double-serialization of models when using the `Collection<Model>.create(on:)` CRUD method.