### PR TITLE
Formatted boolean properties

### DIFF
--- a/Sources/FluentBenchmark/Tests/EnumTests.swift
+++ b/Sources/FluentBenchmark/Tests/EnumTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 extension FluentBenchmarker {
     public func testEnum() throws {
         try self.testEnum_basic()
@@ -6,6 +7,10 @@ extension FluentBenchmarker {
         try self.testEnum_queryFound()
         try self.testEnum_queryMissing()
         try self.testEnum_decode()
+        
+        // Note: These should really be in their own top-level test case, but then I'd have to open
+        // PRs against all the drivers again.
+        try self.testBooleanProperties()
     }
 
     private func testEnum_basic() throws {
@@ -215,6 +220,70 @@ extension FluentBenchmarker {
             XCTAssertEqual(fetched?.baz, .qux)
         }
     }
+    
+    public func testBooleanProperties() throws {
+        try runTest(#function, [
+            FlagsMigration()
+        ]) {
+            let flags1 = Flags(inquired: true, required: true, desired: true, expired: true, inspired: true, retired: true),
+                flags2 = Flags(inquired: false, required: false, desired: false, expired: false, inspired: false, retired: false),
+                flags3 = Flags(inquired: true, required: true, desired: true, expired: nil, inspired: nil, retired: nil)
+            
+            try flags1.create(on: self.database).wait()
+            try flags2.create(on: self.database).wait()
+            try flags3.create(on: self.database).wait()
+            
+            let rawFlags1 = try XCTUnwrap(RawFlags.find(flags1.id!, on: self.database).wait()),
+                rawFlags2 = try XCTUnwrap(RawFlags.find(flags2.id!, on: self.database).wait()),
+                rawFlags3 = try XCTUnwrap(RawFlags.find(flags3.id!, on: self.database).wait())
+            
+            XCTAssertEqual(rawFlags1.inquired, true)
+            XCTAssertEqual(rawFlags1.required, 1)
+            XCTAssertEqual(rawFlags1.desired, "true")
+            XCTAssertEqual(rawFlags1.expired, true)
+            XCTAssertEqual(rawFlags1.inspired, 1)
+            XCTAssertEqual(rawFlags1.retired, "true")
+
+            XCTAssertEqual(rawFlags2.inquired, false)
+            XCTAssertEqual(rawFlags2.required, 0)
+            XCTAssertEqual(rawFlags2.desired, "false")
+            XCTAssertEqual(rawFlags2.expired, false)
+            XCTAssertEqual(rawFlags2.inspired, 0)
+            XCTAssertEqual(rawFlags2.retired, "false")
+
+            XCTAssertEqual(rawFlags3.inquired, true)
+            XCTAssertEqual(rawFlags3.required, 1)
+            XCTAssertEqual(rawFlags3.desired, "true")
+            XCTAssertNil(rawFlags3.expired)
+            XCTAssertNil(rawFlags3.inspired)
+            XCTAssertNil(rawFlags3.retired)
+
+            let savedFlags1 = try XCTUnwrap(Flags.find(flags1.id!, on: self.database).wait()),
+                savedFlags2 = try XCTUnwrap(Flags.find(flags2.id!, on: self.database).wait()),
+                savedFlags3 = try XCTUnwrap(Flags.find(flags3.id!, on: self.database).wait())
+            
+            XCTAssertEqual(savedFlags1.inquired, flags1.inquired)
+            XCTAssertEqual(savedFlags1.required, flags1.required)
+            XCTAssertEqual(savedFlags1.desired, flags1.desired)
+            XCTAssertEqual(savedFlags1.expired, flags1.expired)
+            XCTAssertEqual(savedFlags1.inspired, flags1.inspired)
+            XCTAssertEqual(savedFlags1.retired, flags1.retired)
+
+            XCTAssertEqual(savedFlags2.inquired, flags2.inquired)
+            XCTAssertEqual(savedFlags2.required, flags2.required)
+            XCTAssertEqual(savedFlags2.desired, flags2.desired)
+            XCTAssertEqual(savedFlags2.expired, flags2.expired)
+            XCTAssertEqual(savedFlags2.inspired, flags2.inspired)
+            XCTAssertEqual(savedFlags2.retired, flags2.retired)
+
+            XCTAssertEqual(savedFlags3.inquired, flags3.inquired)
+            XCTAssertEqual(savedFlags3.required, flags3.required)
+            XCTAssertEqual(savedFlags3.desired, flags3.desired)
+            XCTAssertEqual(savedFlags3.expired, flags3.expired)
+            XCTAssertEqual(savedFlags3.inspired, flags3.inspired)
+            XCTAssertEqual(savedFlags3.retired, flags3.retired)
+        }
+    }
 }
 
 private enum Bar: String, Codable {
@@ -328,5 +397,75 @@ private struct PetMigration: Migration {
 
     func revert(on database: Database) -> EventLoopFuture<Void> {
         database.schema("pets").delete()
+    }
+}
+
+private final class Flags: Model {
+    static let schema = "flags"
+    
+    @ID(key: .id)
+    var id: UUID?
+    
+    @Boolean(key: "inquired")
+    var inquired: Bool
+    
+    @Boolean(key: "required", format: .integer)
+    var required: Bool
+
+    @Boolean(key: "desired", format: .trueFalse)
+    var desired: Bool
+    
+    @OptionalBoolean(key: "expired")
+    var expired: Bool?
+
+    @OptionalBoolean(key: "inspired", format: .integer)
+    var inspired: Bool?
+
+    @OptionalBoolean(key: "retired", format: .trueFalse)
+    var retired: Bool?
+    
+    init() {}
+    
+    init(id: IDValue? = nil, inquired: Bool, required: Bool, desired: Bool, expired: Bool? = nil, inspired: Bool? = nil, retired: Bool? = nil) {
+        self.id = id
+        self.inquired = inquired
+        self.required = required
+        self.desired = desired
+        self.expired = expired
+        self.inspired = inspired
+        self.retired = retired
+    }
+}
+
+private final class RawFlags: Model {
+    static let schema = "flags"
+    
+    @ID(key: .id) var id: UUID?
+    @Field(key: "inquired") var inquired: Bool
+    @Field(key: "required") var required: Int
+    @Field(key: "desired") var desired: String
+    @OptionalField(key: "expired") var expired: Bool?
+    @OptionalField(key: "inspired") var inspired: Int?
+    @OptionalField(key: "retired") var retired: String?
+    
+    init() {}
+}
+
+private struct FlagsMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema(Flags.schema)
+            .field(.id, .uuid, .identifier(auto: false), .required)
+            .field("inquired", .bool, .required)
+            .field("required", .int, .required)
+            .field("desired", .string, .required)
+            .field("expired", .bool)
+            .field("inspired", .int)
+            .field("retired", .string)
+            .create()
+    }
+    
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema(Flags.schema)
+            .delete()
     }
 }

