### PR TITLE
Add Siblings's `async`/`await` `detachAll(on:)` API

### DIFF
--- a/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
@@ -53,6 +53,10 @@ public extension SiblingsProperty {
     func detach(_ to: To, on database: Database) async throws {
         try await self.detach(to, on: database).get()
     }
+    
+    func detachAll(on database: Database) async throws {
+        try await self.detachAll(on: database).get()
+    }
 }
 
 #endif


### PR DESCRIPTION
Adds missing async API for a sibling's `detachAll(on:)`