### PR TITLE
Allow use of create and delete for arrays of models that have composite IDs.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "XCTFluent", targets: ["XCTFluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.1.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.4.0"),

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -1,5 +1,5 @@
 import Foundation
-import class NIOConcurrencyHelpers.Lock
+import struct NIOConcurrencyHelpers.NIOLock
 @_exported import class NIO.NIOThreadPool
 
 public struct DatabaseConfigurationFactory {
@@ -22,7 +22,7 @@ public final class Databases {
     private var drivers: [DatabaseID: DatabaseDriver]
 
     // Synchronize access across threads.
-    private var lock: Lock
+    private var lock: NIOLock
 
     public struct Middleware {
         let databases: Databases

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Filter.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Filter.swift
@@ -16,6 +16,17 @@ extension QueryBuilder {
             return self.filter(\Model._$id == id)
         }
     }
+    
+    @discardableResult
+    internal func filter(ids: [Model.IDValue]) -> Self {
+        guard let firstId = ids.first else { return self.limit(0) }
+        if firstId is Fields {
+            assert(!(Model.init().anyID is AnyQueryableProperty), "Model's IDValue should not conform to Fields if it can be directly queried.")
+            return self.group(.or) { _ = ids.reduce($0) { $0.filter(id: $1) } }
+        } else {
+            return self.filter(\Model._$id ~~ ids)
+        }
+    }
 
     @discardableResult
     public func filter<Field>(

--- a/Sources/FluentKit/Query/QueryHistory.swift
+++ b/Sources/FluentKit/Query/QueryHistory.swift
@@ -1,4 +1,4 @@
-import class NIOConcurrencyHelpers.Lock
+import struct NIOConcurrencyHelpers.NIOLock
 
 /// Holds the history of queries for a database
 public final class QueryHistory {
@@ -6,7 +6,7 @@ public final class QueryHistory {
     public var queries: [DatabaseQuery]
 
     /// Protects
-    private var lock: Lock
+    private var lock: NIOLock
 
     /// Create a new `QueryHistory` with no existing history
     public init() {


### PR DESCRIPTION
We no longer crash in a precondition failure when attempting to invoke Fluent's `.create()` and `.delete()` extensions to `Collection`. This in particular enables the use of `Siblings.attach(_:on:edit:)` with pivots which use a composite ID (most often consisting of the two parent relations).

Additional changes:

- Swift 5.4 support removed.
- NIO deprecation warnings fixed.