### PR TITLE
Further improve the workaround for Mirror's slowness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
         swiftver:
           - swift:5.2
           - swift:5.5
+          - swift:5.6
+          - swiftlang/swift:nightly-main
         swiftos:
           - focal
         dependent:
@@ -66,11 +68,11 @@ jobs:
         run: apt-get -q update && apt-get -q install -y libsqlite3-dev
         if: ${{ contains(matrix.dependent, 'sqlite') }}
       - name: Check out package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: package
       - name: Check out dependent
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: vapor/${{ matrix.dependent }}
           path: dependent

--- a/Sources/FluentKit/Model/AnyModel.swift
+++ b/Sources/FluentKit/Model/AnyModel.swift
@@ -34,10 +34,15 @@ extension AnyModel {
     }
 
     var anyID: AnyID {
-        guard let id = Mirror(reflecting: self).descendant("_id") as? AnyID else {
-            fatalError("id property must be declared using @ID")
+        for (nameC, child) in _FastChildSequence(subject: self) {
+            if nameC?.advanced(by: 0).pointee == 0x5f, nameC?.advanced(by: 1).pointee == 0x69,
+               nameC?.advanced(by: 2).pointee == 0x64, nameC?.advanced(by: 3).pointee == 0x00,
+               let idChild = child as? AnyID
+            {
+                return idChild
+            }
         }
-        return id
+        fatalError("id property must be declared using @ID")
     }
 }
 

