### PR TITLE
Make the `$id.exists` flag on models more generically available

### DIFF
--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -26,6 +26,21 @@ extension Model {
         }
         return id
     }
+    
+    /// Replaces the existing common usage of `model._$id.exists`, which indicates whether any
+    /// particular generic model has a non-`nil` ID that was loaded from a database query (or
+    /// was overridden to allow Fluent to assume as such without having to check first). This
+    /// version works for models which use `@CompositeID()`. It would not be necessary if
+    /// support existed for property wrappers in protocols.
+    ///
+    /// - Note: Adding this property to ``Model`` rather than making the ``AnyID`` protocol
+    ///   and ``anyID`` property public was chosen because implementing a new conformance for
+    ///   ``AnyID`` can not be done correctly from outside FluentKit; it would be mostly useless
+    ///   and potentially confusing public API surface.
+    public var _$idExists: Bool {
+        get { self.anyID.exists }
+        set { self.anyID.exists = newValue }
+    }
 
     public var _$id: ID<IDValue> {
         self.anyID as! ID<IDValue>


### PR DESCRIPTION
Simplifies working with generic models which may or may not have composite IDs.