--- a/Sources/FluentBenchmark/Tests/EnumTests.swift
+++ b/Sources/FluentBenchmark/Tests/EnumTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 extension FluentBenchmarker {
     public func testEnum() throws {
         try self.testEnum_basic()

--- a/Sources/FluentKit/Properties/Boolean.swift
+++ b/Sources/FluentKit/Properties/Boolean.swift
@@ -3,6 +3,45 @@ extension Fields {
         where Format: BooleanPropertyFormat
 }
 
+/// A Fluent model property which represents a boolean (true/false) value.
+///
+/// By default, `Bool` properties are stored in a database using the storage format
+/// defined by the database driver, which corresponds to using the `.bool` data type
+/// on the appropriate field in a migration. This property wrapper allows specifying
+/// an alternative storage format - such the strings "true" and "false" - which is
+/// automatically translated to and from a Swift `Bool` when loading and saving the
+/// owning model. This is expected to be most useful when working with existing
+/// database schemas.
+///
+/// Example:
+///
+///     final class MyModel: Model {
+///         let schema = "my_models"
+///
+///         @ID(key: .id) var id: UUID?
+///
+///         // This field will be stored using the database's native boolean format.
+///         @Field(key: "rawEnabled") var rawEnabled: Bool
+///
+///         // This field will be stored as a string, either "true" or "false".
+///         @Boolean(key: "enabled", format: .trueFalse) var enabled: Bool
+///
+///         init() {}
+///     }
+///
+///     struct MyModelMigration: AsyncMigration {
+///         func prepare(on database: Database) async throws -> Void {
+///             try await database.schema(MyModel.schema)
+///                 .id()
+///                 .field("rawEnabled", .bool, .required)
+///                 .field("enabled", .string, .required)
+///                 .create()
+///         }
+///
+///         func revert(on database: Database) async throws -> Void { try await database.schema(MyModel.schema).delete() }
+///     }
+///
+/// - Note: See also ``OptionalBooleanProperty`` and ``BooleanPropertyFormat``.
 @propertyWrapper
 public final class BooleanProperty<Model, Format>
     where Model: FluentKit.Fields, Format: BooleanPropertyFormat

--- a/Sources/FluentKit/Properties/Boolean.swift
+++ b/Sources/FluentKit/Properties/Boolean.swift
@@ -74,6 +74,16 @@ extension BooleanProperty where Format == DefaultBooleanPropertyFormat {
     }
 }
 
+/// This is a workaround for Swift 5.4's inability to correctly infer the format type
+/// using the `Self` constraints on the various static properties.
+#if swift(<5.5)
+extension BooleanProperty {
+    public convenience init(key: FieldKey, format factory: BooleanPropertyFormatFactory<Format>) {
+        self.init(key: key, format: factory.format)
+    }
+}
+#endif
+
 extension BooleanProperty: AnyProperty {}
 
 extension BooleanProperty: Property {

--- a/Sources/FluentKit/Properties/Boolean.swift
+++ b/Sources/FluentKit/Properties/Boolean.swift
@@ -1,0 +1,82 @@
+extension Fields {
+    public typealias Boolean<Format> = BooleanProperty<Self, Format>
+        where Format: BooleanPropertyFormat
+}
+
+@propertyWrapper
+public final class BooleanProperty<Model, Format>
+    where Model: FluentKit.Fields, Format: BooleanPropertyFormat
+{
+    @FieldProperty<Model, Format.Value>
+    public var field: Format.Value
+    public let format: Format
+
+    public var projectedValue: BooleanProperty<Model, Format> { self }
+
+    public var wrappedValue: Bool {
+        get {
+            guard let value = self.value else {
+                fatalError("Cannot access bool field before it is initialized or fetched: \(self.$field.key)")
+            }
+            return value
+        }
+        set { self.value = newValue }
+    }
+
+    public init(key: FieldKey, format: Format) {
+        self._field = .init(key: key)
+        self.format = format
+    }
+}
+
+extension BooleanProperty where Format == DefaultBooleanPropertyFormat {
+    public convenience init(key: FieldKey) {
+        self.init(key: key, format: .default)
+    }
+}
+
+extension BooleanProperty: AnyProperty {}
+
+extension BooleanProperty: Property {
+    public var value: Bool? {
+        get { self.$field.value.map { self.format.parse($0)! } }
+        set { self.$field.value = newValue.map { self.format.serialize($0) } }
+    }
+}
+
+extension BooleanProperty: AnyQueryableProperty {
+    public var path: [FieldKey] { self.$field.path }
+}
+
+extension BooleanProperty: QueryableProperty {
+    public static func queryValue(_ value: Bool) -> DatabaseQuery.Value {
+        .bind(Format.init().serialize(value))
+    }
+}
+
+extension BooleanProperty: AnyQueryAddressableProperty {
+    public var anyQueryableProperty: AnyQueryableProperty { self }
+    public var queryablePath: [FieldKey] { self.path }
+}
+
+extension BooleanProperty: QueryAddressableProperty {
+    public var queryableProperty: BooleanProperty<Model, Format> { self }
+}
+
+extension BooleanProperty: AnyDatabaseProperty {
+    public var keys: [FieldKey] { self.$field.keys }
+    public func input(to input: DatabaseInput) { self.$field.input(to: input) }
+    public func output(from output: DatabaseOutput) throws { try self.$field.output(from: output) }
+}
+
+extension BooleanProperty: AnyCodableProperty {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.wrappedValue)
+    }
+
+    public func decode(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.value = try container.decode(Value.self)
+    }
+}