--- a/Sources/FluentKit/Model/AnyModel.swift
+++ b/Sources/FluentKit/Model/AnyModel.swift
@@ -35,8 +35,9 @@ extension AnyModel {
 
     var anyID: AnyID {
         for (nameC, child) in _FastChildSequence(subject: self) {
-            if nameC?.advanced(by: 0).pointee == 0x5f, nameC?.advanced(by: 1).pointee == 0x69,
-               nameC?.advanced(by: 2).pointee == 0x64, nameC?.advanced(by: 3).pointee == 0x00,
+            /// Match a property named `_id` which conforms to `AnyID`. `as?` is expensive, so check that last.
+            if nameC?.advanced(by: 0).pointee == 0x5f/* '_' */, nameC?.advanced(by: 1).pointee == 0x69/* 'i' */,
+               nameC?.advanced(by: 2).pointee == 0x64/* 'd' */, nameC?.advanced(by: 3).pointee == 0x00/* '\0' */,
                let idChild = child as? AnyID
             {
                 return idChild

--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -69,21 +69,6 @@ extension Fields {
 
 // MARK: Properties
 
-#if compiler(<5.7) && compiler(>=5.2)
-@_silgen_name("swift_reflectionMirror_normalizedType")
-internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
-
-@_silgen_name("swift_reflectionMirror_count")
-internal func _getChildCount<T>(_: T, type: Any.Type) -> Int
-
-@_silgen_name("swift_reflectionMirror_subscript")
-internal func _getChild<T>(
-  of: T, type: Any.Type, index: Int,
-  outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
-  outFreeFunc: UnsafeMutablePointer<(@convention(c) (UnsafePointer<CChar>?) -> Void)?>
-) -> Any
-#endif
-
 extension Fields {
     public var properties: [AnyProperty] {
 #if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)

--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -71,55 +71,19 @@ extension Fields {
 
 extension Fields {
     public var properties: [AnyProperty] {
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
-        let type = _getNormalizedType(self, type: Swift.type(of: self))
-        let childCount = _getChildCount(self, type: type)
-        return (0 ..< childCount).compactMap({
-            var nameC: UnsafePointer<CChar>? = nil
-            var freeFunc: (@convention(c) (UnsafePointer<CChar>?) -> Void)? = nil
-            defer { freeFunc?(nameC) }
-            return _getChild(of: self, type: Self.self, index: $0, outName: &nameC, outFreeFunc: &freeFunc) as? AnyProperty
-        })
-#else
-        Mirror(reflecting: self).children.compactMap {
-            $0.value as? AnyProperty
-        }
-#endif
+        return _FastChildSequence(subject: self).compactMap { $1 as? AnyProperty }
     }
 
     internal var labeledProperties: [String: AnyCodableProperty] {
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
-        let type = _getNormalizedType(self, type: Swift.type(of: self))
-        let childCount = _getChildCount(self, type: type)
-
-        return .init(uniqueKeysWithValues:
-            (0 ..< childCount).compactMap({
-                var nameC: UnsafePointer<CChar>? = nil
-                var freeFunc: (@convention(c) (UnsafePointer<CChar>?) -> Void)? = nil
-                defer { freeFunc?(nameC) }
-                guard let value = _getChild(
-                        of: self, type: Self.self, index: $0, outName: &nameC, outFreeFunc: &freeFunc
-                      ) as? AnyCodableProperty,
-                      let nameCC = nameC, nameCC.pointee != 0, nameCC.advanced(by: 1).pointee != 0,
-                      let name = String(validatingUTF8: nameCC.advanced(by: 1))
-                else { return nil }
-                return (name, value)
-            })
-        )
-#else
-        .init(uniqueKeysWithValues:
-            Mirror(reflecting: self).children.compactMap { child in
-                guard let label = child.label else {
-                    return nil
-                }
-                guard let field = child.value as? AnyCodableProperty else {
-                    return nil
-                }
-                // remove underscore
-                return (String(label.dropFirst()), field)
+        return .init(uniqueKeysWithValues: _FastChildSequence(subject: self).compactMap {
+            guard let value = $1 as? AnyCodableProperty,
+                  let nameC = $0, nameC.pointee != 0, nameC.advanced(by: 1).pointee != 0,
+                  let name = String(utf8String: nameC.advanced(by: 1))
+            else {
+                return nil
             }
-        )
-#endif
+            return (name, value)
+        })
     }
 }
 

--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -1,0 +1,129 @@
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+@_silgen_name("swift_reflectionMirror_normalizedType")
+internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
+
+@_silgen_name("swift_reflectionMirror_count")
+internal func _getChildCount<T>(_: T, type: Any.Type) -> Int
+
+@_silgen_name("swift_reflectionMirror_subscript")
+internal func _getChild<T>(
+  of: T, type: Any.Type, index: Int,
+  outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
+  outFreeFunc: UnsafeMutablePointer<(@convention(c) (UnsafePointer<CChar>?) -> Void)?>
+) -> Any
+#endif
+
+internal struct _FastChildIterator: IteratorProtocol {
+    private final class _CStringBox {
+        let ptr: UnsafePointer<CChar>
+        let freeFunc: (@convention(c) (UnsafePointer<CChar>?) -> Void)
+        init(ptr: UnsafePointer<CChar>, freeFunc: @escaping @convention(c) (UnsafePointer<CChar>?) -> Void) {
+            self.ptr = ptr
+            self.freeFunc = freeFunc
+        }
+        deinit { self.freeFunc(self.ptr) }
+    }
+    
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+    private let subject: AnyObject
+    private let type: Any.Type
+    private let childCount: Int
+    private var index: Int
+#else
+    private var iterator: Mirror.Children.Iterator
+#endif
+    private var lastNameBox: _CStringBox?
+    
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+    fileprivate init(subject: AnyObject, type: Any.Type, childCount: Int) {
+        self.subject = subject
+        self.type = type
+        self.childCount = childCount
+        self.index = 0
+    }
+#else
+    fileprivate init(iterator: Mirror.Children.Iterator) {
+        self.iterator = iterator
+    }
+#endif
+    
+    init(subject: AnyObject) {
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+        let type = _getNormalizedType(subject, type: Swift.type(of: subject))
+        self.init(
+            subject: subject,
+            type: type,
+            childCount: _getChildCount(subject, type: type)
+        )
+#else
+        self.init(iterator: Mirror(reflecting: subject).children.makeIterator())
+#endif
+    }
+    
+    /// The `name` pointer returned by this iterator has a rather unusual lifetime guarantee - it shall remain valid
+    /// until either the proceeding call to `next()` or the end of the iterator's scope. This admittedly bizarre
+    /// semantic is a concession to the fact that this entire API is intended to bypass the massive speed penalties of
+    /// `Mirror` as much as possible, and copying a name that many callers will never even access to begin with is
+    /// hardly a means to that end.
+    ///
+    /// - Note: Ironically, in the fallback case that uses `Mirror` directly, preserving this semantic actually imposes
+    ///   an _additional_ performance penalty.
+    mutating func next() -> (name: UnsafePointer<CChar>?, child: Any)? {
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+        guard self.index < self.childCount else {
+            self.lastNameBox = nil // ensure any lingering name gets freed
+            return nil
+        }
+
+        var nameC: UnsafePointer<CChar>? = nil
+        var freeFunc: (@convention(c) (UnsafePointer<CChar>?) -> Void)? = nil
+        let child = _getChild(of: self.subject, type: self.type, index: self.index, outName: &nameC, outFreeFunc: &freeFunc)
+        
+        self.index += 1
+        self.lastNameBox = nameC.flatMap { nameC in freeFunc.map { _CStringBox(ptr: nameC, freeFunc: $0) } } // don't make a box if there's no name or no free function to call
+        return (name: nameC, child: child)
+#else
+        guard let child = self.iterator.next() else {
+            self.lastNameBox = nil
+            return nil
+        }
+        if let label = child.label {
+            var nameC = calloc(label.utf8.count + 1, MemoryLayout<CChar>.size)
+            memcpy(nameC, label.utf8, label.utf8.count)
+            self.lastNameBox = _CStringBox(name: nameC, freeFunc: free(_:))
+            return (name: nameC, child: child.value)
+        } else {
+            self.lastNameBox = nil
+            return (name: nil, child: child.value)
+        }
+#endif
+    }
+}
+
+internal struct _FastChildSequence: Sequence {
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+    private let subject: AnyObject
+    private let type: Any.Type
+    private let childCount: Int
+#else
+    private let children: Mirror.Children
+#endif
+
+    init(subject: AnyObject) {
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+        self.subject = subject
+        self.type = _getNormalizedType(subject, type: Swift.type(of: subject))
+        self.childCount = _getChildCount(subject, type: self.type)
+#else
+        self.children = Mirror(reflecting: subject).children
+#endif
+    }
+    
+    func makeIterator() -> _FastChildIterator {
+#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+        .init(subject: self.subject, type: self.type, childCount: self.childCount)
+#else
+        .init(iterator: self.children.makeIterator())
+#endif
+    }
+}

--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -93,11 +93,11 @@ internal struct _FastChildIterator: IteratorProtocol {
             self.lastNameBox = nil
             return nil
         }
-        if let label = child.label {
-            var nameC = calloc(label.utf8.count + 1, MemoryLayout<CChar>.size)
-            memcpy(nameC, label.utf8, label.utf8.count)
-            self.lastNameBox = _CStringBox(name: nameC, freeFunc: free(_:))
-            return (name: nameC, child: child.value)
+        if var label = child.label {
+            let nameC = calloc(label.utf8.count + 1, MemoryLayout<CChar>.size).bindMemory(to: CChar.self, capacity: label.utf8.count + 1)
+            label.withUTF8 { _ = memcpy(nameC, $0.baseAddress!, $0.count) }
+            self.lastNameBox = _CStringBox(ptr: UnsafePointer(nameC), freeFunc: { free($0.map { UnsafeMutableRawPointer(mutating: $0) }) })
+            return (name: UnsafePointer(nameC), child: child.value)
         } else {
             self.lastNameBox = nil
             return (name: nil, child: child.value)

--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -1,4 +1,10 @@
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin.C
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#endif
+
+#if compiler(<5.7) && compiler(>=5.2)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
@@ -24,7 +30,7 @@ internal struct _FastChildIterator: IteratorProtocol {
         deinit { self.freeFunc(self.ptr) }
     }
     
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -34,7 +40,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 #endif
     private var lastNameBox: _CStringBox?
     
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2)
     fileprivate init(subject: AnyObject, type: Any.Type, childCount: Int) {
         self.subject = subject
         self.type = type
@@ -48,7 +54,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 #endif
     
     init(subject: AnyObject) {
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2)
         let type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.init(
             subject: subject,
@@ -69,7 +75,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     /// - Note: Ironically, in the fallback case that uses `Mirror` directly, preserving this semantic actually imposes
     ///   an _additional_ performance penalty.
     mutating func next() -> (name: UnsafePointer<CChar>?, child: Any)? {
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2)
         guard self.index < self.childCount else {
             self.lastNameBox = nil // ensure any lingering name gets freed
             return nil
@@ -101,7 +107,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 }
 
 internal struct _FastChildSequence: Sequence {
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -110,7 +116,7 @@ internal struct _FastChildSequence: Sequence {
 #endif
 
     init(subject: AnyObject) {
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
+#if compiler(<5.7) && compiler(>=5.2)
         self.subject = subject
         self.type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.childCount = _getChildCount(subject, type: self.type)
@@ -120,10 +126,10 @@ internal struct _FastChildSequence: Sequence {
     }
     
     func makeIterator() -> _FastChildIterator {
-#if compiler(<5.7) && compiler(>=5.2) && swift(>=5.2)
-        .init(subject: self.subject, type: self.type, childCount: self.childCount)
+#if compiler(<5.7) && compiler(>=5.2)
+        return _FastChildIterator(subject: self.subject, type: self.type, childCount: self.childCount)
 #else
-        .init(iterator: self.children.makeIterator())
+        return _FastChildIterator(iterator: self.children.makeIterator())
 #endif
     }
 }

--- a/Tests/FluentKitTests/AsyncTests/AsyncFilterQueryTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncFilterQueryTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 #if !os(Linux)
-@testable import FluentKit
-@testable import FluentBenchmark
+import FluentKit
+import FluentBenchmark
 import XCTest
 import Foundation
 import FluentSQL

--- a/Tests/FluentKitTests/AsyncTests/AsyncFluentKitTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncFluentKitTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 #if !os(Linux)
-@testable import FluentKit
-@testable import FluentBenchmark
+import FluentKit
+import FluentBenchmark
 import XCTest
 import Foundation
 import FluentSQL

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 #if !os(Linux)
-@testable import FluentKit
-@testable import FluentBenchmark
+import FluentKit
+import FluentBenchmark
 import XCTest
 import Foundation
 import XCTFluent

--- a/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
+++ b/Tests/FluentKitTests/DummyDatabaseForTestSQLSerializer.swift
@@ -1,4 +1,4 @@
-@testable import FluentKit
+import FluentKit
 import FluentSQL
 import NIOEmbedded
 import SQLKit

--- a/Tests/FluentKitTests/FilterQueryTests.swift
+++ b/Tests/FluentKitTests/FilterQueryTests.swift
@@ -5,8 +5,8 @@
 //  Created by Mathew Polzin on 3/8/20.
 //
 
-@testable import FluentKit
-@testable import FluentBenchmark
+import FluentKit
+import FluentBenchmark
 import XCTest
 import Foundation
 import FluentSQL

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -1,5 +1,5 @@
-@testable import FluentKit
-@testable import FluentBenchmark
+import FluentKit
+import FluentBenchmark
 import XCTest
 import Foundation
 import FluentSQL

--- a/Tests/FluentKitTests/OptionalEnumQueryTests.swift
+++ b/Tests/FluentKitTests/OptionalEnumQueryTests.swift
@@ -1,4 +1,4 @@
-@testable import FluentKit
+import FluentKit
 import FluentSQL
 import Foundation
 import XCTest

--- a/Tests/FluentKitTests/OptionalFieldQueryTests.swift
+++ b/Tests/FluentKitTests/OptionalFieldQueryTests.swift
@@ -1,4 +1,4 @@
-@testable import FluentKit
+import FluentKit
 import FluentSQL
 import Foundation
 import XCTest

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -1,5 +1,5 @@
-@testable import FluentKit
-@testable import FluentBenchmark
+import FluentKit
+import FluentBenchmark
 import XCTest
 import Foundation
 import XCTFluent


### PR DESCRIPTION
Refactors the workaround into its own `IteratorProtocol` and `Sequence` implementation, and starts using the workaround for `AnyModel.anyID` for good measure (this was not happening before).

Also removes unneeded `@testable` imports from the tests.