### PR TITLE
Additional API for pagination to access individual page

### DIFF
--- a/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
@@ -216,6 +216,13 @@ public extension QueryBuilder {
     ) async throws -> Page<Model> {
         try await self.paginate(request).get()
     }
+    
+    func page(
+        withIndex page: Int,
+        size per: Int
+    ) async throws -> Page<Model> {
+        try await self.page(withIndex: page, size: per).get()
+    }
 }
 
 #endif

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -9,13 +9,27 @@ extension QueryBuilder {
     public func paginate(
         _ request: PageRequest
     ) -> EventLoopFuture<Page<Model>> {
+        page(withIndex: request.page, size: request.per)
+    }
+    
+    /// Returns a single `Page` out of the complete result set.
+    ///
+    /// This method will first `count()` the result set, then request a subset of the results using `range()` and `all()`.
+    ///
+    /// - Parameters:
+    ///   - page: The index of the page.
+    ///   - per: The size of the page.
+    /// - Returns: A single `Page` of the result set containing the requested items and page metadata.
+    public func page(
+        withIndex page: Int,
+        size per: Int) -> EventLoopFuture<Page<Model>> {
         let trimmedRequest: PageRequest = {
             guard let pageSizeLimit = database.context.pageSizeLimit else {
-                return .init(page: Swift.max(request.page, 1), per: Swift.max(request.per, 1))
+                return .init(page: Swift.max(page, 1), per: Swift.max(per, 1))
             }
             return .init(
-                page: Swift.max(request.page, 1),
-                per: Swift.max(Swift.min(request.per, pageSizeLimit), 1)
+                page: Swift.max(page, 1),
+                per: Swift.max(Swift.min(per, pageSizeLimit), 1)
             )
         }()
         let count = self.count()


### PR DESCRIPTION
Adds the ability to get a single page when paginating a request:

```swift
let page = try await Model.query(on: req.db).page(withIndex: 2, size: 10)
```