### PR TITLE
Fix return type to non optional of Databases.database()

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -9,7 +9,7 @@ public final class FluentBenchmarker {
         self.databases.database(
             logger: .init(label: "codes.fluent.benchmarker"),
             on: self.databases.eventLoopGroup.next()
-        )!
+        )
     }
     
     public init(databases: Databases) {

--- a/Sources/FluentBenchmark/Tests/MigratorTests.swift
+++ b/Sources/FluentBenchmark/Tests/MigratorTests.swift
@@ -67,12 +67,12 @@ extension FluentBenchmarker {
                 databaseID.0,
                 logger: Logger(label: "codes.vapor.tests"),
                 on: self.databases.eventLoopGroup.next()
-            )!
+            )
             let database2 = self.databases.database(
                 databaseID.1,
                 logger: Logger(label: "codes.vapor.tests"),
                 on: self.databases.eventLoopGroup.next()
-            )!
+            )
 
             let migrations = Migrations()
 
@@ -131,7 +131,7 @@ extension FluentBenchmarker {
         try self.runTest(#function, []) {
             let logger = Logger(label: "codes.vapor.tests")
             let databaseIds = Array(self.databases.ids()).prefix(2)
-            let databases = databaseIds.map { self.databases.database($0, logger: logger, on: self.databases.eventLoopGroup.next())! }
+            let databases = databaseIds.map { self.databases.database($0, logger: logger, on: self.databases.eventLoopGroup.next()) }
             let migrations = Migrations()
             
             migrations.add([GalaxyMigration(), StarMigration(), GalaxySeed()], to: databaseIds[0])

--- a/Sources/FluentKit/Database/Databases.swift
+++ b/Sources/FluentKit/Database/Databases.swift
@@ -100,7 +100,7 @@ public final class Databases {
         on eventLoop: EventLoop,
         history: QueryHistory? = nil,
         pageSizeLimit: Int? = nil
-    ) -> Database? {
+    ) -> Database {
         self.lock.lock()
         defer { self.lock.unlock() }
         let id = id ?? self._requireDefaultID()

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -15,7 +15,7 @@ public struct Migrator {
     ) {
         self.init(
             databaseFactory: {
-                databases.database($0, logger: logger, on: eventLoop)!
+                databases.database($0, logger: logger, on: eventLoop)
             },
             migrations: migrations,
             on: eventLoop


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

`Databases.database(...)` is specified to return `Database?` but it never returns `nil` so this PR fixes the signature.
 
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
