### PR TITLE
Enable MirrorBypass in Swift 5.7

### DIFF
--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -4,7 +4,7 @@ import Darwin.C
 import Glibc
 #endif
 
-#if compiler(<5.7) && compiler(>=5.2)
+#if compiler(<5.8) && compiler(>=5.2)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
@@ -30,7 +30,7 @@ internal struct _FastChildIterator: IteratorProtocol {
         deinit { self.freeFunc(self.ptr) }
     }
     
-#if compiler(<5.7) && compiler(>=5.2)
+#if compiler(<5.8) && compiler(>=5.2)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -40,7 +40,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 #endif
     private var lastNameBox: _CStringBox?
     
-#if compiler(<5.7) && compiler(>=5.2)
+#if compiler(<5.8) && compiler(>=5.2)
     fileprivate init(subject: AnyObject, type: Any.Type, childCount: Int) {
         self.subject = subject
         self.type = type
@@ -54,7 +54,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 #endif
     
     init(subject: AnyObject) {
-#if compiler(<5.7) && compiler(>=5.2)
+#if compiler(<5.8) && compiler(>=5.2)
         let type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.init(
             subject: subject,
@@ -75,7 +75,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     /// - Note: Ironically, in the fallback case that uses `Mirror` directly, preserving this semantic actually imposes
     ///   an _additional_ performance penalty.
     mutating func next() -> (name: UnsafePointer<CChar>?, child: Any)? {
-#if compiler(<5.7) && compiler(>=5.2)
+#if compiler(<5.8) && compiler(>=5.2)
         guard self.index < self.childCount else {
             self.lastNameBox = nil // ensure any lingering name gets freed
             return nil
@@ -107,7 +107,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 }
 
 internal struct _FastChildSequence: Sequence {
-#if compiler(<5.7) && compiler(>=5.2)
+#if compiler(<5.8) && compiler(>=5.2)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -116,7 +116,7 @@ internal struct _FastChildSequence: Sequence {
 #endif
 
     init(subject: AnyObject) {
-#if compiler(<5.7) && compiler(>=5.2)
+#if compiler(<5.8) && compiler(>=5.2)
         self.subject = subject
         self.type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.childCount = _getChildCount(subject, type: self.type)
@@ -126,7 +126,7 @@ internal struct _FastChildSequence: Sequence {
     }
     
     func makeIterator() -> _FastChildIterator {
-#if compiler(<5.7) && compiler(>=5.2)
+#if compiler(<5.8) && compiler(>=5.2)
         return _FastChildIterator(subject: self.subject, type: self.type, childCount: self.childCount)
 #else
         return _FastChildIterator(iterator: self.children.makeIterator())


### PR DESCRIPTION
To date, the SPIs used by the Mirror bypass in Fluent are unchanged in Swift 5.7; therefore, enable the bypass in that version.