### PR TITLE
Add missing joins for `@OptionalParent` properties

### DIFF
--- a/Sources/FluentBenchmark/SolarSystem/Planet.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Planet.swift
@@ -12,6 +12,9 @@ public final class Planet: Model {
     @Parent(key: "star_id")
     public var star: Star
 
+    @OptionalParent(key: "possible_star_id")
+    public var possibleStar: Star?
+
     @Children(for: \.$planet)
     public var moons: [Moon]
     
@@ -41,6 +44,7 @@ public struct PlanetMigration: Migration {
             .field("id", .uuid, .identifier(auto: false))
             .field("name", .string, .required)
             .field("star_id", .uuid, .required, .references("stars", "id"))
+            .field("possible_star_id", .uuid, .references("stars", "id"))
             .create()
     }
 

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
@@ -66,6 +66,48 @@ extension QueryBuilder {
     ) -> Self {
         join(from: Model.self, parent: parent, method: method)
     }
+
+    /// This will join a foreign table based on a `@OptionalParent` relation
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     Planet.query(on: db)
+    ///         .join(from: Planet.self, parent: \.$star)
+    ///         .filter(Star.self, \Star.$name == "Sun")
+    ///
+    /// - Parameters:
+    ///   - model: The `Model` to join from
+    ///   - parent: The `OptionalParentProperty` to join
+    ///   - method: The method to use. The default is an inner join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<From, To>(
+        from model: From.Type,
+        parent: KeyPath<From, OptionalParentProperty<From, To>>,
+        method: DatabaseQuery.Join.Method = .inner
+    ) -> Self {
+        join(To.self, on: parent.appending(path: \.$id) == \To._$id, method: method)
+    }
+
+    /// This will join a foreign table based on a `@OptionalParent` relation
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     Planet.query(on: db)
+    ///         .join(parent: \.$star)
+    ///         .filter(Star.self, \Star.$name == "Sun")
+    ///
+    /// - Parameters:
+    ///   - parent: The `OptionalParentProperty` to join
+    ///   - method: The method to use. The default is an inner join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<To>(
+        parent: KeyPath<Model, OptionalParentProperty<Model, To>>,
+        method: DatabaseQuery.Join.Method = .inner
+    ) -> Self {
+        join(from: Model.self, parent: parent, method: method)
+    }
     
     /// This will join a foreign table based on a `@OptionalChild` relation
     ///

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -82,6 +82,11 @@ final class FluentKitTests: XCTestCase {
         XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"INNER JOIN "stars" ON "planets"."star_id" = "stars"."id"#), true)
         db.reset()
 
+        _ = try Planet.query(on: db).join(parent: \Planet.$possibleStar).all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"INNER JOIN "stars" ON "planets"."possible_star_id" = "stars"."id"#), true)
+        db.reset()
+
         _ = try Planet.query(on: db).join(siblings: \Planet.$tags).all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
         XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"INNER JOIN "planet+tag" ON "planets"."id" = "planet+tag"."planet_id""#), true)

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -183,7 +183,7 @@ final class QueryBuilderTests: XCTestCase {
                   on: .custom(#"LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#))
             .all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#)
         print(db.sqlSerializers.first!.sql)
         db.reset()
     }


### PR DESCRIPTION
Adds missing functions on `QueryBuilder` for joins using `OptionalParentProperty`.

### Example usage:
```swift 
// Model
class Planet: Model {

    @OptionalParent(key: "star_id")
    var star: Star?
}

// Usage
Planet.query(on: db)
    .join(from: Planet.self, parent: \.$star)
    // OR
    .join(parent: \.$star)
```