### PR TITLE
Fix input handling for `EnumProperty` and `OptionalEnumProperty`

### DIFF
--- a/Sources/FluentBenchmark/Tests/EnumTests.swift
+++ b/Sources/FluentBenchmark/Tests/EnumTests.swift
@@ -13,11 +13,13 @@ extension FluentBenchmarker {
             FooMigration()
         ]) {
             let foo = Foo(bar: .baz, baz: .qux)
+            XCTAssertTrue(foo.hasChanges)
             try foo.save(on: self.database).wait()
 
             let fetched = try Foo.find(foo.id, on: self.database).wait()
             XCTAssertEqual(fetched?.bar, .baz)
             XCTAssertEqual(fetched?.baz, .qux)
+            XCTAssertEqual(fetched?.hasChanges, false)
         }
     }
 

--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -84,7 +84,7 @@ extension EnumProperty: AnyDatabaseProperty {
         case .enumCase(let string):
             input.set(.enumCase(string), at: self.field.key)
         default:
-            fatalError("Unexpected input value type on '\(Model.self): \(value)")
+            fatalError("Unexpected input value type for '\(Model.self).'\(self.field.key)': \(value)")
         }
     }
 

--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -76,8 +76,15 @@ extension EnumProperty: AnyDatabaseProperty {
     }
 
     public func input(to input: DatabaseInput) {
-        if let value = self.value {
-            input.set(.enumCase(value.rawValue), at: self.field.key)
+        guard let value = self.field.inputValue else { return }
+
+        switch value {
+        case .bind(let bind as String):
+            input.set(.enumCase(bind), at: self.field.key)
+        case .enumCase(let string):
+            input.set(.enumCase(string), at: self.field.key)
+        default:
+            fatalError("Unexpected input value type on '\(Model.self): \(value)")
         }
     }
 

--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -84,7 +84,7 @@ extension EnumProperty: AnyDatabaseProperty {
         case .enumCase(let string):
             input.set(.enumCase(string), at: self.field.key)
         default:
-            fatalError("Unexpected input value type for '\(Model.self).'\(self.field.key)': \(value)")
+            fatalError("Unexpected input value type for '\(Model.self)'.'\(self.field.key)': \(value)")
         }
     }
 

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -82,8 +82,17 @@ extension OptionalEnumProperty: AnyDatabaseProperty {
     }
 
     public func input(to input: DatabaseInput) {
-        if let value = self.value {
-            input.set(value.map { .enumCase($0.rawValue) } ?? .null, at: self.field.key)
+        guard let value = self.field.inputValue else { return }
+
+        switch value {
+        case .bind(let bind as String):
+            input.set(.enumCase(bind), at: self.field.key)
+        case .enumCase(let string):
+            input.set(.enumCase(string), at: self.field.key)
+        case .null:
+            input.set(.null, at: self.field.key)
+        default:
+            fatalError("Unexpected input value type on '\(Model.self): \(value)")
         }
     }
 

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -92,7 +92,7 @@ extension OptionalEnumProperty: AnyDatabaseProperty {
         case .null:
             input.set(.null, at: self.field.key)
         default:
-            fatalError("Unexpected input value type for '\(Model.self).'\(self.field.key)': \(value)")
+            fatalError("Unexpected input value type for '\(Model.self)'.'\(self.field.key)': \(value)")
         }
     }
 

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -92,7 +92,7 @@ extension OptionalEnumProperty: AnyDatabaseProperty {
         case .null:
             input.set(.null, at: self.field.key)
         default:
-            fatalError("Unexpected input value type on '\(Model.self): \(value)")
+            fatalError("Unexpected input value type for '\(Model.self).'\(self.field.key)': \(value)")
         }
     }
 


### PR DESCRIPTION
`input(to input: DatabaseInput)` on `EnumProperty` and `OptionalEnumProperty` was incorrectly using the value instead of the inputValue. This caused `Model.hasChanges` to always return true for any model with an Enum property. Additionally Enum properties would always be updated in queries generated by `Model.update(on:)`.

