### PR TITLE
Upsert Support

### DIFF
--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -56,7 +56,11 @@ extension Model {
             .cascadeFailure(to: promise)
 
         return promise.futureResult.flatMapThrowing { output in
-            try self.output(from: SavedInput(self.collectInput()))
+            var input = self.collectInput()
+            if case .default = self._$id.inputValue {
+                input.removeValue(forKey: self._$id.key)
+            }
+            try self.output(from: SavedInput(input))
             try self.output(from: output.schema(Self.schema))
         }
     }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Upsert.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Upsert.swift
@@ -48,7 +48,17 @@ extension QueryBuilder {
         case .update(let closure):
             let builder = UpsertBuilder<Model>()
             closure(builder)
-            action = .update(builder.values)
+            var updates = builder.values
+
+            let timestamps = Model().timestamps.filter { $0.trigger == .update }
+            for timestamp in timestamps {
+                // Only add timestamps if they weren't already set
+                if updates[timestamp.key] == nil {
+                    updates[timestamp.key] = timestamp.currentTimestampInput
+                }
+            }
+
+            action = .update(updates)
         }
         query.conflictResolutionStrategy = .init(targets: targets, action: action)
 

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Upsert.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Upsert.swift
@@ -1,0 +1,58 @@
+public class UpsertBuilder<Model> where Model: FluentKit.Model {
+
+    public var values = [FieldKey: DatabaseQuery.Value]()
+
+    @discardableResult
+    public func set<Field>(
+        _ field: KeyPath<Model, Field>,
+        to value: Field.Value
+    ) -> Self
+        where
+            Field: QueryableProperty,
+            Field.Model == Model
+    {
+        let path = Model.path(for: field)
+        assert(path.count == 1, "Set on nested properties is not yet supported.")
+        values[path[0]] = Field.queryValue(value)
+
+        return self
+    }
+}
+
+
+extension QueryBuilder {
+
+    public enum ConflictStrategy<Model: FluentKit.Model> {
+        case ignore
+        case update((UpsertBuilder<Model>) -> Void)
+    }
+
+    public func create<Field>(
+        onConflict field: KeyPath<Model, Field>,
+        strategy: ConflictStrategy<Model>
+    ) -> EventLoopFuture<Void>
+        where
+            Field: QueryableProperty,
+            Field.Model == Model
+    {
+        create(onConflict: Model.path(for: field), strategy: strategy)
+    }
+
+    public func create(onConflict fields: [FieldKey], strategy: ConflictStrategy<Model>) -> EventLoopFuture<Void> {
+        let targets = fields.map { DatabaseQuery.Field.path([$0], schema: Model.schema) }
+
+        let action: DatabaseQuery.ConflictResolutionStrategy.ConflictAction
+        switch strategy {
+        case .ignore:
+            action = .ignore
+        case .update(let closure):
+            let builder = UpsertBuilder<Model>()
+            closure(builder)
+            action = .update(builder.values)
+        }
+        query.conflictResolutionStrategy = .init(targets: targets, action: action)
+
+        query.action = .create
+        return self.run()
+    }
+}

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Upsert.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Upsert.swift
@@ -1,0 +1,30 @@
+extension DatabaseQuery {
+
+    public struct ConflictResolutionStrategy {
+        public var targets: [Field]
+        public var action: ConflictAction
+
+        public enum ConflictAction {
+            case ignore
+            case update([FieldKey: Value])
+        }
+    }
+}
+
+extension DatabaseQuery.ConflictResolutionStrategy: CustomStringConvertible {
+    public var description: String {
+        "on \(targets) \(action)"
+    }
+}
+
+
+extension DatabaseQuery.ConflictResolutionStrategy.ConflictAction: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .ignore:
+            return "ignore"
+        case .update(let values):
+            return "update \(values)"
+        }
+    }
+}

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Upsert.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Upsert.swift
@@ -1,7 +1,7 @@
 extension DatabaseQuery {
 
     public struct ConflictResolutionStrategy {
-        public var targets: [Field]
+        public var targets: [FieldKey]
         public var action: ConflictAction
 
         public enum ConflictAction {
@@ -10,7 +10,7 @@ extension DatabaseQuery {
         }
 
         init<Model: FluentKit.Model>(fields: [FieldKey], strategy: QueryBuilder<Model>.ConflictStrategy) {
-            targets = fields.map { DatabaseQuery.Field.path([$0], schema: Model.schema) }
+            targets = fields
 
             switch strategy {
             case .ignore:

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Upsert.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Upsert.swift
@@ -17,7 +17,6 @@ extension DatabaseQuery.ConflictResolutionStrategy: CustomStringConvertible {
     }
 }
 
-
 extension DatabaseQuery.ConflictResolutionStrategy.ConflictAction: CustomStringConvertible {
     public var description: String {
         switch self {

--- a/Sources/FluentKit/Query/Database/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery.swift
@@ -10,6 +10,7 @@ public struct DatabaseQuery {
     public var sorts: [Sort]
     public var limits: [Limit]
     public var offsets: [Offset]
+    public var conflictResolutionStrategy: ConflictResolutionStrategy?
 
     init(schema: String) {
         self.schema = schema
@@ -49,6 +50,9 @@ extension DatabaseQuery: CustomStringConvertible {
         }
         if !self.offsets.isEmpty {
             parts.append("offsets=\(self.offsets)")
+        }
+        if let conflictResolutionStrategy = self.conflictResolutionStrategy {
+            parts.append("conflictResolution=\(conflictResolutionStrategy)")
         }
         return parts.joined(separator: " ")
     }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery.swift
@@ -11,6 +11,7 @@ public struct DatabaseQuery {
     public var limits: [Limit]
     public var offsets: [Offset]
     public var conflictResolutionStrategy: ConflictResolutionStrategy?
+    public var returning: [Field]
 
     init(schema: String) {
         self.schema = schema
@@ -23,6 +24,7 @@ public struct DatabaseQuery {
         self.sorts = []
         self.limits = []
         self.offsets = []
+        self.returning = []
     }
 }
 
@@ -53,6 +55,9 @@ extension DatabaseQuery: CustomStringConvertible {
         }
         if let conflictResolutionStrategy = self.conflictResolutionStrategy {
             parts.append("conflictResolution=\(conflictResolutionStrategy)")
+        }
+        if !self.returning.isEmpty {
+            parts.append("returning=\(self.returning)")
         }
         return parts.joined(separator: " ")
     }

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -99,7 +99,7 @@ public struct SQLQueryConverter {
         insert.returning = self.returning(query)
 
         if let conflictStrategy = query.conflictResolutionStrategy {
-            let targets = conflictStrategy.targets.map { self.field($0) }
+            let targets = conflictStrategy.targets.map { self.key($0) }
 
             switch conflictStrategy.action {
             case .ignore:

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -121,6 +121,21 @@ public struct SQLQueryConverter {
                 return self.value(value)
             }
         }
+
+        if let conflictStrategy = query.conflictResolutionStrategy {
+            let targets = conflictStrategy.targets.map { self.field($0) }
+
+            switch conflictStrategy.action {
+            case .ignore:
+                insert.conflictStrategy = SQLConflictResolutionStrategy(targets: targets, action: .noAction)
+            case .update(let values):
+                let assignments = values.map {
+                    SQLColumnAssignment(setting: self.key($0.key), to: self.value($0.value))
+                }
+                insert.conflictStrategy = SQLConflictResolutionStrategy(targets: targets, action: .update(assignments: assignments, predicate: nil))
+            }
+        }
+        
         return insert
     }
     

--- a/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
+++ b/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
@@ -90,6 +90,8 @@ struct DummyDatabaseDialect: SQLDialect {
         true
     }
 
+    var supportsReturning: Bool { true }
+
     var enumSyntax: SQLEnumSyntax {
         .unsupported
     }

--- a/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
+++ b/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
@@ -106,6 +106,8 @@ struct DummyDatabaseDialect: SQLDialect {
         return SQLRaw("'")
     }
 
+    var upsertSyntax: SQLUpsertSyntax { .standard }
+
     func bindPlaceholder(at position: Int) -> SQLExpression {
         return SQLRaw("$" + position.description)
     }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -566,7 +566,7 @@ final class FluentKitTests: XCTestCase {
             )
             .wait()
 
-        assertLastQuery(db, #"INSERT INTO "things" ("name") VALUES ($1) ON CONFLICT ("things"."name") DO UPDATE SET "name" = $2"#)
+        assertLastQuery(db, #"INSERT INTO "things" ("name") VALUES ($1) ON CONFLICT ("name") DO UPDATE SET "name" = $2"#)
         db.reset()
     }
 
@@ -581,7 +581,7 @@ final class FluentKitTests: XCTestCase {
             )
             .wait()
 
-        assertLastQuery(db, #"INSERT INTO "things" ("name") VALUES ($1) ON CONFLICT ("things"."name") DO NOTHING"#)
+        assertLastQuery(db, #"INSERT INTO "things" ("name") VALUES ($1) ON CONFLICT ("name") DO NOTHING"#)
         db.reset()
     }
 
@@ -598,7 +598,7 @@ final class FluentKitTests: XCTestCase {
             on: db
         ).wait()
 
-        assertLastQuery(db, #"INSERT INTO "things" ("name") VALUES ($1) ON CONFLICT ("things"."name") DO UPDATE SET "name" = $2"#)
+        assertLastQuery(db, #"INSERT INTO "things" ("name") VALUES ($1) ON CONFLICT ("name") DO UPDATE SET "name" = $2 RETURNING "things"."name" AS "things_name", "things"."id" AS "things_id""#)
         db.reset()
     }
 }

--- a/Tests/FluentKitTests/OptionalFieldQueryTests.swift
+++ b/Tests/FluentKitTests/OptionalFieldQueryTests.swift
@@ -70,32 +70,6 @@ final class OptionalFieldQueryTests: DbQueryTestCase {
         _ = try things.create(on: db).wait()
         assertQuery(db, #"INSERT INTO "things" ("name", "id") VALUES ($1, $2), (NULL, $3)"#)
     }
-
-    func testConflictUpdate() throws {
-        try Thing.query(on: db)
-            .set(\.$name, to: "First")
-            .create(
-                onConflict: \.$name,
-                strategy: .update { builder in
-                    builder.set(\.$name, to: "Last")
-                }
-            )
-            .wait()
-
-        assertLastQuery(db, #"INSERT INTO "things" ("name") VALUES ($1) ON CONFLICT ("things"."name") DO UPDATE SET "name" = $2"#)
-    }
-
-    func testConflictIgnore() throws {
-        try Thing.query(on: db)
-            .set(\.$name, to: "First")
-            .create(
-                onConflict: \.$name,
-                strategy: .ignore
-            )
-            .wait()
-
-        assertLastQuery(db, #"INSERT INTO "things" ("name") VALUES ($1) ON CONFLICT ("things"."name") DO NOTHING"#)
-    }
 }
 
 private final class Thing: Model {


### PR DESCRIPTION
Adds basic support for upsert/conflict strategy. I'm looking for feedback on the API.

Addresses #50.

### Query
```swift
try Thing.query(on: db)
    .set(\.$name, to: "First")
    .create(
        onConflict: \.$name,
        strategy: .update {
            $0.set(\.$name, to: "Last")
        }
    )
```

### Model
```swift
try Thing(name: "First")
  .create(
    onConflict: \.$name,
    .update {
        $0.set(\.$name, to: "Last")
    },
    on: db
)
```

When used on a Model, the conflict fields are returned by the query and saved back to the model. So if there is a conflict, the model will have all the correct values.