### PR TITLE
Support multi-column foreign key constraint in `SchemaBuilder`

### DIFF
--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -86,6 +86,29 @@ public final class SchemaBuilder {
         return self
     }
 
+    public func foreignKey(
+        _ fields: [FieldKey],
+        references foreignSchema: String,
+        inSpace foreignSpace: String? = nil,
+        _ foreignFields: [FieldKey],
+        onDelete: DatabaseSchema.ForeignKeyAction = .noAction,
+        onUpdate: DatabaseSchema.ForeignKeyAction = .noAction,
+        name: String? = nil
+    ) -> Self {
+        self.schema.createConstraints.append(.constraint(
+            .foreignKey(
+                fields.map({.key($0)}),
+                foreignSchema,
+                space: foreignSpace,
+                foreignFields.map({.key($0)}),
+                onDelete: onDelete,
+                onUpdate: onUpdate
+            ),
+            name: name
+        ))
+        return self
+    }
+
     public func updateField(
         _ key: FieldKey,
         _ dataType: DatabaseSchema.DataType

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -233,6 +233,20 @@ final class FluentKitTests: XCTestCase {
             .wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
         XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, CONSTRAINT "fk:planets.galaxy_id+planets.id" FOREIGN KEY ("galaxy_id") REFERENCES "galaxies" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)"#)
+        db.reset()
+
+        try db.schema("planets")
+            .field("galaxy_id", .int64)
+            .field("galaxy_name", .string)
+            .foreignKey(
+                ["galaxy_id", "galaxy_name"],
+                references: "galaxies", ["id", "name"],
+                onUpdate: .cascade
+            )
+            .create()
+            .wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"CREATE TABLE "planets"("galaxy_id" BIGINT, "galaxy_name" TEXT, CONSTRAINT "fk:planets.galaxy_id+planets.galaxy_name+planets.id+planets.name" FOREIGN KEY ("galaxy_id", "galaxy_name") REFERENCES "galaxies" ("id", "name") ON DELETE NO ACTION ON UPDATE CASCADE)"#)
     }
     
     func testIfNotExistsTableCreate() throws {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

This adds the missing multi-column foreign key constraint support to `SchemaBuilder`.

Now you can create foreign key constraints that reference multiple fields when building the schema:
```swift
db.schema("planets")
    .field("galaxy_id", .int64)
    .field("galaxy_name", .string)
    .foreignKey(
        ["galaxy_id", "galaxy_name"],
        references: "galaxies", ["id", "name"]
    )
    .create()
```

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
