### PR TITLE
Address performance regression in Swift 5.6

### DIFF
--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -69,7 +69,7 @@ extension Fields {
 
 // MARK: Properties
 
-#if compiler(<5.6) && compiler(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
@@ -86,7 +86,7 @@ internal func _getChild<T>(
 
 extension Fields {
     public var properties: [AnyProperty] {
-#if compiler(<5.6) && compiler(>=5.2) && swift(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
         let type = _getNormalizedType(self, type: Swift.type(of: self))
         let childCount = _getChildCount(self, type: type)
         return (0 ..< childCount).compactMap({
@@ -103,7 +103,7 @@ extension Fields {
     }
 
     internal var labeledProperties: [String: AnyCodableProperty] {
-#if compiler(<5.6) && compiler(>=5.2) && swift(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
         let type = _getNormalizedType(self, type: Swift.type(of: self))
         let childCount = _getChildCount(self, type: type)
 


### PR DESCRIPTION
Bump maximum allowed compiler version for the use of runtime SPI to speeds up reflection, as the SPI is still valid for 5.6. Restores previous performance improvement.