### PR TITLE
Remove several sources of fatal errors from @Group

### DIFF
--- a/Sources/FluentKit/Properties/Group.swift
+++ b/Sources/FluentKit/Properties/Group.swift
@@ -68,10 +68,11 @@ extension GroupProperty: AnyDatabaseProperty {
     }
 
     public func input(to input: DatabaseInput) {
-        self.value!.input(to: input.prefixed(by: self.prefix))
+        self.value?.input(to: input.prefixed(by: self.prefix))
     }
 
     public func output(from output: DatabaseOutput) throws {
+        if self.value == nil { self.value = .init() }
         try self.value!.output(from: output.prefixed(by: self.prefix))
     }
 }
@@ -80,11 +81,14 @@ extension GroupProperty: AnyDatabaseProperty {
 
 extension GroupProperty: AnyCodableProperty {
     public func encode(to encoder: Encoder) throws {
-        try self.value!.encode(to: encoder)
+        try self.value?.encode(to: encoder)
     }
 
     public func decode(from decoder: Decoder) throws {
-        self.value = try .init(from: decoder)
+        let container = try decoder.singleValueContainer()
+        
+        guard !container.decodeNil() else { return }
+        self.value = .some(try container.decode(Value.self))
     }
 }
 

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -598,26 +598,29 @@ final class FluentKitTests: XCTestCase {
             
             init() {}
         }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let decoder = JSONDecoder()
         
         let groupFoo = GroupFoo()
         groupFoo.id = UUID()
         groupFoo.group.string = "hi"
-        let encoded = try JSONEncoder().encode(groupFoo)
+        let encoded = try encoder.encode(groupFoo)
         XCTAssertEqual(String(decoding: encoded, as: UTF8.self), #"{"group":{"string":"hi"},"id":"\#(groupFoo.id!.uuidString)"}"#)
         
         // TODO: This currently causes a fatal error when the Codable conformance tries to encode the unset group members.
         /*
         let missingGroupFoo = GroupFoo()
         missingGroupFoo.id = UUID()
-        let missingEncoded = try JSONEncoder().encode(missingGroupFoo)
+        let missingEncoded = try encoder.encode(missingGroupFoo)
         XCTAssertEqual(String(decoding: missingEncoded, as: UTF8.self), #"{"id":"\#(groupFoo.id!.uuidString)"}"#)
         */
         
-        let decoded = try JSONDecoder().decode(GroupFoo.self, from: encoded)
+        let decoded = try decoder.decode(GroupFoo.self, from: encoded)
         XCTAssertEqual(decoded.id?.uuidString, groupFoo.id?.uuidString)
         XCTAssertEqual(decoded.group.string, groupFoo.group.string)
         
-        let decodedMissing = try JSONDecoder().decode(GroupFoo.self, from: #"{"id":"\#(groupFoo.id!.uuidString)"}"#.data(using: .utf8)!)
+        let decodedMissing = try decoder.decode(GroupFoo.self, from: #"{"id":"\#(groupFoo.id!.uuidString)"}"#.data(using: .utf8)!)
         XCTAssertEqual(decodedMissing.id?.uuidString, groupFoo.id?.uuidString)
         XCTAssertNotNil(decodedMissing.$group.value)
     }


### PR DESCRIPTION
This removes most of the easier ways to cause fatal errors (esp. from user input) from `@Group`'s implementation.

Fixes #530
