### PR TITLE
Add missing info to missingParent error, fix ID compare for composite IDs

### DIFF
--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -1,3 +1,4 @@
+import XCTest
 extension FluentBenchmarker {
     public func testSoftDelete() throws {
         try self.testSoftDelete_model()
@@ -208,7 +209,13 @@ extension FluentBenchmarker {
             // this should throw an error now because one of the
             // parents is missing and the results cannot be loaded
             XCTAssertThrowsError(try Foo.query(on: self.database).with(\.$bar).all().wait()) { error in
-                XCTAssertEqual("\(error)", FluentError.missingParent.description)
+                guard case let .missingParent(from, to, key, id) = error as? FluentError else {
+                    return XCTFail("Expected FluentError.missingParent, but got \(error)")
+                }
+                XCTAssertEqual(from, "\(Foo.self)")
+                XCTAssertEqual(to, "\(Bar.self)")
+                XCTAssertEqual(key, "bar")
+                XCTAssertEqual(id, "\(bar1.id!)")
             }
         }
     }

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -5,7 +5,7 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
     case invalidField(name: String, valueType: Any.Type, error: Error)
     case missingField(name: String)
     case relationNotLoaded(name: String)
-    case missingParent
+    case missingParent(from: String, to: String, key: String, id: String)
     case noResults
 
     public var description: String {
@@ -16,8 +16,8 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
             return "field missing: \(name)"
         case .relationNotLoaded(let name):
             return "relation not loaded: \(name)"
-        case .missingParent:
-            return "parent missing"
+        case .missingParent(let model, let parent, let key, let id):
+            return "parent missing: \(model).\(key): \(parent).\(id)"
         case .invalidField(let name, let valueType, let error):
             return "invalid field: \(name) type: \(valueType) error: \(error)"
         case .noResults:

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -161,7 +161,12 @@ private struct ParentEagerLoader<From, To>: EagerLoader
                     $0.id == model[keyPath: self.relationKey].id
                 }).first else {
                     database.logger.debug("No parent '\(To.self)' with id '\(model[keyPath: self.relationKey].id)' was found in eager-load results.")
-                    throw FluentError.missingParent
+                    throw FluentError.missingParent(
+                        from: "\(From.self)",
+                        to: "\(To.self)",
+                        key: From.path(for: self.relationKey.appending(path: \.$id)).first!.description,
+                        id: "\(model[keyPath: self.relationKey].id)"
+                    )
                 }
                 model[keyPath: self.relationKey].value = parent
             }


### PR DESCRIPTION
- The `missingParent` case of `FluentError` now contains detailed information about which model was missing as part of the error itself. (Yes, this is technically a public API-breaking change, but I'm invoking the "enums are a messy edge case for semver" exception because it's a real problem that this info has been missing from the API.)
- `.filter(\.$id == ...)` and `.filter(\.$id != ...)` now work when the queried model is using `@CompositeID`.