### PR TITLE
Fix NULL handling for OptionalFieldProperty and OptionalEnumProperty

### DIFF
--- a/.github/workflows/main-codecov.yml
+++ b/.github/workflows/main-codecov.yml
@@ -1,0 +1,9 @@
+name: Update code coverage baselines
+on:
+  push: { branches: [ main ] }
+jobs:
+  update-main-codecov:
+    uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+    with:
+      with_coverage: true
+      with_tsan: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,4 +104,6 @@ jobs:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
     with:
       with_coverage: true
-      with_tsan: true
+      with_tsan: false
+      coverage_ignores: '/Tests/|/Sources/FluentBenchmark/'
+      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,6 @@ jobs:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
     with:
       with_coverage: true
-      with_tsan: false
+      with_tsan: true
       coverage_ignores: '/Tests/|/Sources/FluentBenchmark/'
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,12 +33,16 @@ jobs:
           POSTGRES_USER: vapor_username
           POSTGRES_PASSWORD: vapor_password
           POSTGRES_DB: vapor_database
+          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+          POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
       postgres-b:
         image: postgres:latest
         env: 
           POSTGRES_USER: vapor_username
           POSTGRES_PASSWORD: vapor_password
           POSTGRES_DB: vapor_database
+          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+          POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
       mongo-a:
         image: mongo:latest
       mongo-b:
@@ -78,13 +82,13 @@ jobs:
         working-directory: dependent
         env:
           POSTGRES_HOSTNAME_A: postgres-a
-          POSTGRES_USERNAME_A: vapor_username
+          POSTGRES_USER_A: vapor_username
           POSTGRES_PASSWORD_A: vapor_password
-          POSTGRES_DATABASE_A: vapor_database
+          POSTGRES_DB_A: vapor_database
           POSTGRES_HOSTNAME_B: postgres-b
-          POSTGRES_USERNAME_B: vapor_username
+          POSTGRES_USER_B: vapor_username
           POSTGRES_PASSWORD_B: vapor_password
-          POSTGRES_DATABASE_B: vapor_database
+          POSTGRES_DB_B: vapor_database
           MYSQL_HOSTNAME_A: mysql-a
           MYSQL_USERNAME_A: vapor_username
           MYSQL_PASSWORD_A: vapor_password
@@ -96,42 +100,8 @@ jobs:
           MONGO_HOSTNAME_A: mongo-a
           MONGO_HOSTNAME_B: mongo-b
 
-  linux-unit:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        swiftver:
-          - swift:5.2
-          - swift:5.3
-          - swift:5.4
-          - swift:5.5
-          - swiftlang/swift:nightly-main
-        swiftos:
-          - focal
-    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
-
-  macos-unit:
-    strategy:
-      fail-fast: false
-      matrix:
-        xcode:
-          - latest
-          - latest-stable
-    runs-on: macos-11
-    steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with: 
-          xcode-version: ${{ matrix.xcode }}
-      - name: Check out package
-        uses: actions/checkout@v2
-      - name: Run tests with Thread Sanitizer
-        run: |
-          swift test --sanitize=thread -Xlinker -rpath \
-                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
+  unit-tests:
+    uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+    with:
+      with_coverage: true
+      with_tsan: true

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -48,8 +48,13 @@ extension OptionalEnumProperty: Property {
             }
         }
         set {
-            self.field.value = newValue?.map {
-                $0.rawValue
+            switch newValue {
+            case .some(.some(let newValue)):
+                self.field.value = .some(.some(newValue.rawValue))
+            case .some(.none):
+                self.field.value = .some(.none)
+            case .none:
+                self.field.value = .none
             }
         }
     }

--- a/Sources/FluentKit/Properties/OptionalField.swift
+++ b/Sources/FluentKit/Properties/OptionalField.swift
@@ -47,7 +47,7 @@ extension OptionalFieldProperty: Property {
                 case .default:
                     fatalError("Cannot access default field for '\(Model.self).\(key)' before it is initialized or fetched")
                 case .null:
-                    return nil
+                    return .some(.none)
                 default:
                     fatalError("Unexpected input value type for '\(Model.self).\(key)': \(value)")
                 }
@@ -58,9 +58,10 @@ extension OptionalFieldProperty: Property {
             }
         }
         set {
-
             if let value = newValue {
-                self.inputValue = value.flatMap { .bind($0) } ?? .null
+                self.inputValue = value
+                    .flatMap { .bind($0) }
+                    ?? .null
             } else {
                 self.inputValue = nil
             }


### PR DESCRIPTION
`OptionalFieldProperty.value.getter` was incorrectly returning `.none(.none)` instead of `.some(.none)` when `self.inputValue` was `DatabaseQuery.Value.null`, preventing explicitly set `nil` values set by properties that wrap optional field properties (i.e. `OptionalEnumProperty`) from taking effect as they should.

Additionally, `OptionalEnumProperty.value.setter` was not correctly forwarding the double-optional state of `newValue`, causing a `fatalError()` due to non-uniform input sets on bulk inserts.

This fixes both of those issues and updates the appropriate tests. The behavior of `OptionalEnumProperty` is noticeably different now, so even though this does not change any public API, it will be released as `semver-minor` to lessen impact for those who were relying on the incorrect old behavior.

Fixes #396.
Fixes #444.