### PR TITLE
Add basic support for further qualifying model schemas

### DIFF
--- a/Sources/FluentKit/Model/ModelAlias.swift
+++ b/Sources/FluentKit/Model/ModelAlias.swift
@@ -19,6 +19,10 @@ public protocol _ModelAlias: Schema {
 }
 
 extension _ModelAlias {
+    public static var space: String? {
+        Model.space
+    }
+    
     public static var schema: String {
         Model.schema
     }

--- a/Sources/FluentKit/Model/Schema.swift
+++ b/Sources/FluentKit/Model/Schema.swift
@@ -1,9 +1,12 @@
 public protocol Schema: Fields {
+    static var space: String? { get }
     static var schema: String { get }
     static var alias: String? { get }
 }
 
 extension Schema {
+    public static var space: String? { nil }
+    
     public static var schemaOrAlias: String {
         self.alias ?? self.schema
     }

--- a/Sources/FluentKit/Operators/FieldOperators.swift
+++ b/Sources/FluentKit/Operators/FieldOperators.swift
@@ -2,9 +2,9 @@ extension QueryBuilder {
     @discardableResult
     public func filter(_ filter: ModelFieldFilter<Model, Model>) -> Self {
         self.filter(
-            .path(filter.lhsPath, schema: Model.schema),
+            .extendedPath(filter.lhsPath, schema: Model.schema, space: Model.space),
             filter.method,
-            .path(filter.rhsPath, schema: Model.schema)
+            .extendedPath(filter.rhsPath, schema: Model.schema, space: Model.space)
         )
     }
 
@@ -13,9 +13,9 @@ extension QueryBuilder {
         where Left: Schema, Right: Schema
     {
         self.filter(
-            .path(filter.lhsPath, schema: Left.schemaOrAlias),
+            .extendedPath(filter.lhsPath, schema: Left.schemaOrAlias, space: Left.space),
             filter.method,
-            .path(filter.rhsPath, schema: Right.schemaOrAlias)
+            .extendedPath(filter.rhsPath, schema: Right.schemaOrAlias, space: Right.space)
         )
     }
 }

--- a/Sources/FluentKit/Operators/ValueOperators.swift
+++ b/Sources/FluentKit/Operators/ValueOperators.swift
@@ -12,7 +12,7 @@ extension QueryBuilder {
         where Joined: Schema
     {
         self.filter(
-            .path(filter.path, schema: Joined.schemaOrAlias),
+            .extendedPath(filter.path, schema: Joined.schemaOrAlias, space: Joined.space),
             filter.method,
             filter.value
         )

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -199,9 +199,10 @@ extension Schema {
         guard let timestamp = self.init().deletedTimestamp else {
             return
         }
-        let deletedAtField = DatabaseQuery.Field.path(
+        let deletedAtField = DatabaseQuery.Field.extendedPath(
             [timestamp.key],
-            schema: self.schemaOrAlias
+            schema: self.schemaOrAlias,
+            space: self.space
         )
         query.filters.append(.group([
             .value(deletedAtField, .equal, .null),

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Aggregate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Aggregate.swift
@@ -124,7 +124,7 @@ extension QueryBuilder {
         // Set custom action.
         copy.query.action = .aggregate(
             .field(
-                .path(path, schema: Model.schema),
+                .extendedPath(path, schema: Model.schema, space: Model.space),
                 method
             )
         )

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Filter.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Filter.swift
@@ -9,9 +9,10 @@ extension QueryBuilder {
     ) -> Self
         where Field: QueryableProperty, Field.Model == Model
     {
-        self.filter(.path(
+        self.filter(.extendedPath(
             Model.path(for: field),
-            schema: Model.schemaOrAlias
+            schema: Model.schemaOrAlias,
+            space: Model.space
         ), method, Field.queryValue(value))
     }
 
@@ -24,9 +25,10 @@ extension QueryBuilder {
     ) -> Self
         where Joined: Schema, Field: QueryableProperty, Field.Model == Joined
     {
-        self.filter(.path(
+        self.filter(.extendedPath(
             Joined.path(for: field),
-            schema: Joined.schemaOrAlias
+            schema: Joined.schemaOrAlias,
+            space: Joined.space
         ), method, Field.queryValue(value))
     }
 
@@ -64,7 +66,7 @@ extension QueryBuilder {
         where Value: Codable
     {
         self.filter(
-            .path(fieldPath, schema: Model.schema),
+            .extendedPath(fieldPath, schema: Model.schema, space: Model.space),
             method,
             .bind(value)
         )
@@ -86,9 +88,9 @@ extension QueryBuilder {
         _ rightPath: [FieldKey]
     ) -> Self {
         self.filter(
-            .path(leftPath, schema: Model.schema),
+            .extendedPath(leftPath, schema: Model.schema, space: Model.space),
             method,
-            .path(rightPath, schema: Model.schema)
+            .extendedPath(rightPath, schema: Model.schema, space: Model.space)
         )
     }
 

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
@@ -269,12 +269,13 @@ extension QueryBuilder {
         where Foreign: Schema, Local: Schema
     {
         self.models.append(Foreign.self)
-        self.query.joins.append(.join(
+        self.query.joins.append(.extendedJoin(
             schema: Foreign.schema,
+            space: Foreign.space,
             alias: Foreign.alias,
             method,
-            foreign: .path(foreignPath, schema: Foreign.schemaOrAlias),
-            local: .path(localPath, schema: Local.schemaOrAlias)
+            foreign: .extendedPath(foreignPath, schema: Foreign.schemaOrAlias, space: Foreign.space),
+            local: .extendedPath(localPath, schema: Local.schemaOrAlias, space: Local.space)
         ))
         return self
     }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Sort.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Sort.swift
@@ -23,7 +23,7 @@ extension QueryBuilder {
         _ path: [FieldKey],
         _ direction: DatabaseQuery.Sort.Direction = .ascending
     ) -> Self {
-        self.sort(.path(path, schema: Model.schema), direction)
+        self.sort(.extendedPath(path, schema: Model.schema, space: Model.space), direction)
     }
 
     public func sort<Joined, Field>(
@@ -59,7 +59,7 @@ extension QueryBuilder {
     ) -> Self
         where Joined: Schema
     {
-        self.sort(.path(path, schema: Joined.schemaOrAlias), direction)
+        self.sort(.extendedPath(path, schema: Joined.schemaOrAlias, space: Joined.space), direction)
     }
 
     public func sort(

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Field.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Field.swift
@@ -1,6 +1,7 @@
 extension DatabaseQuery {
     public enum Field {
         case path([FieldKey], schema: String)
+        case extendedPath([FieldKey], schema: String, space: String?)
         case custom(Any)
     }
 }
@@ -10,6 +11,8 @@ extension DatabaseQuery.Field: CustomStringConvertible {
         switch self {
         case .path(let path, let schema):
             return "\(schema)\(path)"
+        case .extendedPath(let path, let schema, let space):
+            return "\(space.map { "\($0)." } ?? "")\(schema)\(path)"
         case .custom(let custom):
             return "custom(\(custom))"
         }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Join.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Join.swift
@@ -13,6 +13,16 @@ extension DatabaseQuery {
             foreign: Field,
             local: Field
         )
+        
+        case extendedJoin(
+            schema: String,
+            space: String?,
+            alias: String?,
+            Method,
+            foreign: Field,
+            local: Field
+        )
+        
         case custom(Any)
     }
 }
@@ -26,6 +36,14 @@ extension DatabaseQuery.Join: CustomStringConvertible {
                 schemaString = "\(schema) as \(alias)"
             } else {
                 schemaString = "\(schema)"
+            }
+            return "\(schemaString) \(method) on \(foreign) == \(local)"
+        case .extendedJoin(let schema, let space, let alias, let method, let foreign, let local):
+            let schemaString: String
+            if let alias = alias {
+                schemaString = "\(space.map { "\($0)." } ?? "")\(schema) as \(alias)"
+            } else {
+                schemaString = "\(space.map { "\($0)." } ?? "")\(schema)"
             }
             return "\(schemaString) \(method) on \(foreign) == \(local)"
         case .custom(let custom):

--- a/Sources/FluentKit/Query/Database/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery.swift
@@ -1,5 +1,6 @@
 public struct DatabaseQuery {
     public var schema: String
+    public var space: String?
     public var customIDKey: FieldKey?
     public var isUnique: Bool
     public var fields: [Field]
@@ -11,8 +12,9 @@ public struct DatabaseQuery {
     public var limits: [Limit]
     public var offsets: [Offset]
 
-    init(schema: String) {
+    init(schema: String, space: String? = nil) {
         self.schema = schema
+        self.space = space
         self.isUnique = false
         self.fields = []
         self.action = .read
@@ -30,8 +32,11 @@ extension DatabaseQuery: CustomStringConvertible {
         var parts = [
             "query",
             "\(self.action)",
-            self.schema
         ]
+        if let space = self.space {
+            parts.append(space)
+        }
+        parts.append(self.schema)
         if self.isUnique {
             parts.append("unique")
         }

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -67,12 +67,14 @@ public struct DatabaseSchema {
     public enum FieldConstraint {
         public static func references(
             _ schema: String,
+            space: String? = nil,
             _ field: FieldKey,
             onDelete: ForeignKeyAction = .noAction,
             onUpdate: ForeignKeyAction = .noAction
         ) -> Self {
             .foreignKey(
                 schema,
+                space: space,
                 .key(field),
                 onDelete: onDelete,
                 onUpdate: onUpdate
@@ -83,6 +85,7 @@ public struct DatabaseSchema {
         case identifier(auto: Bool)
         case foreignKey(
             _ schema: String,
+            space: String? = nil,
             _ field: FieldName,
             onDelete: ForeignKeyAction,
             onUpdate: ForeignKeyAction
@@ -100,6 +103,7 @@ public struct DatabaseSchema {
         case foreignKey(
             _ fields: [FieldName],
             _ schema: String,
+            space: String? = nil,
             _ foreign: [FieldName],
             onDelete: ForeignKeyAction,
             onUpdate: ForeignKeyAction
@@ -142,6 +146,7 @@ public struct DatabaseSchema {
 
     public var action: Action
     public var schema: String
+    public var space: String?
     public var createFields: [FieldDefinition]
     public var updateFields: [FieldUpdate]
     public var deleteFields: [FieldName]
@@ -149,9 +154,10 @@ public struct DatabaseSchema {
     public var deleteConstraints: [ConstraintDelete]
     public var exclusiveCreate: Bool
     
-    public init(schema: String) {
+    public init(schema: String, space: String? = nil) {
         self.action = .create
         self.schema = schema
+        self.space = space
         self.createFields = []
         self.updateFields = []
         self.deleteFields = []

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -1,6 +1,6 @@
 extension Database {
-    public func schema(_ schema: String) -> SchemaBuilder {
-        return .init(database: self, schema: schema)
+    public func schema(_ schema: String, space: String? = nil) -> SchemaBuilder {
+        return .init(database: self, schema: schema, space: space)
     }
 }
 
@@ -8,9 +8,9 @@ public final class SchemaBuilder {
     let database: Database
     public var schema: DatabaseSchema
 
-    init(database: Database, schema: String) {
+    init(database: Database, schema: String, space: String? = nil) {
         self.database = database
-        self.schema = .init(schema: schema)
+        self.schema = .init(schema: schema, space: space)
     }
 
     public func id() -> Self {
@@ -66,6 +66,7 @@ public final class SchemaBuilder {
     public func foreignKey(
         _ field: FieldKey,
         references foreignSchema: String,
+        inSpace foreignSpace: String? = nil,
         _ foreignField: FieldKey,
         onDelete: DatabaseSchema.ForeignKeyAction = .noAction,
         onUpdate: DatabaseSchema.ForeignKeyAction = .noAction,
@@ -75,6 +76,7 @@ public final class SchemaBuilder {
             .foreignKey(
                 [.key(field)],
                 foreignSchema,
+                space: foreignSpace,
                 [.key(foreignField)],
                 onDelete: onDelete,
                 onUpdate: onUpdate

--- a/Sources/FluentSQL/SQLQualifiedTable.swift
+++ b/Sources/FluentSQL/SQLQualifiedTable.swift
@@ -1,0 +1,23 @@
+import SQLKit
+
+public struct SQLQualifiedTable: SQLExpression {
+    public var table: SQLExpression
+    public var space: SQLExpression?
+    
+    public init(_ table: String, space: String? = nil) {
+        self.init(SQLIdentifier(table), space: space.flatMap(SQLIdentifier.init(_:)))
+    }
+    
+    public init(_ table: SQLExpression, space: SQLExpression? = nil) {
+        self.table = table
+        self.space = space
+    }
+    
+    public func serialize(to serializer: inout SQLSerializer) {
+        if let space = self.space {
+            space.serialize(to: &serializer)
+            serializer.write(".")
+        }
+        self.table.serialize(to: &serializer)
+    }
+}

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -158,6 +158,10 @@ final class AsyncQueryBuilderTests: XCTestCase {
             case .path(let path, let schema):
                 XCTAssertEqual(path, ["name"])
                 XCTAssertEqual(schema, "stars")
+            case .extendedPath(let path, let schema, let space):
+                XCTAssertEqual(path, ["name"])
+                XCTAssertEqual(schema, "stars")
+                XCTAssertNil(space)
             default:
                 XCTFail("\(field)")
             }

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -155,6 +155,10 @@ final class QueryBuilderTests: XCTestCase {
             case .path(let path, let schema):
                 XCTAssertEqual(path, ["name"])
                 XCTAssertEqual(schema, "stars")
+            case .extendedPath(let path, let schema, let space):
+                XCTAssertEqual(path, ["name"])
+                XCTAssertEqual(schema, "stars")
+                XCTAssertNil(space)
             default: 
                 XCTFail("\(field)")
             }


### PR DESCRIPTION
This supports the partitioning of individual Fluent models between PostgreSQL schemas, MySQL databases, and multiple attached SQLite databases. 