### PR TITLE
Allow updating deleted models with `Model.update(on:)`

### DIFF
--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -58,6 +58,7 @@ extension Model {
         let input = self.collectInput()
         guard let id = self.id else { throw FluentError.idRequired }
         return Self.query(on: database)
+            .withDeleted()
             .filter(id: id)
             .set(input)
             .update()


### PR DESCRIPTION
Previously could not update a model that was deleted using `Model.update(on:)` which seem unintuitive.