### PR TITLE
Explicitly forbid unsupported combinations of @CompositeID with @Parent etc.

### DIFF
--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -19,12 +19,20 @@ public final class ChildrenProperty<From, To>
 
     public var value: [To]?
 
-    public init(for parent: KeyPath<To, To.Parent<From>>) {
-        self.parentKey = .required(parent)
+    public convenience init(for parent: KeyPath<To, To.Parent<From>>) {
+        self.init(for: .required(parent))
     }
 
-    public init(for optionalParent: KeyPath<To, To.OptionalParent<From>>) {
-        self.parentKey = .optional(optionalParent)
+    public convenience init(for optionalParent: KeyPath<To, To.OptionalParent<From>>) {
+        self.init(for: .optional(optionalParent))
+    }
+    
+    private init(for parentKey: Key) {
+        guard !(From.IDValue.self is Fields.Type) /*From().anyId is AnyQueryAddressableProperty*/ else {
+            fatalError("Can not use @Children with a model whose ID is not addressable (this probably means '\(From.self)' uses `@CompositeID`).")
+        }
+
+        self.parentKey = parentKey
     }
 
     public var wrappedValue: [To] {

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -19,12 +19,20 @@ public final class OptionalChildProperty<From, To>
 
     public var value: To??
 
-    public init(for parent: KeyPath<To, To.Parent<From>>) {
-        self.parentKey = .required(parent)
+    public convenience init(for parent: KeyPath<To, To.Parent<From>>) {
+        self.init(for: .required(parent))
     }
 
-    public init(for optionalParent: KeyPath<To, To.OptionalParent<From>>) {
-        self.parentKey = .optional(optionalParent)
+    public convenience init(for optionalParent: KeyPath<To, To.OptionalParent<From>>) {
+        self.init(for: .optional(optionalParent))
+    }
+    
+    private init(for parentKey: Key) {
+        guard !(From.IDValue.self is Fields.Type) /*From().anyId is AnyQueryAddressableProperty*/ else {
+            fatalError("Can not use @OptionalChild with a model whose ID is not addressable (this probably means '\(From.self)' uses `@CompositeID`).")
+        }
+
+        self.parentKey = parentKey
     }
 
     public var wrappedValue: To? {

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -28,6 +28,10 @@ public final class OptionalParentProperty<From, To>
     public var value: To??
 
     public init(key: FieldKey) {
+        guard !(To.IDValue.self is Fields.Type) /*To().anyId is AnyQueryAddressableProperty*/ else {
+            fatalError("Can not use @OptionalParent to target a model whose ID is not addressable (this probably means '\(To.self)' uses `@CompositeID`).")
+        }
+
         self._id = .init(key: key)
     }
 

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -29,6 +29,10 @@ public final class ParentProperty<From, To>
     public var value: To?
 
     public init(key: FieldKey) {
+        guard !(To.IDValue.self is Fields.Type) /*To().anyId is AnyQueryAddressableProperty*/ else {
+            fatalError("Can not use @Parent to target a model whose ID is not addressable (this probably means '\(To.self)' uses `@CompositeID`).")
+        }
+        
         self._id = .init(key: key)
     }
 

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -39,6 +39,12 @@ public final class SiblingsProperty<From, To, Through>
         from: KeyPath<Through, Through.Parent<From>>,
         to: KeyPath<Through, Through.Parent<To>>
     ) {
+        guard !(From.IDValue.self is Fields.Type) /*From().anyId is AnyQueryAddressableProperty*/,
+              !(To.IDValue.self is Fields.Type) /*To().anyId is AnyQueryAddressableProperty*/
+        else {
+            fatalError("Can not use @Siblings with models whose IDs are not addressable (this probably means '\(From.self)' and/or '\(To.self)' uses `@CompositeID`).")
+        }
+
         self.from = from
         self.to = to
         self._pivots = ChildrenProperty<From, Through>(for: from)


### PR DESCRIPTION
Stopgap workaround for #512 / #513