### PR TITLE
Fix support for composite ID models with QueryBuilder.count() 

### DIFF
--- a/Sources/FluentBenchmark/Tests/CompositeIDTests.swift
+++ b/Sources/FluentBenchmark/Tests/CompositeIDTests.swift
@@ -7,6 +7,7 @@ extension FluentBenchmarker {
         try self.testCompositeID_asPivot()
         try self.testCompositeID_eagerLoaders()
         try self.testCompositeID_arrayCreateAndDelete()
+        try self.testCompositeID_count()
     }
     
     private func testCompositeID_create() throws {
@@ -145,6 +146,21 @@ extension FluentBenchmarker {
 
             let milkyWayGalaxyRevolutions = try XCTUnwrap(Galaxy.query(on: self.database).filter(\.$name == "Milky Way").with(\.$jurisdictions).first().wait())
             XCTAssertEqual(milkyWayGalaxyRevolutions.jurisdictions.count, 0)
+        }
+    }
+    
+    private func testCompositeID_count() throws {
+        try self.runTest(#function, [
+            GalaxyMigration(),
+            JurisdictionMigration(),
+            GalacticJurisdictionMigration(),
+            GalaxySeed(),
+            JurisdictionSeed(),
+            GalacticJurisdictionSeed(),
+        ]) {
+            let pivotCount = try GalacticJurisdiction.query(on: self.database).count().wait()
+            
+            XCTAssertGreaterThan(pivotCount, 0)
         }
     }
 }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Aggregate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Aggregate.swift
@@ -2,10 +2,12 @@ extension QueryBuilder {
     // MARK: Aggregate
 
     public func count() -> EventLoopFuture<Int> {
-        if let fieldsId = Model.init().anyID as? Fields {
-            return self.aggregate(.count, (fieldsId.properties.first! as! AnyQueryAddressableProperty).anyQueryableProperty.path)
-        } else {
+        if Model().anyID is AnyQueryableProperty {
             return self.count(\._$id)
+        } else if let fieldsIDType = Model.IDValue.self as? Fields.Type {
+            return self.aggregate(.count, (fieldsIDType.init().properties.first! as! AnyQueryAddressableProperty).anyQueryableProperty.path)
+        } else {
+            fatalError("Model '\(Model.self)' has neither @ID nor @CompositeID, this is not valid.")
         }
     }
 


### PR DESCRIPTION
This functionality appeared to exist before but would actually crash at runtime. We now handle it correctly, including a test.