### PR TITLE
Add ability to control transactions

### DIFF
--- a/Sources/FluentKit/Database/TransactionControlDatabase.swift
+++ b/Sources/FluentKit/Database/TransactionControlDatabase.swift
@@ -1,0 +1,31 @@
+public protocol TransactionControlDatabase {
+    var context: DatabaseContext { get }
+
+    func beginTransaction() -> EventLoopFuture<Void>
+    func commitTransaction() -> EventLoopFuture<Void>
+    func rollbackTransaction() -> EventLoopFuture<Void>
+    
+    func withConnection<T>(_ closure: @escaping (TransactionControlDatabase) -> EventLoopFuture<T>) -> EventLoopFuture<T>
+}
+
+extension TransactionControlDatabase {
+    public var configuration: DatabaseConfiguration {
+        self.context.configuration
+    }
+    
+    public var logger: Logger {
+        self.context.logger
+    }
+    
+    public var eventLoop: EventLoop {
+        self.context.eventLoop
+    }
+
+    public var history: QueryHistory? {
+        self.context.history
+    }
+
+    public var pageSizeLimit: Int? {
+        self.context.pageSizeLimit
+    }
+}

--- a/Sources/FluentKit/Database/TransactionControlDatabase.swift
+++ b/Sources/FluentKit/Database/TransactionControlDatabase.swift
@@ -1,31 +1,5 @@
-public protocol TransactionControlDatabase {
-    var context: DatabaseContext { get }
-
+public protocol TransactionControlDatabase: Database {
     func beginTransaction() -> EventLoopFuture<Void>
     func commitTransaction() -> EventLoopFuture<Void>
     func rollbackTransaction() -> EventLoopFuture<Void>
-    
-    func withConnection<T>(_ closure: @escaping (TransactionControlDatabase) -> EventLoopFuture<T>) -> EventLoopFuture<T>
-}
-
-extension TransactionControlDatabase {
-    public var configuration: DatabaseConfiguration {
-        self.context.configuration
-    }
-    
-    public var logger: Logger {
-        self.context.logger
-    }
-    
-    public var eventLoop: EventLoop {
-        self.context.eventLoop
-    }
-
-    public var history: QueryHistory? {
-        self.context.history
-    }
-
-    public var pageSizeLimit: Int? {
-        self.context.pageSizeLimit
-    }
 }

--- a/Sources/FluentKit/Database/TransactionControlDatabase.swift
+++ b/Sources/FluentKit/Database/TransactionControlDatabase.swift
@@ -1,5 +1,21 @@
+/// Protocol for describing a database that allows fine-grained control over transcactions
+/// when you need more control than provided by `Database.transaction(_:)`
+///
+/// ⚠️ **WARNING**: it is the developer's responsiblity that they get hold of a `DatabaseConnection`
+/// and execute the transaction functions on that connection and ensure the functions aren't called across
+/// different conenctions. You are also responsible for ensuring that you commit or rollback queries
+/// when you're ready
 public protocol TransactionControlDatabase: Database {
+    /// Start the transaction on the current connection. This is equivalent to an SQL `BEGIN`
+    /// - Returns: future `Void` when the transaction has been started
     func beginTransaction() -> EventLoopFuture<Void>
+    /// Commit the queries executed for the transaction and write them to the database
+    /// This is equivalent to an SQL `COMMIT`
+    /// - Returns: future `Void` when the transaction has been committed
     func commitTransaction() -> EventLoopFuture<Void>
+    /// Rollback the current transaction's queries. You may want to trigger this when handling an error
+    /// when trying to create models.
+    /// This is equivalent to an SQL `ROLLBACK`
+    /// - Returns: future `Void` when the transaction has been rollbacked
     func rollbackTransaction() -> EventLoopFuture<Void>
 }

--- a/Sources/FluentKit/Database/TransactionControlDatabase.swift
+++ b/Sources/FluentKit/Database/TransactionControlDatabase.swift
@@ -5,6 +5,7 @@
 /// and execute the transaction functions on that connection and ensure the functions aren't called across
 /// different conenctions. You are also responsible for ensuring that you commit or rollback queries
 /// when you're ready
+/// You should not mix these functions and `Database.transaction(_:)`
 public protocol TransactionControlDatabase: Database {
     /// Start the transaction on the current connection. This is equivalent to an SQL `BEGIN`
     /// - Returns: future `Void` when the transaction has been started

--- a/Sources/FluentKit/Database/TransactionControlDatabase.swift
+++ b/Sources/FluentKit/Database/TransactionControlDatabase.swift
@@ -1,19 +1,22 @@
 /// Protocol for describing a database that allows fine-grained control over transcactions
 /// when you need more control than provided by `Database.transaction(_:)`
 ///
-/// ⚠️ **WARNING**: it is the developer's responsiblity that they get hold of a `DatabaseConnection`
-/// and execute the transaction functions on that connection and ensure the functions aren't called across
+/// ⚠️ **WARNING**: it is the developer's responsiblity to get hold of a `DatabaseConnection`,
+/// execute the transaction functions on that connection, and ensure that the functions aren't called across
 /// different conenctions. You are also responsible for ensuring that you commit or rollback queries
-/// when you're ready
-/// You should not mix these functions and `Database.transaction(_:)`
+/// when you're ready.
+///
+/// Do not mix these functions and `Database.transaction(_:)`.
 public protocol TransactionControlDatabase: Database {
     /// Start the transaction on the current connection. This is equivalent to an SQL `BEGIN`
     /// - Returns: future `Void` when the transaction has been started
     func beginTransaction() -> EventLoopFuture<Void>
+
     /// Commit the queries executed for the transaction and write them to the database
     /// This is equivalent to an SQL `COMMIT`
     /// - Returns: future `Void` when the transaction has been committed
     func commitTransaction() -> EventLoopFuture<Void>
+
     /// Rollback the current transaction's queries. You may want to trigger this when handling an error
     /// when trying to create models.
     /// This is equivalent to an SQL `ROLLBACK`


### PR DESCRIPTION
Adds the ability to control starting, committing and rolling back transactions outside of the main Fluent API. This could be used for setting up tests or when you need more control over a transaction.

Introduces a new `TransactionControlDatabase` protocol to implement, that conforms to `Database`

> **Warning**: It is the users' responsibility to ensure the handle errors and rollback when necessary and commit transactions