### PR TITLE
Reducing availability conditions on Concurrency code

### DIFF
--- a/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
+++ b/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
@@ -4,7 +4,7 @@ extension FluentBenchmarker {
         try self.testMiddleware_methods()
         try self.testMiddleware_batchCreationFail()
         #if compiler(>=5.5) && canImport(_Concurrency)
-        if #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) {
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
             try self.testAsyncMiddleware_methods()
         }
         #endif
@@ -61,7 +61,7 @@ extension FluentBenchmarker {
     }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func testAsyncMiddleware_methods() throws {
         try self.runTest(#function, [
             UserMigration(),
@@ -174,7 +174,7 @@ private struct UserBatchMiddleware: ModelMiddleware {
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct AsyncUserMiddleware: AsyncModelMiddleware {
     func create(model: User, on db: Database, next: AnyAsyncModelResponder) async throws {
         model.name = "B"

--- a/Sources/FluentKit/Concurrency/AsyncMigration.swift
+++ b/Sources/FluentKit/Concurrency/AsyncMigration.swift
@@ -1,13 +1,13 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncMigration: Migration {
     func prepare(on database: Database) async throws
     func revert(on database: Database) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension AsyncMigration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         let promise = database.eventLoop.makePromise(of: Void.self)

--- a/Sources/FluentKit/Concurrency/AsyncModelMiddleware.swift
+++ b/Sources/FluentKit/Concurrency/AsyncModelMiddleware.swift
@@ -1,6 +1,6 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncModelMiddleware: AnyModelMiddleware {
     associatedtype Model: FluentKit.Model
     
@@ -11,7 +11,7 @@ public protocol AsyncModelMiddleware: AnyModelMiddleware {
     func restore(model: Model, on db: Database, next: AnyAsyncModelResponder) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncModelMiddleware {
     public func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database, chainingTo next: AnyModelResponder) -> EventLoopFuture<Void> {
         let promise = db.eventLoop.makePromise(of: Void.self)

--- a/Sources/FluentKit/Concurrency/Children+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Children+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension ChildrenProperty {
     
     func load(on database: Database) async throws {

--- a/Sources/FluentKit/Concurrency/Database+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Database+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Database {
     func transaction<T>(_ closure: @Sendable @escaping (Database) async throws -> T) async throws -> T {
         try await self.transaction { db -> EventLoopFuture<T> in

--- a/Sources/FluentKit/Concurrency/EnumBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/EnumBuilder+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension EnumBuilder {
     func create() async throws -> DatabaseSchema.DataType {
         try await self.create().get()

--- a/Sources/FluentKit/Concurrency/Model+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Model+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Model {
     static func find(
         _ id: Self.IDValue?,
@@ -32,7 +32,7 @@ public extension Model {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Collection where Element: FluentKit.Model {
     func delete(force: Bool = false, on database: Database) async throws {
         try await self.delete(force: force, on: database).get()

--- a/Sources/FluentKit/Concurrency/ModelResponder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/ModelResponder+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AnyAsyncModelResponder: AnyModelResponder {
     func handle(
         _ event: ModelEvent,
@@ -10,7 +10,7 @@ public protocol AnyAsyncModelResponder: AnyModelResponder {
     ) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AnyAsyncModelResponder {
     func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
         let promise = db.eventLoop.makePromise(of: Void.self)
@@ -21,7 +21,7 @@ extension AnyAsyncModelResponder {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AnyAsyncModelResponder {
     public func create(_ model: AnyModel, on db: Database) async throws {
         try await handle(.create, model, on: db)
@@ -44,7 +44,7 @@ extension AnyAsyncModelResponder {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal struct AsyncBasicModelResponder: AnyAsyncModelResponder {
     private let _handle: (ModelEvent, AnyModel, Database) async throws -> Void
 

--- a/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension OptionalChildProperty {
     
     func load(on database: Database) async throws {

--- a/Sources/FluentKit/Concurrency/OptionalParent+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalParent+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension OptionalParentProperty {
     func load(on database: Database) async throws {
         try await self.load(on: database).get()

--- a/Sources/FluentKit/Concurrency/Parent+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Parent+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension ParentProperty {
     func load(on database: Database) async throws {
         try await self.load(on: database).get()

--- a/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension QueryBuilder {
     // MARK: - Actions
     func create() async throws {

--- a/Sources/FluentKit/Concurrency/Relation+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Relation+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Relation {
     func get(reload: Bool = false, on database: Database) async throws -> RelatedValue {
         try await self.get(reload: reload, on: database).get()

--- a/Sources/FluentKit/Concurrency/SchemaBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/SchemaBuilder+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension SchemaBuilder {
     func create() async throws {
         try await self.create().get()

--- a/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension SiblingsProperty {
     
     func load(on database: Database) async throws {

--- a/Sources/FluentSQL/SQLDatabase+Model+Concurrency.swift
+++ b/Sources/FluentSQL/SQLDatabase+Model+Concurrency.swift
@@ -2,7 +2,7 @@
 import NIOCore
 import SQLKit
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension SQLQueryFetcher {
     public func first<Model>(decoding model: Model.Type) async throws -> Model?
         where Model: FluentKit.Model

--- a/Tests/FluentKitTests/AsyncTests/AsyncFilterQueryTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncFilterQueryTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import Foundation
 import FluentSQL
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncFilterQueryTests: XCTestCase {
     override class func setUp() {
         super.setUp()

--- a/Tests/FluentKitTests/AsyncTests/AsyncFluentKitTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncFluentKitTests.swift
@@ -7,7 +7,7 @@ import Foundation
 import FluentSQL
 import XCTFluent
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncFluentKitTests: XCTestCase {
     override class func setUp() {
         super.setUp()

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import Foundation
 import XCTFluent
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncQueryBuilderTests: XCTestCase {
     override class func setUp() {
         super.setUp()


### PR DESCRIPTION
As of Xcode 13.2, Swift Concurrency has been back ported down to macOS 10.15, iOS 13, tvOS 13 and watchOS 6.