### PR TITLE
Move `DummyDatabase` to `XCTFluent`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,6 @@ let package = Package(
     ],
     targets: [
         .target(name: "FluentKit", dependencies: [
-            .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOCore", package: "swift-nio"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "AsyncKit", package: "async-kit"),
@@ -35,12 +34,13 @@ let package = Package(
             .product(name: "SQLKit", package: "sql-kit"),
         ]),
         .target(name: "XCTFluent", dependencies: [
-            .target(name: "FluentKit")
+            .target(name: "FluentKit"),
+            .product(name: "NIOEmbedded", package: "swift-nio"),
         ]),
         .testTarget(name: "FluentKitTests", dependencies: [
             .target(name: "FluentBenchmark"),
             .target(name: "FluentSQL"),
-            .target(name: "XCTFluent")
+            .target(name: "XCTFluent"),
         ]),
     ]
 )

--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -1,6 +1,5 @@
 import FluentKit
 import Foundation
-import NIO
 import XCTest
 
 public final class FluentBenchmarker {

--- a/Sources/FluentKit/Concurrency/AsyncModelMiddleware.swift
+++ b/Sources/FluentKit/Concurrency/AsyncModelMiddleware.swift
@@ -1,5 +1,4 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
-import NIOCore
 
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncModelMiddleware: AnyModelMiddleware {

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -1,5 +1,5 @@
 import AsyncKit
-import NIO
+import NIOCore
 
 public final class QueryBuilder<Model>
     where Model: FluentKit.Model

--- a/Sources/XCTFluent/DummyDatabase.swift
+++ b/Sources/XCTFluent/DummyDatabase.swift
@@ -1,4 +1,6 @@
-import NIO
+import FluentKit
+import Foundation
+import NIOEmbedded
 
 public struct DummyDatabase: Database {
     public var context: DatabaseContext

--- a/Sources/XCTFluent/TestDatabase.swift
+++ b/Sources/XCTFluent/TestDatabase.swift
@@ -1,5 +1,5 @@
 import FluentKit
-import NIO
+import NIOEmbedded
 
 /// Lets you mock the row results for each query.
 ///

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -5,7 +5,6 @@
 import XCTest
 import Foundation
 import XCTFluent
-import NIO
 
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncQueryBuilderTests: XCTestCase {

--- a/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
+++ b/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
@@ -1,7 +1,8 @@
 @testable import FluentKit
 import FluentSQL
-import NIO
+import NIOEmbedded
 import SQLKit
+import XCTFluent
 
 public class DummyDatabaseForTestSQLSerializer: Database, SQLDatabase {
     public var inTransaction: Bool {

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -3,7 +3,6 @@
 import XCTest
 import Foundation
 import XCTFluent
-import NIO
 
 final class QueryBuilderTests: XCTestCase {
     func testFirstEmptyResult() throws {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

`DummyDatabase` is only meant to be used in tests, so `XCTFluent` is where it should be.
`FluentKit` will benefit from dropping dependency on the `NIO` module.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
