### PR TITLE
SchemaBuilder functions with @discardableResult

### DIFF
--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -13,10 +13,12 @@ public final class SchemaBuilder {
         self.schema = .init(schema: schema, space: space)
     }
 
+    @discardableResult
     public func id() -> Self {
         self.field(.id, .uuid, .identifier(auto: false))
     }
 
+    @discardableResult
     public func field(
         _ key: FieldKey,
         _ dataType: DatabaseSchema.DataType,
@@ -29,11 +31,13 @@ public final class SchemaBuilder {
         ))
     }
 
+    @discardableResult
     public func field(_ field: DatabaseSchema.FieldDefinition) -> Self {
         self.schema.createFields.append(field)
         return self
     }
 
+    @discardableResult
     public func unique(on fields: FieldKey..., name: String? = nil) -> Self {
         self.constraint(.constraint(
             .unique(fields: fields.map { .key($0) }),
@@ -41,15 +45,18 @@ public final class SchemaBuilder {
         ))
     }
     
+    @discardableResult
     public func compositeIdentifier(over fields: FieldKey...) -> Self {
         self.constraint(.constraint(.compositeIdentifier(fields.map { .key($0) }), name: ""))
     }
 
+    @discardableResult
     public func constraint(_ constraint: DatabaseSchema.Constraint) -> Self {
         self.schema.createConstraints.append(constraint)
         return self
     }
 
+    @discardableResult
     public func deleteUnique(on fields: FieldKey...) -> Self {
         self.schema.deleteConstraints.append(.constraint(
             .unique(fields: fields.map { .key($0) })
@@ -57,16 +64,19 @@ public final class SchemaBuilder {
         return self
     }
 
+    @discardableResult
     public func deleteConstraint(name: String) -> Self {
         self.schema.deleteConstraints.append(.name(name))
         return self
     }
 
+    @discardableResult
     public func deleteConstraint(_ constraint: DatabaseSchema.ConstraintDelete) -> Self {
         self.schema.deleteConstraints.append(constraint)
         return self
     }
 
+    @discardableResult
     public func foreignKey(
         _ field: FieldKey,
         references foreignSchema: String,
@@ -90,6 +100,7 @@ public final class SchemaBuilder {
         return self
     }
 
+    @discardableResult
     public func foreignKey(
         _ fields: [FieldKey],
         references foreignSchema: String,
@@ -113,6 +124,7 @@ public final class SchemaBuilder {
         return self
     }
 
+    @discardableResult
     public func updateField(
         _ key: FieldKey,
         _ dataType: DatabaseSchema.DataType
@@ -123,20 +135,24 @@ public final class SchemaBuilder {
         ))
     }
 
+    @discardableResult
     public func updateField(_ field: DatabaseSchema.FieldUpdate) -> Self {
         self.schema.updateFields.append(field)
         return self
     }
 
+    @discardableResult
     public func deleteField(_ name: FieldKey) -> Self {
         return self.deleteField(.key(name))
     }
 
+    @discardableResult
     public func deleteField(_ name: DatabaseSchema.FieldName) -> Self {
         self.schema.deleteFields.append(name)
         return self
     }
 
+    @discardableResult
     public func ignoreExisting() -> Self {
         self.schema.exclusiveCreate = false
         return self


### PR DESCRIPTION
Added @discardableResult to all functions in SchemaBuilder that modify Self and return Self. This brings it in line with QueryBuilder and also allows more complicated migrations that use conditional logic (ie not chained) to work without having to use `let _ =` to avoid `Result of call to 'xxx' is unused` warnings.