--- a/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
+++ b/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
@@ -71,6 +71,28 @@ extension BooleanPropertyFormat where Self == OneZeroBooleanPropertyFormat {
     public static var oneZero: Self { .init() }
 }
 
+/// Represent a `Bool` as the strings "N" and "Y". Parsing is case-insensitive. Serialization always stores uppercase.
+public struct YNBooleanPropertyFormat: BooleanPropertyFormat {
+    public init() {}
+    
+    public func parse(_ value: String) -> Bool? {
+        switch value.lowercased() {
+        case "n": return false
+        case "y": return true
+        default: return nil
+        }
+    }
+    
+    public func serialize(_ bool: Bool) -> String {
+        return bool ? "Y" : "N"
+    }
+}
+
+extension BooleanPropertyFormat where Self == YNBooleanPropertyFormat {
+    public static var yn: Self { .init() }
+}
+
+
 /// Represent a `Bool` as the strings "NO" and "YES". Parsing is case-insensitive. Serialization always stores uppercase.
 public struct YesNoBooleanPropertyFormat: BooleanPropertyFormat {
     public init() {}

--- a/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
+++ b/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
@@ -1,0 +1,131 @@
+/// A conversion between `Bool` and an arbitrary alternative storage format, usually a string.
+public protocol BooleanPropertyFormat {
+    associatedtype Value: Codable
+
+    init()
+
+    func parse(_ value: Value) -> Bool?
+    func serialize(_ bool: Bool) -> Value
+}
+
+/// Represent a `Bool` natively, using the database's underlying support (if any). This is the default.
+public struct DefaultBooleanPropertyFormat: BooleanPropertyFormat {
+    public init() {}
+    
+    public func parse(_ value: Bool) -> Bool? {
+        return value
+    }
+    
+    public func serialize(_ bool: Bool) -> Bool {
+        return bool
+    }
+}
+
+extension BooleanPropertyFormat where Self == DefaultBooleanPropertyFormat {
+    public static var `default`: Self { .init() }
+}
+
+/// Represent a `Bool` as any integer type. Any value other than `0` or `1` is considered invalid.
+public struct IntegerBooleanPropertyFormat<T: FixedWidthInteger & Codable>: BooleanPropertyFormat {
+    public init() {}
+    
+    public func parse(_ value: T) -> Bool? {
+        switch value {
+        case .zero: return false
+        case .zero.advanced(by: 1): return true
+        default: return nil
+        }
+    }
+    
+    public func serialize(_ bool: Bool) -> T {
+        return .zero.advanced(by: bool ? 1 : 0)
+    }
+}
+
+extension BooleanPropertyFormat where Self == IntegerBooleanPropertyFormat<Int> {
+    public static var integer: Self { .init() }
+}
+
+/// Represent a `Bool` as the strings "0" and "1". Any other value is considered invalid.
+public struct OneZeroBooleanPropertyFormat: BooleanPropertyFormat {
+    public init() {}
+    
+    public func parse(_ value: String) -> Bool? {
+        switch value {
+        case "0": return false
+        case "1": return true
+        default: return nil
+        }
+    }
+    
+    public func serialize(_ bool: Bool) -> String {
+        return bool ? "1" : "0"
+    }
+}
+
+extension BooleanPropertyFormat where Self == OneZeroBooleanPropertyFormat {
+    public static var oneZero: Self { .init() }
+}
+
+/// Represent a `Bool` as the strings "NO" and "YES". Parsing is case-insensitive. Serialization always stores uppercase.
+public struct YesNoBooleanPropertyFormat: BooleanPropertyFormat {
+    public init() {}
+    
+    public func parse(_ value: String) -> Bool? {
+        switch value.lowercased() {
+        case "no": return false
+        case "yes": return true
+        default: return nil
+        }
+    }
+    
+    public func serialize(_ bool: Bool) -> String {
+        return bool ? "YES" : "NO"
+    }
+}
+
+extension BooleanPropertyFormat where Self == YesNoBooleanPropertyFormat {
+    public static var yesNo: Self { .init() }
+}
+
+/// Represent a `Bool` as the strings "OFF" and "ON". Parsing is case-insensitive. Serialization always stores uppercase.
+public struct OnOffBooleanPropertyFormat: BooleanPropertyFormat {
+    public init() {}
+
+    public func parse(_ value: String) -> Bool? {
+        switch value.lowercased() {
+        case "off": return false
+        case "on": return true
+        default: return nil
+        }
+    }
+        
+    public func serialize(_ bool: Bool) -> String {
+        return bool ? "ON" : "OFF"
+    }
+}
+
+extension BooleanPropertyFormat where Self == OnOffBooleanPropertyFormat {
+    public static var onOff: Self { .init() }
+}
+
+/// Represent a `Bool` as the strings "false" and "true". Parsing is case-insensitive. Serialization always stores lowercase.
+public struct TrueFalseBooleanPropertyFormat: BooleanPropertyFormat {
+    public init() {}
+    
+    public func parse(_ value: String) -> Bool? {
+        switch value.lowercased() {
+        case "false": return false
+        case "true": return true
+        default: return nil
+        }
+    }
+    
+    public func serialize(_ bool: Bool) -> String {
+        return bool ? "true" : "false"
+    }
+}
+
+extension BooleanPropertyFormat where Self == TrueFalseBooleanPropertyFormat {
+    public static var trueFalse: Self { .init() }
+}

--- a/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
+++ b/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
@@ -26,6 +26,10 @@ extension BooleanPropertyFormat where Self == DefaultBooleanPropertyFormat {
 }
 
 /// Represent a `Bool` as any integer type. Any value other than `0` or `1` is considered invalid.
+///
+/// - Note: This format is primarily useful when the underlying database's native boolean format is
+///   an integer of different width than the one that was used by the model - for example, a MySQL
+///   model with a `BIGINT` field instead of the default `TINYINT`.
 public struct IntegerBooleanPropertyFormat<T: FixedWidthInteger & Codable>: BooleanPropertyFormat {
     public init() {}
     

--- a/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
+++ b/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
@@ -155,3 +155,37 @@ public struct TrueFalseBooleanPropertyFormat: BooleanPropertyFormat {
 extension BooleanPropertyFormat where Self == TrueFalseBooleanPropertyFormat {
     public static var trueFalse: Self { .init() }
 }
+
+/// This is a workaround for Swift 5.4's inability to correctly infer the format type
+/// using the `Self` constraints on the various static properties.
+#if swift(<5.5)
+public struct BooleanPropertyFormatFactory<Format: BooleanPropertyFormat> {
+    public var format: Format
+}
+
+extension BooleanPropertyFormatFactory {
+    public static var integer: BooleanPropertyFormatFactory<IntegerBooleanPropertyFormat<Int>> {
+        .init(format: .init())
+    }
+    
+    public static var oneZero: BooleanPropertyFormatFactory<OneZeroBooleanPropertyFormat> {
+        .init(format: .init())
+    }
+
+    public static var yn: BooleanPropertyFormatFactory<YNBooleanPropertyFormat> {
+        .init(format: .init())
+    }
+
+    public static var yesNo: BooleanPropertyFormatFactory<YesNoBooleanPropertyFormat> {
+        .init(format: .init())
+    }
+
+    public static var onOff: BooleanPropertyFormatFactory<OnOffBooleanPropertyFormat> {
+        .init(format: .init())
+    }
+
+    public static var trueFalse: BooleanPropertyFormatFactory<TrueFalseBooleanPropertyFormat> {
+        .init(format: .init())
+    }
+}
+#endif

--- a/Sources/FluentKit/Properties/OptionalBoolean.swift
+++ b/Sources/FluentKit/Properties/OptionalBoolean.swift
@@ -1,0 +1,98 @@
+extension Fields {
+    public typealias OptionalBoolean<Format> = OptionalBooleanProperty<Self, Format>
+        where Format: BooleanPropertyFormat
+}
+
+@propertyWrapper
+public final class OptionalBooleanProperty<Model, Format>
+    where Model: FluentKit.Fields, Format: BooleanPropertyFormat
+{
+    @OptionalFieldProperty<Model, Format.Value>
+    public var field: Format.Value?
+    public let format: Format
+
+    public var projectedValue: OptionalBooleanProperty<Model, Format> { self }
+
+    public var wrappedValue: Bool? {
+        get {
+            switch self.value {
+            case .none, .some(.none): return nil
+            case .some(.some(let value)): return value
+            }
+        }
+        set { self.value = .some(newValue) }
+    }
+
+    public init(key: FieldKey, format: Format) {
+        self._field = .init(key: key)
+        self.format = format
+    }
+}
+
+extension OptionalBooleanProperty where Format == DefaultBooleanPropertyFormat {
+    public convenience init(key: FieldKey) {
+        self.init(key: key, format: .default)
+    }
+}
+
+extension OptionalBooleanProperty: AnyProperty {}
+
+extension OptionalBooleanProperty: Property {
+    public var value: Bool?? {
+        get {
+            switch self.$field.value {
+            case .some(.some(let value)): return .some(self.format.parse(value))
+            case .some(.none): return .some(.none)
+            case .none: return .none
+            }
+        }
+        set {
+            switch newValue {
+            case .some(.some(let newValue)): self.$field.value = .some(.some(self.format.serialize(newValue)))
+            case .some(.none): self.$field.value = .some(.none)
+            case .none: self.$field.value = .none
+            }
+        }
+    }
+}
+
+extension OptionalBooleanProperty: AnyQueryableProperty {
+    public var path: [FieldKey] { self.$field.path }
+}
+
+extension OptionalBooleanProperty: QueryableProperty {
+    public static func queryValue(_ value: Bool?) -> DatabaseQuery.Value {
+        value.map { .bind(Format.init().serialize($0)) } ?? .null
+    }
+}
+
+extension OptionalBooleanProperty: AnyQueryAddressableProperty {
+    public var anyQueryableProperty: AnyQueryableProperty { self }
+    public var queryablePath: [FieldKey] { self.path }
+}
+
+extension OptionalBooleanProperty: QueryAddressableProperty {
+    public var queryableProperty: OptionalBooleanProperty<Model, Format> { self }
+}
+
+extension OptionalBooleanProperty: AnyDatabaseProperty {
+    public var keys: [FieldKey] { self.$field.keys }
+    public func input(to input: DatabaseInput) { self.$field.input(to: input) }
+    public func output(from output: DatabaseOutput) throws { try self.$field.output(from: output) }
+}
+
+extension OptionalBooleanProperty: AnyCodableProperty {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.wrappedValue)
+    }
+
+    public func decode(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self.value = nil
+        } else {
+            self.value = try container.decode(Value.self)
+        }
+    }
+}

