### PR TITLE
Make it easier to save and restore models with relations outside the database

### DIFF
--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -44,7 +44,8 @@ public final class ChildrenProperty<From, To>
     }
     
     public var fromId: From.IDValue? {
-        return self.idValue
+        get { return self.idValue }
+        set { self.idValue = newValue }
     }
 
     public func query(on database: Database) -> QueryBuilder<To> {

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -44,7 +44,8 @@ public final class OptionalChildProperty<From, To>
     }
     
     public var fromId: From.IDValue? {
-        return self.idValue
+        get { return self.idValue }
+        set { self.idValue = newValue }
     }
 
     public func query(on database: Database) -> QueryBuilder<To> {

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -60,6 +60,11 @@ public final class SiblingsProperty<From, To, Through>
         return self
     }
 
+    public var fromId: From.IDValue? {
+        get { return self.idValue }
+        set { self.idValue = newValue }
+    }
+
     // MARK: Checking state
 
     /// Check whether a specific model is already attached through a sibling relationship.


### PR DESCRIPTION
When trying to cache database lookup results in a faster storage, such as Redis, it is often difficult to store models, as the `Children`, `OptionalChild`, and `Siblings` property wrappers do not round-trip correctly through `Codable`. This doesn't solve the issue, but it does enable users to work around it by manually restoring the necessary ID value, which is not currently possible except by faking a database output (and doing so in turn incurs much of the overhead of Fluent decoding which is otherwise bypassed by cache storage).