### PR TITLE
Allow public use of `TimestampFormatFactory.makeFormat()`

### DIFF
--- a/Sources/FluentKit/Properties/TimestampFormat.swift
+++ b/Sources/FluentKit/Properties/TimestampFormat.swift
@@ -12,7 +12,7 @@ public protocol TimestampFormat {
 }
 
 public struct TimestampFormatFactory<Format> {
-    let makeFormat: () -> Format
+    public let makeFormat: () -> Format
     
     public init(_ makeFormat: @escaping () -> Format) {
         self.makeFormat = makeFormat

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -33,10 +33,9 @@ public struct SQLQueryConverter {
             fatalError("Missing query input generating update query")
         }
         values.forEach { (key, value) in
-            update.values.append(SQLBinaryExpression(
-                left: SQLColumn(self.key(key)),
-                op: SQLBinaryOperator.equal,
-                right: self.value(value)
+            update.values.append(SQLColumnAssignment(
+                setting: SQLColumn(self.key(key)),
+                to: self.value(value)
             ))
         }
         update.predicate = self.filters(query.filters)


### PR DESCRIPTION
This enables using the various `TimestampFormat`s outside of `@Timestamp` and defining alternatives to `@Timestamp` (such as `@RequiredTimestamp`).