--- a/Sources/FluentKit/Properties/OptionalBoolean.swift
+++ b/Sources/FluentKit/Properties/OptionalBoolean.swift
@@ -74,6 +74,16 @@ extension OptionalBooleanProperty where Format == DefaultBooleanPropertyFormat {
     }
 }
 
+/// This is a workaround for Swift 5.4's inability to correctly infer the format type
+/// using the `Self` constraints on the various static properties.
+#if swift(<5.5)
+extension OptionalBooleanProperty {
+    public convenience init(key: FieldKey, format factory: BooleanPropertyFormatFactory<Format>) {
+        self.init(key: key, format: factory.format)
+    }
+}
+#endif
+
 extension OptionalBooleanProperty: AnyProperty {}
 
 extension OptionalBooleanProperty: Property {

--- a/Sources/FluentKit/Properties/OptionalBoolean.swift
+++ b/Sources/FluentKit/Properties/OptionalBoolean.swift
@@ -3,6 +3,45 @@ extension Fields {
         where Format: BooleanPropertyFormat
 }
 
+/// A Fluent model property which represents an optional boolean (true/false) value.
+///
+/// By default, `Bool` properties are stored in a database using the storage format
+/// defined by the database driver, which corresponds to using the `.bool` data type
+/// on the appropriate field in a migration. This property wrapper allows specifying
+/// an alternative storage format - such the strings "true" and "false" - which is
+/// automatically translated to and from a Swift `Bool` when loading and saving the
+/// owning model. This is expected to be most useful when working with existing
+/// database schemas.
+///
+/// Example:
+///
+///     final class MyModel: Model {
+///         let schema = "my_models"
+///
+///         @ID(key: .id) var id: UUID?
+///
+///         // When not `nil`, this field will be stored using the database's native boolean format.
+///         @OptionalField(key: "rawEnabled") var rawEnabled: Bool?
+///
+///         // When not `nil`, this field will be stored as a string, either "true" or "false".
+///         @OptionalBoolean(key: "enabled", format: .trueFalse) var enabled: Bool?
+///
+///         init() {}
+///     }
+///
+///     struct MyModelMigration: AsyncMigration {
+///         func prepare(on database: Database) async throws -> Void {
+///             try await database.schema(MyModel.schema)
+///                 .id()
+///                 .field("rawEnabled", .bool)
+///                 .field("enabled", .string)
+///                 .create()
+///         }
+///
+///         func revert(on database: Database) async throws -> Void { try await database.schema(MyModel.schema).delete() }
+///     }
+///
+/// - Note: See also ``BooleanProperty`` and ``BooleanPropertyFormat``.
 @propertyWrapper
 public final class OptionalBooleanProperty<Model, Format>
     where Model: FluentKit.Fields, Format: BooleanPropertyFormat


### PR DESCRIPTION
Adds two new property types to Fluent: `@Boolean` and `@OptionalBoolean`. These properties always have `Bool` values, and can be configured with a storage format, similarly to `@Timestamp`. For example, the `.trueFalse` format stores the strings `"true"` and `"false"` in the database, and parses those strings on load. If no format is specified, the database's default native format for `Bool` is used, equivalently to using `@Field` or `@OptionalField`. An appropriate column data type must be specified in the migration for the model.