### PR TITLE
Add support for `.custom(...)` join clauses

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
@@ -12,6 +12,19 @@ extension QueryBuilder {
         self.join(Foreign.self, filter.foreign, to: Local.self, filter.local , method: method)
     }
 
+    @discardableResult
+    public func join<Foreign, Local>(
+        _ local: Local.Type,
+        _ foreign: Foreign.Type,
+        on join: DatabaseQuery.Join
+    ) -> Self
+        where Foreign: Schema, Local: Schema
+    {
+        self.models.append(Foreign.self)
+        self.query.joins.append(join)
+        return self
+    }
+
     /// This will join a foreign table based on a `@Parent` relation
     ///
     /// This will not decode the joined data, but can be used in order to filter.

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -175,4 +175,16 @@ final class QueryBuilderTests: XCTestCase {
             XCTFail("no query")
         }
     }
+
+    func testCustomJoinOverload() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Planet.query(on: db)
+            .join(Planet.self,  Star.self,
+                  on: .custom(#"LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#))
+            .all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#)
+        print(db.sqlSerializers.first!.sql)
+        db.reset()
+    }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

We need to perform a `LEFT JOIN` with an additional constraint on the joined table, i.e. in SQL terms we need to execute:

```sql
LEFT JOIN "versions" AS "pre_release_version" 
ON ("packages"."id" = "pre_release_version"."package_id" AND "pre_release_version"."latest" = 'pre_release')
```

This cannot (as far as I can see) be expressed any other way, because moving the additional constraint out of the `ON` clause will effectively turn the query into an `INNER` query: either the ids match or the extra filter will reject any "outer" rows. The `LEFT JOIN` needs to happen "after" the selection, so to speak.

This PR adds an overload exposing the existing `.custom` `QueryBuilder.Join` case such that we can write this as

```swift
            let p = try Package.query(on: app.db)
                .join(Package.self,
                      PreReleaseVersion.self,
                      on: .custom(#"""
                            LEFT JOIN "versions" AS "pre_release_version"
                            ON "packages"."id" = "pre_release_version"."package_id"
                            AND "pre_release_version"."latest" = 'pre_release'
                            """#)
                )
                .all().wait()
```

(See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1072 for some additional details.)

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
