### PR TITLE
Make accessing `model.id` safe

### DIFF
--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -362,7 +362,8 @@ private struct SiblingsEagerLoader<From, To, Through>: EagerLoader
                 map[fromID, default: []].append(to)
             }
             for model in models {
-                model[keyPath: self.relationKey].value = map[model.id!] ?? []
+                guard let id = model.id else { throw FluentError.idRequired }
+                model[keyPath: self.relationKey].value = map[id] ?? []
             }
         }
     }


### PR DESCRIPTION
This removes force unwraps when accessing a model's ID in the CRUD operations and changes them to throw an error instead to make the code safer.

Resolves #495 
