### PR TITLE
Improve usefulness of fatalError() messages in Fluent

### DIFF
--- a/Sources/FluentKit/Concurrency/Database+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Database+Concurrency.swift
@@ -3,7 +3,7 @@ import NIOCore
 
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension Database {
-    func transaction<T>(_ closure: @escaping (Database) async throws -> T) async throws -> T {
+    func transaction<T>(_ closure: @Sendable @escaping (Database) async throws -> T) async throws -> T {
         try await self.transaction { db -> EventLoopFuture<T> in
             let promise = self.eventLoop.makePromise(of: T.self)
             promise.completeWithTask{ try await closure(db) }
@@ -11,7 +11,7 @@ public extension Database {
         }.get()
     }
 
-    func withConnection<T>(_ closure: @escaping (Database) async throws -> T) async throws -> T {
+    func withConnection<T>(_ closure: @Sendable @escaping (Database) async throws -> T) async throws -> T {
         try await self.withConnection { db -> EventLoopFuture<T> in
             let promise = self.eventLoop.makePromise(of: T.self)
             promise.completeWithTask{ try await closure(db) }

--- a/Sources/FluentKit/Model/AnyModel.swift
+++ b/Sources/FluentKit/Model/AnyModel.swift
@@ -26,7 +26,7 @@ extension AnyModel {
         where Joined: Schema
     {
         guard let output = self.anyID.cachedOutput else {
-            fatalError("Can only access joined models using models fetched from database.")
+            fatalError("Can only access joined models using models fetched from database (from \(Self.self) to \(Joined.self)).")
         }
         let joined = Joined()
         try joined.output(from: output.schema(Joined.schemaOrAlias))

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -30,12 +30,12 @@ public final class ChildrenProperty<From, To>
     public var wrappedValue: [To] {
         get {
             guard let value = self.value else {
-                fatalError("Children relation not eager loaded, use $ prefix to access: \(name)")
+                fatalError("Children relation not eager loaded, use $ prefix to access: \(self.name)")
             }
             return value
         }
         set {
-            fatalError("Children relation is get-only.")
+            fatalError("Children relation \(self.name) is get-only.")
         }
     }
 
@@ -49,7 +49,7 @@ public final class ChildrenProperty<From, To>
 
     public func query(on database: Database) -> QueryBuilder<To> {
         guard let id = self.idValue else {
-            fatalError("Cannot query children relation from unsaved model.")
+            fatalError("Cannot query children relation \(self.name) from unsaved model.")
         }
         let builder = To.query(on: database)
         switch self.parentKey {
@@ -63,7 +63,7 @@ public final class ChildrenProperty<From, To>
 
     public func create(_ to: [To], on database: Database) -> EventLoopFuture<Void> {
         guard let id = self.idValue else {
-            fatalError("Cannot save child to unsaved model.")
+            fatalError("Cannot save child in relation \(self.name) to unsaved model.")
         }
         to.forEach {
             switch self.parentKey {
@@ -78,7 +78,7 @@ public final class ChildrenProperty<From, To>
 
     public func create(_ to: To, on database: Database) -> EventLoopFuture<Void> {
         guard let id = self.idValue else {
-            fatalError("Cannot save child to unsaved model.")
+            fatalError("Cannot save child in relation \(self.name) to unsaved model.")
         }
         switch self.parentKey {
         case .required(let keyPath):

--- a/Sources/FluentKit/Properties/Group.swift
+++ b/Sources/FluentKit/Properties/Group.swift
@@ -19,7 +19,7 @@ public final class GroupProperty<Model, Value>
     public var wrappedValue: Value {
         get {
             guard let value = self.value else {
-                fatalError("Cannot access unitialized Group field.")
+                fatalError("Cannot access unitialized Group field: \(self.description)")
             }
             return value
         }

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -35,7 +35,7 @@ public final class OptionalChildProperty<From, To>
             return value
         }
         set {
-            fatalError("Child relation is get-only.")
+            fatalError("Child relation  \(self.name) is get-only.")
         }
     }
 
@@ -49,7 +49,7 @@ public final class OptionalChildProperty<From, To>
 
     public func query(on database: Database) -> QueryBuilder<To> {
         guard let id = self.idValue else {
-            fatalError("Cannot query child relation from unsaved model.")
+            fatalError("Cannot query child relation \(self.name) from unsaved model.")
         }
         let builder = To.query(on: database)
         switch self.parentKey {
@@ -63,7 +63,7 @@ public final class OptionalChildProperty<From, To>
 
     public func create(_ to: To, on database: Database) -> EventLoopFuture<Void> {
         guard let id = self.idValue else {
-            fatalError("Cannot save child to unsaved model.")
+            fatalError("Cannot save child in \(self.name) to unsaved model in.")
         }
         switch self.parentKey {
         case .required(let keyPath):

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -17,7 +17,7 @@ public final class OptionalParentProperty<From, To>
             self.value ?? nil
         }
         set {
-            fatalError("OptionalParent relation is get-only.")
+            fatalError("OptionalParent relation \(self.name) is get-only.")
         }
     }
 

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -15,11 +15,11 @@ public final class ParentProperty<From, To>
     public var wrappedValue: To {
         get {
             guard let value = self.value else {
-                fatalError("Parent relation not eager loaded, use $ prefix to access: \(name)")
+                fatalError("Parent relation not eager loaded, use $ prefix to access: \(self.name)")
             }
             return value
         }
-        set { fatalError("use $ prefix to access") }
+        set { fatalError("use $ prefix to access \(self.name)") }
     }
 
     public var projectedValue: ParentProperty<From, To> {

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -47,12 +47,12 @@ public final class SiblingsProperty<From, To, Through>
     public var wrappedValue: [To] {
         get {
             guard let value = self.value else {
-                fatalError("Siblings relation not eager loaded, use $ prefix to access: \(name)")
+                fatalError("Siblings relation not eager loaded, use $ prefix to access: \(self.name)")
             }
             return value
         }
         set {
-            fatalError("Siblings relation is get-only.")
+            fatalError("Siblings relation \(self.name) is get-only.")
         }
     }
 
@@ -82,7 +82,7 @@ public final class SiblingsProperty<From, To, Through>
     ///     - database: The database to perform the check on.
     public func isAttached(toID: To.IDValue, on database: Database) -> EventLoopFuture<Bool> {
         guard let fromID = self.idValue else {
-            fatalError("Cannot check if siblings are attached to an unsaved model.")
+            fatalError("Cannot check if siblings are attached to an unsaved model in \(self.name).")
         }
 
         return Through.query(on: database)
@@ -106,12 +106,12 @@ public final class SiblingsProperty<From, To, Through>
         _ edit: (Through) -> () = { _ in }
     ) -> EventLoopFuture<Void> {
         guard let fromID = self.idValue else {
-            fatalError("Cannot attach siblings relation to unsaved model.")
+            fatalError("Cannot attach siblings relation \(self.name) to unsaved model.")
         }
 
         return tos.map { to -> Through in
             guard let toID = to.id else {
-                fatalError("Cannot attach unsaved model.")
+                fatalError("Cannot attach unsaved model to \(self.name).")
             }
             let pivot = Through()
             pivot[keyPath: self.from].id = fromID
@@ -160,10 +160,10 @@ public final class SiblingsProperty<From, To, Through>
         _ edit: (Through) -> () = { _ in }
     ) -> EventLoopFuture<Void> {
         guard let fromID = self.idValue else {
-            fatalError("Cannot attach siblings relation to unsaved model.")
+            fatalError("Cannot attach siblings relation \(self.name) to unsaved model.")
         }
         guard let toID = to.id else {
-            fatalError("Cannot attach unsaved model.")
+            fatalError("Cannot attach unsaved model \(self.name).")
         }
 
         let pivot = Through()
@@ -180,11 +180,11 @@ public final class SiblingsProperty<From, To, Through>
     ///     - database: The database to perform the attachment on.
     public func detach(_ tos: [To], on database: Database) -> EventLoopFuture<Void> {
         guard let fromID = self.idValue else {
-            fatalError("Cannot detach siblings relation to unsaved model.")
+            fatalError("Cannot detach siblings relation \(self.name) to unsaved model.")
         }
         let toIDs = tos.map { to -> To.IDValue in
             guard let toID = to.id else {
-                fatalError("Cannot detach unsaved model.")
+                fatalError("Cannot detach unsaved model \(self.name).")
             }
             return toID
         }
@@ -202,10 +202,10 @@ public final class SiblingsProperty<From, To, Through>
     ///     - database: The database to perform the attachment on.
     public func detach(_ to: To, on database: Database) -> EventLoopFuture<Void> {
         guard let fromID = self.idValue else {
-            fatalError("Cannot detach siblings relation from unsaved model.")
+            fatalError("Cannot detach siblings relation \(self.name) from unsaved model.")
         }
         guard let toID = to.id else {
-            fatalError("Cannot detach unsaved model.")
+            fatalError("Cannot detach unsaved model \(self.name).")
         }
 
         return Through.query(on: database)
@@ -217,7 +217,7 @@ public final class SiblingsProperty<From, To, Through>
     /// Detach all models by deleting all pivots from this model.
     public func detachAll(on database: Database) -> EventLoopFuture<Void> {
         guard let fromID = self.idValue else {
-            fatalError("Cannot detach siblings relation from unsaved model.")
+            fatalError("Cannot detach siblings relation \(self.name) from unsaved model.")
         }
         
         return Through.query(on: database)
@@ -230,7 +230,7 @@ public final class SiblingsProperty<From, To, Through>
     /// Returns a `QueryBuilder` that can be used to query the siblings.
     public func query(on database: Database) -> QueryBuilder<To> {
         guard let fromID = self.idValue else {
-            fatalError("Cannot query siblings relation from unsaved model.")
+            fatalError("Cannot query siblings relation \(self.name) from unsaved model.")
         }
 
         return To.query(on: database)

--- a/Sources/FluentSQL/SQLJSONColumnPath.swift
+++ b/Sources/FluentSQL/SQLJSONColumnPath.swift
@@ -17,7 +17,7 @@ public struct SQLJSONColumnPath: SQLExpression {
                 let inner = path[0..<path.count - 1].map { "'\($0)'" }.joined(separator: "->")
                 serializer.write("\(column)->\(inner)->>'\(path.last!)'")
             default:
-                fatalError()
+                fatalError("Impossible path array count serializing column \(self.column) as JSON")
             }
         default:
             let path = self.path.joined(separator: ".")

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -28,7 +28,7 @@ public struct SQLQueryConverter {
     private func update(_ query: DatabaseQuery) -> SQLExpression {
         var update = SQLUpdate(table: SQLIdentifier(query.schema))
         guard case .dictionary(let values) = query.input.first! else {
-            fatalError()
+            fatalError("Missing query input generating update query")
         }
         values.forEach { (key, value) in
             update.values.append(SQLBinaryExpression(


### PR DESCRIPTION
Fluent's implementation includes a number of uses of `fatalError()` in cases of API misuse. However, the stack backtraces for fatal errors have become less and less reliable as a means of locating the source of the error, especially in cases like Fluent's where the error itself is in completely generic code. To make matters worse, most of the error messages are extremely unhelpful - it's completely impossible to determine, for example, just _which_ child relation on what original model something accessed without loading it first. And so on.

Therefore, as of now, all of the fatal error messages try to make sure they include some kind of description of what specific access or data was responsible for the crash. Hopefully this will make it easier to debug failures, especially when these code paths get hit in production systems.