### PR TITLE
fix: detach not invoke delete lifecycle

### DIFF
--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -203,7 +203,7 @@ public final class SiblingsProperty<From, To, Through>
         return Through.query(on: database)
             .filter(self.from.appending(path: \.$id) == fromID)
             .filter(self.to.appending(path: \.$id) ~~ toIDs)
-            .delete()
+            .all().flatMapEach(on: database.eventLoop) { $0.delete(on: database) }
     }
 
     /// Detach a single model by deleting the pivot.
@@ -222,7 +222,7 @@ public final class SiblingsProperty<From, To, Through>
         return Through.query(on: database)
             .filter(self.from.appending(path: \.$id) == fromID)
             .filter(self.to.appending(path: \.$id) == toID)
-            .delete()
+            .all().flatMapEach(on: database.eventLoop) { $0.delete(on: database) }
     }
     
     /// Detach all models by deleting all pivots from this model.
@@ -233,7 +233,7 @@ public final class SiblingsProperty<From, To, Through>
         
         return Through.query(on: database)
             .filter(self.from.appending(path: \.$id) == fromID)
-            .delete()
+            .all().flatMapEach(on: database.eventLoop) { $0.delete(on: database) }
     }
 
     // MARK: Query


### PR DESCRIPTION

This PR is aiming to fix the issue #533 and [vapor/fluent#747](https://github.com/vapor/fluent/issues/747#issuecomment-1259817436_).

The `SiblingsProperty.detach(_:on:)` miss to invoke delete lifecycle, while `SiblingsProperty.attach(_:on:)` does.

The last line `.delete()` just simply build an sql and runs it, which cause some issues.

```Swift
    public func detach(_ tos: [To], on database: Database) -> EventLoopFuture<Void> {
        guard let fromID = self.idValue else {...}
        let toIDs = tos.map {...}

        return Through.query(on: database)
            .filter(self.from.appending(path: \.$id) == fromID)
            .filter(self.to.appending(path: \.$id) ~~ toIDs)
            .delete()
    }
```

