### PR TITLE
Additional relations support for CompositeID models

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,9 +60,9 @@ jobs:
             POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
         }
       mongo-a:
-        image: mongo:5
+        image: mongo:6
       mongo-b:
-        image: mongo:5
+        image: mongo:6
     strategy:
       fail-fast: false
       matrix:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.5.2
 import PackageDescription
 
 let package = Package(

--- a/Sources/FluentBenchmark/Tests/CompositeIDTests.swift
+++ b/Sources/FluentBenchmark/Tests/CompositeIDTests.swift
@@ -13,7 +13,7 @@ extension FluentBenchmarker {
         
         // Embed this here instead of having to update all the Fluent drivers
         if self.database is SQLDatabase {
-            try self.testCompositeParent()
+            try self.testCompositeRelations()
         }
     }
     

--- a/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
+++ b/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import SQLKit
 
 extension FluentBenchmarker {
-    public func testCompositeParent() throws {
+    public func testCompositeRelations() throws {
         try testCompositeParent_get()
         try testCompositeParent_eagerLoad()
     }

--- a/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
+++ b/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
@@ -3,91 +3,315 @@ import SQLKit
 
 extension FluentBenchmarker {
     public func testCompositeRelations() throws {
-        try testCompositeParent_get()
-        try testCompositeParent_eagerLoad()
+        try testCompositeParent_loading()
+        try testCompositeChildren_loading()
     }
 
-    private func testCompositeParent_get() throws {
+    private func testCompositeParent_loading() throws {
         try self.runTest(#function, [
-            CompositeIDModelMigration(),
-            CompositeIDModelSeed(),
+            CompositeIDParentModel.ModelMigration(),
+            CompositeIDParentModel.ModelSeed(),
             CompositeIDChildModel.ModelMigration(),
             CompositeIDChildModel.ModelSeed(),
         ]) {
-            let childModel = try XCTUnwrap(CompositeIDChildModel.query(on: self.database).first().wait())
+            let child1 = try XCTUnwrap(CompositeIDChildModel.find(1, on: self.database).wait())
+            let child2 = try XCTUnwrap(CompositeIDChildModel.find(2, on: self.database).wait())
             
-            XCTAssertNotNil(childModel.$compositeIdModel.id.$name.value)
-            XCTAssertNotNil(childModel.$compositeIdModel.id.$dimensions.value)
+            XCTAssertEqual(child1.$compositeIdParentModel.id, .init(name: "A"))
+            XCTAssertNil(child1.$additionalCompositeIdParentModel.id)
+            XCTAssertEqual(child1.$linkedCompositeIdParentModel.id, .init(name: "A"))
+            XCTAssertNil(child1.$additionalLinkedCompositeIdParentModel.id)
+
+            XCTAssertEqual(child2.$compositeIdParentModel.id, .init(name: "A"))
+            XCTAssertEqual(child2.$additionalCompositeIdParentModel.id, .init(name: "B"))
+            XCTAssertEqual(child2.$linkedCompositeIdParentModel.id, .init(name: "B"))
+            XCTAssertEqual(child2.$additionalLinkedCompositeIdParentModel.id, .init(name: "A"))
             
-            let parentModel = try childModel.$compositeIdModel.get(on: self.database).wait()
+            XCTAssertEqual(try child1.$compositeIdParentModel.get(on: self.database).wait().id, child1.$compositeIdParentModel.id)
+            XCTAssertNil(try child1.$additionalCompositeIdParentModel.get(on: self.database).wait())
+            XCTAssertEqual(try child1.$linkedCompositeIdParentModel.get(on: self.database).wait().id, child1.$linkedCompositeIdParentModel.id)
+            XCTAssertNil(try child1.$additionalLinkedCompositeIdParentModel.get(on: self.database).wait())
+
+            XCTAssertEqual(try child2.$compositeIdParentModel.get(on: self.database).wait().id, child2.$compositeIdParentModel.id)
+            XCTAssertEqual(try child2.$additionalCompositeIdParentModel.get(on: self.database).wait()?.id, child2.$additionalCompositeIdParentModel.id)
+            XCTAssertEqual(try child2.$linkedCompositeIdParentModel.get(on: self.database).wait().id, child2.$linkedCompositeIdParentModel.id)
+            XCTAssertEqual(try child2.$additionalLinkedCompositeIdParentModel.get(on: self.database).wait()?.id, child2.$additionalLinkedCompositeIdParentModel.id)
             
-            XCTAssertEqual(parentModel.id, childModel.$compositeIdModel.id)
+            let child3 = try XCTUnwrap(CompositeIDChildModel.query(on: self.database).filter(\.$id == 1).with(\.$compositeIdParentModel).with(\.$additionalCompositeIdParentModel).with(\.$linkedCompositeIdParentModel).with(\.$additionalLinkedCompositeIdParentModel).first().wait())
+            let child4 = try XCTUnwrap(CompositeIDChildModel.query(on: self.database).filter(\.$id == 2).with(\.$compositeIdParentModel).with(\.$additionalCompositeIdParentModel).with(\.$linkedCompositeIdParentModel).with(\.$additionalLinkedCompositeIdParentModel).first().wait())
+            
+            XCTAssertEqual(child3.$compositeIdParentModel.value?.id, child3.$compositeIdParentModel.id)
+            XCTAssertNil(child3.$additionalCompositeIdParentModel.value??.id)
+            XCTAssertEqual(child3.$linkedCompositeIdParentModel.value?.id, child3.$linkedCompositeIdParentModel.id)
+            XCTAssertNil(child3.$additionalLinkedCompositeIdParentModel.value??.id)
+
+            XCTAssertEqual(child4.$compositeIdParentModel.value?.id, child4.$compositeIdParentModel.id)
+            XCTAssertEqual(child4.$additionalCompositeIdParentModel.value??.id, child4.$additionalCompositeIdParentModel.id)
+            XCTAssertEqual(child4.$linkedCompositeIdParentModel.value?.id, child4.$linkedCompositeIdParentModel.id)
+            XCTAssertEqual(child4.$additionalLinkedCompositeIdParentModel.value??.id, child4.$additionalLinkedCompositeIdParentModel.id)
         }
     }
 
-    private func testCompositeParent_eagerLoad() throws {
+    private func testCompositeChildren_loading() throws {
         try self.runTest(#function, [
-            CompositeIDModelMigration(),
-            CompositeIDModelSeed(),
+            CompositeIDParentModel.ModelMigration(),
+            CompositeIDParentModel.ModelSeed(),
             CompositeIDChildModel.ModelMigration(),
             CompositeIDChildModel.ModelSeed(),
         ]) {
-            let childModel = try XCTUnwrap(CompositeIDChildModel.query(on: self.database).with(\.$compositeIdModel).first().wait())
+            let parent1 = try XCTUnwrap(CompositeIDParentModel.query(on: self.database).filter(\.$id.$name == "A").first().wait())
+            let parent2 = try XCTUnwrap(CompositeIDParentModel.query(on: self.database).filter(\.$id.$name == "B").first().wait())
+            let parent3 = try XCTUnwrap(CompositeIDParentModel.query(on: self.database).filter(\.$id.$name == "C").first().wait())
             
-            XCTAssertNotNil(childModel.$compositeIdModel.id.$name.value)
-            XCTAssertNotNil(childModel.$compositeIdModel.id.$dimensions.value)
+            let children1_1 = try parent1.$compositeIdChildModels.get(on: self.database).wait()
+            let children1_2 = try parent1.$additionalCompositeIdChildModels.get(on: self.database).wait()
+            let children1_3 = try parent1.$linkedCompositeIdChildModel.get(on: self.database).wait()
+            let children1_4 = try parent1.$additionalLinkedCompositeIdChildModel.get(on: self.database).wait()
             
-            let loadedParentModel = try XCTUnwrap(childModel.$compositeIdModel.value)
-            XCTAssertEqual(loadedParentModel.id, childModel.$compositeIdModel.id)
+            let children2_1 = try parent2.$compositeIdChildModels.get(on: self.database).wait()
+            let children2_2 = try parent2.$additionalCompositeIdChildModels.get(on: self.database).wait()
+            let children2_3 = try parent2.$linkedCompositeIdChildModel.get(on: self.database).wait()
+            let children2_4 = try parent2.$additionalLinkedCompositeIdChildModel.get(on: self.database).wait()
+
+            let children3_1 = try parent3.$compositeIdChildModels.get(on: self.database).wait()
+            let children3_2 = try parent3.$additionalCompositeIdChildModels.get(on: self.database).wait()
+            let children3_3 = try parent3.$linkedCompositeIdChildModel.get(on: self.database).wait()
+            let children3_4 = try parent3.$additionalLinkedCompositeIdChildModel.get(on: self.database).wait()
+            
+            XCTAssertEqual(children1_1.compactMap(\.id).sorted(), [1, 2, 3])
+            XCTAssertTrue(children1_2.isEmpty)
+            XCTAssertEqual(children1_3?.id, 1)
+            XCTAssertEqual(children1_4?.id, 2)
+            
+            XCTAssertTrue(children2_1.isEmpty)
+            XCTAssertEqual(children2_2.compactMap(\.id).sorted(), [2, 3])
+            XCTAssertEqual(children2_3?.id, 2)
+            XCTAssertEqual(children2_4?.id, 3)
+            
+            XCTAssertTrue(children3_1.isEmpty)
+            XCTAssertTrue(children3_2.isEmpty)
+            XCTAssertEqual(children3_3?.id, 3)
+            XCTAssertNil(children3_4)
+
+            let parent4 = try XCTUnwrap(CompositeIDParentModel.query(on: self.database).filter(\.$id.$name == "A").with(\.$compositeIdChildModels).with(\.$additionalCompositeIdChildModels).with(\.$linkedCompositeIdChildModel).with(\.$additionalLinkedCompositeIdChildModel).first().wait())
+            let parent5 = try XCTUnwrap(CompositeIDParentModel.query(on: self.database).filter(\.$id.$name == "B").with(\.$compositeIdChildModels).with(\.$additionalCompositeIdChildModels).with(\.$linkedCompositeIdChildModel).with(\.$additionalLinkedCompositeIdChildModel).first().wait())
+            let parent6 = try XCTUnwrap(CompositeIDParentModel.query(on: self.database).filter(\.$id.$name == "C").with(\.$compositeIdChildModels).with(\.$additionalCompositeIdChildModels).with(\.$linkedCompositeIdChildModel).with(\.$additionalLinkedCompositeIdChildModel).first().wait())
+            
+            XCTAssertEqual(parent4.$compositeIdChildModels.value?.compactMap(\.id).sorted(), [1, 2, 3])
+            XCTAssertTrue(parent4.$additionalCompositeIdChildModels.value?.isEmpty ?? false)
+            XCTAssertEqual(parent4.$linkedCompositeIdChildModel.value??.id, 1)
+            XCTAssertEqual(parent4.$additionalLinkedCompositeIdChildModel.value??.id, 2)
+            
+            XCTAssertTrue(parent5.$compositeIdChildModels.value?.isEmpty ?? false)
+            XCTAssertEqual(parent5.$additionalCompositeIdChildModels.value?.compactMap(\.id).sorted(), [2, 3])
+            XCTAssertEqual(parent5.$linkedCompositeIdChildModel.value??.id, 2)
+            XCTAssertEqual(parent5.$additionalLinkedCompositeIdChildModel.value??.id, 3)
+            
+            XCTAssertTrue(parent6.$compositeIdChildModels.value?.isEmpty ?? false)
+            XCTAssertTrue(parent6.$additionalCompositeIdChildModels.value?.isEmpty ?? false)
+            XCTAssertEqual(parent6.$linkedCompositeIdChildModel.value??.id, 3)
+            XCTAssertNil(parent6.$additionalLinkedCompositeIdChildModel.value??.id)
         }
     }
 }
 
-public final class CompositeIDChildModel: Model {
-    public static let schema = "composite_id_child_models"
+final class CompositeIDParentModel: Model {
+    static let schema = "composite_id_parent_models"
     
-    @ID(custom: .id)
-    public var id: Int?
-    
-    @CompositeParent(prefix: "comp_id_model", strategy: .snakeCase)
-    public var compositeIdModel: CompositeIDModel
-    
-    public init() {}
-    
-    public init(id: Int? = nil, compositeIdModelId: CompositeIDModel.IDValue) {
-        self.id = id
-        self.$compositeIdModel.id = compositeIdModelId
+    final class IDValue: Fields, Hashable {
+        @Field(key: "name")
+        var name: String
+        
+        @Field(key: "dimensions")
+        var dimensions: Int
+        
+        init() {}
+        
+        init(name: String, dimensions: Int = 1) {
+            self.name = name
+            self.dimensions = dimensions
+        }
+        
+        static func == (lhs: IDValue, rhs: IDValue) -> Bool {
+            lhs.name == rhs.name && lhs.dimensions == rhs.dimensions
+        }
+        
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(self.name)
+            hasher.combine(self.dimensions)
+        }
     }
     
-    public struct ModelMigration: Migration {
-        public init() {}
+    @CompositeID
+    var id: IDValue?
+    
+    @CompositeChildren(for: \.$compositeIdParentModel) // Children referencing required composite parent
+    var compositeIdChildModels: [CompositeIDChildModel]
+    
+    @CompositeChildren(for: \.$additionalCompositeIdParentModel) // Children referencing optional composite parent
+    var additionalCompositeIdChildModels: [CompositeIDChildModel]
+    
+    @CompositeOptionalChild(for: \.$linkedCompositeIdParentModel) // Optional child referencing required composite parent
+    var linkedCompositeIdChildModel: CompositeIDChildModel?
+    
+    @CompositeOptionalChild(for: \.$additionalLinkedCompositeIdParentModel) // Optional child referencing optional composite parent
+    var additionalLinkedCompositeIdChildModel: CompositeIDChildModel?
+    
+    init() {}
+    
+    init(id: IDValue) {
+        self.id = id
+    }
+    
+    convenience init(name: String, dimensions: Int) {
+        self.init(id: .init(name: name, dimensions: dimensions))
+    }
+
+    struct ModelMigration: Migration {
+        init() {}
         
-        public func prepare(on database: Database) -> EventLoopFuture<Void> {
-            database.schema(CompositeIDChildModel.schema)
-                .field(.id, .int, .required, .identifier(auto: (database as? SQLDatabase)?.dialect.name != "sqlite"))
-                .field("comp_id_model_name", .string, .required)
-                .field("comp_id_model_dimensions", .int, .required)
-                .foreignKey(["comp_id_model_name", "comp_id_model_dimensions"], references: CompositeIDModel.schema, ["name", "dimensions"], onDelete: .cascade, onUpdate: .cascade)
+        func prepare(on database: Database) -> EventLoopFuture<Void> {
+            database.schema(CompositeIDParentModel.schema)
+                .field("name", .string, .required)
+                .field("dimensions", .int, .required)
+                .compositeIdentifier(over: "name", "dimensions")
                 .create()
         }
         
-        public func revert(on database: Database) -> EventLoopFuture<Void> {
+        func revert(on database: Database) -> EventLoopFuture<Void> {
+            database.schema(CompositeIDParentModel.schema)
+                .delete()
+        }
+    }
+
+    struct ModelSeed: Migration {
+        init() {}
+        
+        func prepare(on database: Database) -> EventLoopFuture<Void> {
+            [
+                CompositeIDParentModel(name: "A", dimensions: 1),
+                CompositeIDParentModel(name: "B", dimensions: 1),
+                CompositeIDParentModel(name: "C", dimensions: 1),
+            ].map { $0.create(on: database) }.flatten(on: database.eventLoop)
+        }
+        
+        func revert(on database: Database) -> EventLoopFuture<Void> {
+            CompositeIDParentModel.query(on: database).delete()
+        }
+    }
+}
+
+final class CompositeIDChildModel: Model {
+    static let schema = "composite_id_child_models"
+    
+    @ID(custom: .id)
+    var id: Int?
+    
+    @CompositeParent(prefix: "comp_parent_model", strategy: .snakeCase) // required composite parent referencing multiple children
+    var compositeIdParentModel: CompositeIDParentModel
+    
+    @CompositeOptionalParent(prefix: "addl_comp_parent_model", strategy: .snakeCase) // optional composite parent referencing multiple children
+    var additionalCompositeIdParentModel: CompositeIDParentModel?
+    
+    @CompositeParent(prefix: "comp_linked_model", strategy: .snakeCase) // required composite parent referencing one optional child
+    var linkedCompositeIdParentModel: CompositeIDParentModel
+    
+    @CompositeOptionalParent(prefix: "addl_comp_linked_model", strategy: .snakeCase) // optional composite parent referencing one optional child
+    var additionalLinkedCompositeIdParentModel: CompositeIDParentModel?
+    
+    init() {}
+    
+    init(
+        id: Int? = nil,
+        parentId: CompositeIDParentModel.IDValue,
+        additionalParentId: CompositeIDParentModel.IDValue?,
+        linkedId: CompositeIDParentModel.IDValue,
+        additionalLinkedId: CompositeIDParentModel.IDValue?
+    ) {
+        self.id = id
+        self.$compositeIdParentModel.id = parentId
+        self.$additionalCompositeIdParentModel.id = additionalParentId
+        self.$linkedCompositeIdParentModel.id = linkedId
+        self.$additionalLinkedCompositeIdParentModel.id = additionalLinkedId
+    }
+    
+    struct ModelMigration: Migration {
+        init() {}
+        
+        func prepare(on database: Database) -> EventLoopFuture<Void> {
+            database.schema(CompositeIDChildModel.schema)
+                .field(.id, .int, .required, .identifier(auto: (database as? SQLDatabase)?.dialect.name != "sqlite"))
+
+                .field("comp_parent_model_name", .string, .required)
+                .field("comp_parent_model_dimensions", .int, .required)
+                .foreignKey(["comp_parent_model_name", "comp_parent_model_dimensions"],
+                    references: CompositeIDParentModel.schema, ["name", "dimensions"]
+                )
+
+                .field("addl_comp_parent_model_name", .string)
+                .field("addl_comp_parent_model_dimensions", .int)
+                .constraint(.optionalCompositeReferenceCheck("addl_comp_parent_model_name", "addl_comp_parent_model_dimensions"))
+                .foreignKey(["addl_comp_parent_model_name", "addl_comp_parent_model_dimensions"],
+                    references: CompositeIDParentModel.schema, ["name", "dimensions"]
+                )
+
+                .field("comp_linked_model_name", .string, .required)
+                .field("comp_linked_model_dimensions", .int, .required)
+                .unique(on: "comp_linked_model_name", "comp_linked_model_dimensions")
+                .foreignKey(["comp_linked_model_name", "comp_linked_model_dimensions"],
+                    references: CompositeIDParentModel.schema, ["name", "dimensions"]
+                )
+                
+                .field("addl_comp_linked_model_name", .string)
+                .field("addl_comp_linked_model_dimensions", .int)
+                .unique(on: "addl_comp_linked_model_name", "addl_comp_linked_model_dimensions")
+                .constraint(.optionalCompositeReferenceCheck("addl_comp_linked_model_name", "addl_comp_linked_model_dimensions"))
+                .foreignKey(["addl_comp_linked_model_name", "addl_comp_linked_model_dimensions"],
+                    references: CompositeIDParentModel.schema, ["name", "dimensions"]
+                )
+                .create()
+        }
+        
+        func revert(on database: Database) -> EventLoopFuture<Void> {
             database.schema(CompositeIDChildModel.schema).delete()
         }
     }
     
-    public struct ModelSeed: Migration {
-        public init() {}
+    struct ModelSeed: Migration {
+        init() {}
         
-        public func prepare(on database: Database) -> EventLoopFuture<Void> {
+        func prepare(on database: Database) -> EventLoopFuture<Void> {
             [
-                CompositeIDChildModel(compositeIdModelId: .init(name: "A", dimensions: 1)),
-                CompositeIDChildModel(compositeIdModelId: .init(name: "B", dimensions: 1)),
+                CompositeIDChildModel(id: 1, parentId: .init(name: "A"), additionalParentId: nil,              linkedId: .init(name: "A"), additionalLinkedId: nil),
+                CompositeIDChildModel(id: 2, parentId: .init(name: "A"), additionalParentId: .init(name: "B"), linkedId: .init(name: "B"), additionalLinkedId: .init(name: "A")),
+                CompositeIDChildModel(id: 3, parentId: .init(name: "A"), additionalParentId: .init(name: "B"), linkedId: .init(name: "C"), additionalLinkedId: .init(name: "B")),
             ].create(on: database)
         }
         
-        public func revert(on database: Database) -> EventLoopFuture<Void> {
+        func revert(on database: Database) -> EventLoopFuture<Void> {
             CompositeIDChildModel.query(on: database).delete()
         }
+    }
+}
+
+extension DatabaseSchema.Constraint {
+    /// Convenience overload of `optionalCompositeReferenceCheck(_:)`.
+    static func optionalCompositeReferenceCheck(_ field1: FieldKey, _ field2: FieldKey, _ moreFields: FieldKey...) -> DatabaseSchema.Constraint {
+        return self.optionalCompositeReferenceCheck([field1, field2] + moreFields)
+    }
+
+    /// Returns a `CHECK` constraint whose condition requires that none of the provided fields be NULL
+    /// unless all of them are. This is useful for guaranteeing that the columns making up a NULLable
+    /// multi-column foreign key never specify only a partial key (even if such a key is permitted by
+    /// the database itself, Fluent's relations make no attempt to support it).
+    static func optionalCompositeReferenceCheck<C>(_ fields: C) -> DatabaseSchema.Constraint where C: Collection, C.Element == FieldKey {
+        guard fields.count > 1 else { fatalError("A composite reference check must cover at least two fields.") }
+        let fields = fields.map { SQLIdentifier($0.description) }
+        
+        return .sql(.check(SQLGroupExpression(SQLBinaryExpression(
+            SQLGroupExpression(SQLBinaryExpression(fields.first!, .is, SQLLiteral.null)),
+            .equal,
+            SQLGroupExpression(SQLBinaryExpression(SQLFunction.coalesce([SQLLiteral.null] + fields.dropFirst().map{$0}), .is, SQLLiteral.null))
+        ))))
     }
 }

--- a/Sources/FluentKit/Concurrency/AsyncMigration.swift
+++ b/Sources/FluentKit/Concurrency/AsyncMigration.swift
@@ -1,13 +1,10 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncMigration: Migration {
     func prepare(on database: Database) async throws
     func revert(on database: Database) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension AsyncMigration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         let promise = database.eventLoop.makePromise(of: Void.self)
@@ -25,6 +22,3 @@ public extension AsyncMigration {
         return promise.futureResult
     }
 }
-
-#endif
-

--- a/Sources/FluentKit/Concurrency/AsyncModelMiddleware.swift
+++ b/Sources/FluentKit/Concurrency/AsyncModelMiddleware.swift
@@ -1,6 +1,3 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
-
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncModelMiddleware: AnyModelMiddleware {
     associatedtype Model: FluentKit.Model
     
@@ -11,7 +8,6 @@ public protocol AsyncModelMiddleware: AnyModelMiddleware {
     func restore(model: Model, on db: Database, next: AnyAsyncModelResponder) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncModelMiddleware {
     public func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database, chainingTo next: AnyModelResponder) -> EventLoopFuture<Void> {
         let promise = db.eventLoop.makePromise(of: Void.self)
@@ -61,5 +57,3 @@ extension AsyncModelMiddleware {
         try await next.restore(model, on: db)
     }
 }
-
-#endif

--- a/Sources/FluentKit/Concurrency/Children+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Children+Concurrency.swift
@@ -1,9 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension ChildrenProperty {
-    
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
@@ -17,4 +14,8 @@ public extension ChildrenProperty {
     }
 }
 
-#endif
+public extension CompositeChildrenProperty {
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
+}

--- a/Sources/FluentKit/Concurrency/Database+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Database+Concurrency.swift
@@ -1,7 +1,5 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension Database {
     func transaction<T>(_ closure: @Sendable @escaping (Database) async throws -> T) async throws -> T {
         try await self.transaction { db -> EventLoopFuture<T> in
@@ -19,5 +17,3 @@ public extension Database {
         }.get()
     }
 }
-
-#endif

--- a/Sources/FluentKit/Concurrency/EnumBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/EnumBuilder+Concurrency.swift
@@ -1,7 +1,5 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension EnumBuilder {
     func create() async throws -> DatabaseSchema.DataType {
         try await self.create().get()
@@ -19,5 +17,3 @@ public extension EnumBuilder {
         try await self.delete().get()
     }
 }
-
-#endif

--- a/Sources/FluentKit/Concurrency/Model+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Model+Concurrency.swift
@@ -1,7 +1,5 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension Model {
     static func find(
         _ id: Self.IDValue?,
@@ -32,7 +30,6 @@ public extension Model {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension Collection where Element: FluentKit.Model {
     func delete(force: Bool = false, on database: Database) async throws {
         try await self.delete(force: force, on: database).get()
@@ -42,5 +39,3 @@ public extension Collection where Element: FluentKit.Model {
         try await self.create(on: database).get()
     }
 }
-
-#endif

--- a/Sources/FluentKit/Concurrency/ModelResponder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/ModelResponder+Concurrency.swift
@@ -1,7 +1,5 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AnyAsyncModelResponder: AnyModelResponder {
     func handle(
         _ event: ModelEvent,
@@ -10,7 +8,6 @@ public protocol AnyAsyncModelResponder: AnyModelResponder {
     ) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AnyAsyncModelResponder {
     func handle(_ event: ModelEvent, _ model: AnyModel, on db: Database) -> EventLoopFuture<Void> {
         let promise = db.eventLoop.makePromise(of: Void.self)
@@ -21,7 +18,6 @@ extension AnyAsyncModelResponder {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AnyAsyncModelResponder {
     public func create(_ model: AnyModel, on db: Database) async throws {
         try await handle(.create, model, on: db)
@@ -44,7 +40,6 @@ extension AnyAsyncModelResponder {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 internal struct AsyncBasicModelResponder: AnyAsyncModelResponder {
     private let _handle: (ModelEvent, AnyModel, Database) async throws -> Void
 
@@ -56,5 +51,3 @@ internal struct AsyncBasicModelResponder: AnyAsyncModelResponder {
         self._handle = handle
     }
 }
-
-#endif

--- a/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
@@ -1,9 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension OptionalChildProperty {
-    
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
@@ -13,4 +10,10 @@ public extension OptionalChildProperty {
     }
 }
 
-#endif
+/*
+public extension OptionalCompositeChildProperty {
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
+}
+*/

--- a/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalChild+Concurrency.swift
@@ -10,10 +10,8 @@ public extension OptionalChildProperty {
     }
 }
 
-/*
-public extension OptionalCompositeChildProperty {
+public extension CompositeOptionalChildProperty {
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
 }
-*/

--- a/Sources/FluentKit/Concurrency/OptionalParent+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/OptionalParent+Concurrency.swift
@@ -1,12 +1,13 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension OptionalParentProperty {
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
 }
 
-#endif
-
+public extension CompositeOptionalParentProperty {
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
+}

--- a/Sources/FluentKit/Concurrency/Parent+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Parent+Concurrency.swift
@@ -1,12 +1,13 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension ParentProperty {
     func load(on database: Database) async throws {
         try await self.load(on: database).get()
     }
 }
 
-#endif
-
+public extension CompositeParentProperty {
+    func load(on database: Database) async throws {
+        try await self.load(on: database).get()
+    }
+}

--- a/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/QueryBuilder+Concurrency.swift
@@ -1,7 +1,5 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension QueryBuilder {
     // MARK: - Actions
     func create() async throws {
@@ -224,5 +222,3 @@ public extension QueryBuilder {
         try await self.page(withIndex: page, size: per).get()
     }
 }
-
-#endif

--- a/Sources/FluentKit/Concurrency/Relation+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Relation+Concurrency.swift
@@ -1,11 +1,7 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension Relation {
     func get(reload: Bool = false, on database: Database) async throws -> RelatedValue {
         try await self.get(reload: reload, on: database).get()
     }
 }
-
-#endif

--- a/Sources/FluentKit/Concurrency/SchemaBuilder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/SchemaBuilder+Concurrency.swift
@@ -1,7 +1,5 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension SchemaBuilder {
     func create() async throws {
         try await self.create().get()
@@ -15,5 +13,3 @@ public extension SchemaBuilder {
         try await self.delete().get()
     }
 }
-
-#endif

--- a/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
@@ -1,7 +1,5 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension SiblingsProperty {
     
     func load(on database: Database) async throws {
@@ -58,5 +56,3 @@ public extension SiblingsProperty {
         try await self.detachAll(on: database).get()
     }
 }
-
-#endif

--- a/Sources/FluentKit/Database/DatabaseInput.swift
+++ b/Sources/FluentKit/Database/DatabaseInput.swift
@@ -28,7 +28,7 @@ public protocol DatabaseInput {
     /// value with the new. Conforming types _can_ choose alternative semantics, but must take care
     /// that doing so is compatible with the expectations of callers.
     ///
-    /// - Note: As a rule, a key being set multiple times for a single input usually indicates or at
+    /// > Note: As a rule, a key being set multiple times for a single input usually indicates or at
     ///   least implies buggy behavior (such as a Model which specifies a particular key in more than
     ///   one of its properties). However, there are cases where doing so is useful; as such, no
     ///   attempt is made to diagnose multiple sets for the same key and the API must permit said
@@ -48,13 +48,13 @@ public protocol DatabaseInput {
     /// For the purposes of this flag, when the value is `true`, both unmodified _and unset_ properties
     /// should be included. The value of unset properties should be ``DatabaseQuery/Value/default``.
     ///
-    /// - Important: The value of this property _MUST NOT_ change during the instance's lifetime. It is
+    /// > Important: The value of this property _MUST NOT_ change during the instance's lifetime. It is
     ///   generally recommended - though not required - that it be a constant value. This is the case for
     ///   all ``DatabaseInput`` types in FluentKit at the time of this writing. It has been left as an
     ///   instance property rather than being declared `static` to avoid artificially limiting the
     ///   flexibility of conforming types.
     ///
-    /// - Warning: While all of FluentKit's built-in property wrapper types correctly honor this flag, if
+    /// > Warning: While all of FluentKit's built-in property wrapper types correctly honor this flag, if
     ///   there are any custom property types in use which do not defer to a builtin type as a backing
     ///   store (as ``IDProperty`` does, for example), that type's ``AnyDatabaseProperty`` conformance must
     ///   be updated accordingly.
@@ -111,7 +111,7 @@ private struct PrefixedDatabaseInput<Base: DatabaseInput>: DatabaseInput {
 /// multiple filters is handled appropriately for their use case - most commonly by using the builder passed
 /// to a   ``QueryBuilder/group(_:_:)`` closure to create an instance of this type.
 ///
-/// - Tip: Applying a query filter via database input is especially useful as a means of providing generic
+/// > Tip: Applying a query filter via database input is especially useful as a means of providing generic
 ///   support for filters involving a ``CompositeIDProperty``. For example, using an instance of this type
 ///   as the input for a ``CompositeParentProperty`` filters the query according to the set of appropriately
 ///   prefixed field keys the property encapsulates.

--- a/Sources/FluentKit/Database/DatabaseInput.swift
+++ b/Sources/FluentKit/Database/DatabaseInput.swift
@@ -1,24 +1,136 @@
+/// A helper type for working with properties which conform to the ``AnyDatabaseProperty`` protocol.
+///
+/// All types conforming to either ``Fields`` or ``AnyDatabaseProperty`` provide an `input(to:)` method
+/// (see ``Fields/input(to:)-3g6gt`` and ``AnyDatabaseProperty/input(to:)``). This method in turn calls
+/// the ``DatabaseInput/set(_:at:)`` method of the provided ``DatabaseInput`` once for each ``FieldKey``
+/// the implementing type is responsible for, providing both the key and the ``DatabaseQuery/Value``
+/// associated with that key.
+///
+/// As the protocol name suggests, the primary purpose of ``DatabaseInput`` is to allow a complete set of
+/// data, in the form of a key-value map, to be generically gathered for input "into" a database. However,
+/// to allow useful semantics such as composition (such as transparently remapping field keys) and alternate
+/// data handling (such as saving existing state so it can be temporarily overwritten), this mechanism is
+/// expressed as a protocol rather than just handing around a dictionary or other similar structure.
+///
+/// > TODO: Define a new protocol formalizing the `input(to:)` and `output(from:)` methods found on both
+///   ``AnyDatabaseProperty`` and ``Fields``, and have them conform to it rather than independently
+///   providing identical requirements. This will allow inputtable and outputtable (corresponding to
+///   encodable and decodable) types to be generically addressed cleanly.
+///
+/// > See Also: ``FluentKit/DatabaseOutput``
 public protocol DatabaseInput {
+    /// Called by individual database properties to register a given field key and associated database
+    /// value as part of the data set represented by the ``DatabaseInput``.
+    ///
+    /// Implemented by conforming types to handle key/value pairs provided by callers.
+    ///
+    /// Setting a value for a key which has already been registered is expected to overwrite the old
+    /// value with the new. Conforming types _can_ choose alternative semantics, but must take care
+    /// that doing so is compatible with the expectations of callers.
+    ///
+    /// - Note: As a rule, a key being set multiple times for a single input usually indicates or at
+    ///   least implies buggy behavior (such as a Model which specifies a particular key in more than
+    ///   one of its properties). However, there are cases where doing so is useful; as such, no
+    ///   attempt is made to diagnose multiple sets for the same key and the API must permit said
+    ///   behavior unless the semantics of the conforming type explicitly require otherwise and
+    ///   the alternate behavior is clearly documented.
     func set(_ value: DatabaseQuery.Value, at key: FieldKey)
+    
+    /// Indicates whether this ``DatabaseInput`` instance is requesting key/value pairs for _all_ defined
+    /// database fields regardless of status, or only those pairs where the current value
+    /// is known to be out of date (also referred to variously as "dirty", "modified", or "has changes").
+    ///
+    /// By default, only changed values are requested. This choice was made because this property was
+    /// added long after the first release of the protocol, before which time unmodified properties were
+    /// always unconditionally omitted; as such, in order to remain fully source-compatible with existing
+    /// conforming types, there must be a default which is chosen so as to preserve existing behavior.
+    ///
+    /// For the purposes of this flag, when the value is `true`, both unmodified _and unset_ properties
+    /// should be included. The value of unset properties should be ``DatabaseQuery/Value/default``.
+    ///
+    /// - Important: The value of this property _MUST NOT_ change during the instance's lifetime. It is
+    ///   generally recommended - though not required - that it be a constant value. This is the case for
+    ///   all ``DatabaseInput`` types in FluentKit at the time of this writing. It has been left as an
+    ///   instance property rather than being declared `static` to avoid artificially limiting the
+    ///   flexibility of conforming types.
+    ///
+    /// - Warning: While all of FluentKit's built-in property wrapper types correctly honor this flag, if
+    ///   there are any custom property types in use which do not defer to a builtin type as a backing
+    ///   store (as ``IDProperty`` does, for example), that type's ``AnyDatabaseProperty`` conformance must
+    ///   be updated accordingly.
+    var wantsUnmodifiedKeys: Bool { get }
 }
 
 extension DatabaseInput {
+    /// Default implementation of ``wantsUnmodifiedKeys-4tisb``. Always assume the old behavior (modified
+    /// data only) unless explcitly told otherwise.
+    public var wantsUnmodifiedKeys: Bool {
+        false
+    }
+}
+
+extension DatabaseInput {
+    /// Return a ``DatabaseInput`` wrapping `self` so as to apply a given prefix to each field key
+    /// before processing.
     public func prefixed(by prefix: FieldKey) -> DatabaseInput {
         PrefixedDatabaseInput(prefix: prefix, strategy: .none, base: self)
     }
     
+    /// Return a ``DatabaseInput`` wrapping `self` so as to apply a given prefix, according to a given
+    /// ``KeyPrefixingStrategy``, to each field key before processing.
     public func prefixed(by prefix: FieldKey, using stratgey: KeyPrefixingStrategy) -> DatabaseInput {
         PrefixedDatabaseInput(prefix: prefix, strategy: stratgey, base: self)
     }
 }
 
-private struct PrefixedDatabaseInput: DatabaseInput {
+/// A ``DatabaseInput`` which applies a key prefix according to a ``KeyPrefixingStrategy`` to each key
+/// sent to it before passing the resulting key and the unmodified value on to another ``DatabaseInput``.
+private struct PrefixedDatabaseInput<Base: DatabaseInput>: DatabaseInput {
     let prefix: FieldKey
     let strategy: KeyPrefixingStrategy
-    let base: DatabaseInput
+    let base: Base
 
     func set(_ value: DatabaseQuery.Value, at key: FieldKey) {
         self.base.set(value, at: self.strategy.apply(prefix: self.prefix, to: key))
     }
 }
 
+/// A ``DatabaseInput`` which generates a ``DatabaseQuery/Filter`` based on each key-value pair sent to it,
+/// using ``DatabaseQuery/Filter/Method/equal``, and adds each such filter to a ``QueryBuilder``.
+///
+/// All fields directed to the input are assumed to belong to the entity referenced by `InputModel`, which
+/// need not be the same as `BuilderModel` (the base model of the query builder). This permits filtering
+/// to be applied based on a joined model, and enables support for ``ModelAlias``.
+///
+/// The ``DatabaseInput/wantsUnmodifiedKeys-1qajw`` flag is enabled for this input type.
+///
+/// The query builder is modified in-place. Callers may either retain their own reference to the builder or
+/// retrieve it from this structure when ready. It is the caller's responsibility to ensure that grouping of
+/// multiple filters is handled appropriately for their use case - most commonly by using the builder passed
+/// to a   ``QueryBuilder/group(_:_:)`` closure to create an instance of this type.
+///
+/// - Tip: Applying a query filter via database input is especially useful as a means of providing generic
+///   support for filters involving a ``CompositeIDProperty``. For example, using an instance of this type
+///   as the input for a ``CompositeParentProperty`` filters the query according to the set of appropriately
+///   prefixed field keys the property encapsulates.
+internal struct QueryFilterInput<BuilderModel: FluentKit.Model, InputModel: Schema>: DatabaseInput {
+    let builder: QueryBuilder<BuilderModel>
+    
+    var wantsUnmodifiedKeys: Bool { true }
+    
+    init(builder: QueryBuilder<BuilderModel>) where BuilderModel == InputModel {
+        self.init(BuilderModel.self, builder: builder)
+    }
+    
+    init(_: InputModel.Type, builder: QueryBuilder<BuilderModel>) {
+        self.builder = builder
+    }
+
+    func set(_ value: DatabaseQuery.Value, at key: FieldKey) {
+        builder.filter(
+            .extendedPath([key], schema: InputModel.schemaOrAlias, space: InputModel.spaceIfNotAliased),
+            .equal,
+            value
+        )
+    }
+}

--- a/Sources/FluentKit/Database/KeyPrefixingStrategy.swift
+++ b/Sources/FluentKit/Database/KeyPrefixingStrategy.swift
@@ -42,7 +42,7 @@ public enum KeyPrefixingStrategy: CustomStringConvertible {
                 return .prefix(prefix, .string(key.description.withUppercasedFirstCharacter()))
 
             case .prefix(let originalPrefix, let originalSuffix):
-                return .prefix(.prefix(prefix, originalPrefix), originalSuffix)
+                return .prefix(self.apply(prefix: prefix, to: originalPrefix), originalSuffix)
             }
 
         case .snakeCase:

--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -87,13 +87,21 @@ extension EnumProperty: AnyDatabaseProperty {
     }
 
     public func input(to input: DatabaseInput) {
-        guard let value = self.field.inputValue else { return }
+        let value: DatabaseQuery.Value
+        if !input.wantsUnmodifiedKeys {
+            guard let ivalue = self.field.inputValue else { return }
+            value = ivalue
+        } else {
+            value = self.field.inputValue ?? .default
+        }
 
         switch value {
         case .bind(let bind as String):
             input.set(.enumCase(bind), at: self.field.key)
         case .enumCase(let string):
             input.set(.enumCase(string), at: self.field.key)
+        case .default:
+            input.set(.default, at: self.field.key)
         default:
             fatalError("Unexpected input value type for '\(Model.self)'.'\(self.field.key)': \(value)")
         }

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -93,7 +93,14 @@ extension OptionalEnumProperty: AnyDatabaseProperty {
     }
 
     public func input(to input: DatabaseInput) {
-        guard let value = self.field.inputValue else { return }
+        let value: DatabaseQuery.Value
+        if !input.wantsUnmodifiedKeys {
+            guard let ivalue = self.field.inputValue else { return }
+            value = ivalue
+        } else {
+            value = self.field.inputValue ?? .default
+        }
+
 
         switch value {
         case .bind(let bind as String):
@@ -102,6 +109,8 @@ extension OptionalEnumProperty: AnyDatabaseProperty {
             input.set(.enumCase(string), at: self.field.key)
         case .null:
             input.set(.null, at: self.field.key)
+        case .default:
+            input.set(.default, at: self.field.key)
         default:
             fatalError("Unexpected input value type for '\(Model.self)'.'\(self.field.key)': \(value)")
         }

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -63,4 +63,15 @@ extension FluentError {
             id: "\(id)"
         )
     }
+
+    internal static func missingParentError<Child: Model, Parent: Model>(
+        _: Child.Type = Child.self, _: Parent.Type = Parent.self, keyPath: KeyPath<Child, Child.CompositeOptionalParent<Parent>>, id: Parent.IDValue
+    ) -> Self where Parent.IDValue: Fields {
+        .missingParent(
+            from: "\(Child.self)",
+            to: "\(Parent.self)",
+            key: Child()[keyPath: keyPath].prefix.description,
+            id: "\(id)"
+        )
+    }
 }

--- a/Sources/FluentKit/Model/AnyModel.swift
+++ b/Sources/FluentKit/Model/AnyModel.swift
@@ -24,7 +24,7 @@ extension AnyModel {
             fatalError("Can only access joined models using models fetched from database (from \(Self.self) to \(Joined.self)).")
         }
         let joined = Joined()
-        try joined.output(from: output.schema(Joined.schemaOrAlias))
+        try joined.output(from: output.qualifiedSchema(space: Joined.spaceIfNotAliased, Joined.schemaOrAlias))
         return joined
     }
 

--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -130,8 +130,11 @@ extension Fields {
 // MARK: Has Changes
 
 extension Fields {
-    /// Indicates whether the model has fields that have been set, but the model
-    /// has not yet been saved to the database.
+    /// Returns `true` if a model has fields whose values have been explicitly set or modified
+    /// since the most recent load from and/or save to the database (if any).
+    ///
+    /// If `false` is returned, attempts to save changes to the database (or more precisely, to
+    /// send values to any given ``DatabaseInput``) will do nothing.
     public var hasChanges: Bool {
         let input = HasChangesInput()
         self.input(to: input)
@@ -139,6 +142,7 @@ extension Fields {
     }
 }
 
+/// Helper type for the implementation of ``Fields/hasChanges``.
 private final class HasChangesInput: DatabaseInput {
     var hasChanges: Bool = false
 
@@ -150,6 +154,8 @@ private final class HasChangesInput: DatabaseInput {
 // MARK: Collect Input
 
 extension Fields {
+    /// Returns a dictionary of field keys and associated values representing all "pending"
+    /// data - e.g. all fields (if any) which have been changed by something other than Fluent.
     internal func collectInput() -> [FieldKey: DatabaseQuery.Value] {
         let input = DictionaryInput()
         self.input(to: input)
@@ -157,6 +163,7 @@ extension Fields {
     }
 }
 
+/// Helper type for the implementation of `Fields.collectInput()`.
 private final class DictionaryInput: DatabaseInput {
     var storage: [FieldKey: DatabaseQuery.Value] = [:]
 

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -9,10 +9,7 @@ extension Model {
 public final class ChildrenProperty<From, To>
     where From: Model, To: Model
 {
-    public enum Key {
-        case required(KeyPath<To, To.Parent<From>>)
-        case optional(KeyPath<To, To.OptionalParent<From>>)
-    }
+    public typealias Key = RelationParentKey<From, To>
 
     public let parentKey: Key
     var idValue: From.IDValue?
@@ -162,17 +159,6 @@ extension ChildrenProperty: Relation {
     public func load(on database: Database) -> EventLoopFuture<Void> {
         self.query(on: database).all().map {
             self.value = $0
-        }
-    }
-}
-
-extension ChildrenProperty.Key: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .optional(let keyPath):
-            return To.path(for: keyPath.appending(path: \.$id)).description
-        case .required(let keyPath):
-            return To.path(for: keyPath.appending(path: \.$id)).description
         }
     }
 }

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -1,0 +1,151 @@
+extension Model {
+    public typealias CompositeChildren<To> = CompositeChildrenProperty<Self, To>
+        where To: FluentKit.Model, Self.IDValue: Fields
+}
+
+@propertyWrapper
+public final class CompositeChildrenProperty<From, To>
+    where From: Model, To: Model, From.IDValue: Fields
+{
+    public let parentKey: KeyPath<To, To.CompositeParent<From>>
+    var idValue: From.IDValue?
+
+    public var value: [To]?
+
+    public init(for parentKey: KeyPath<To, To.CompositeParent<From>>) {
+        self.parentKey = parentKey
+    }
+
+    public var wrappedValue: [To] {
+        get {
+            guard let value = self.value else {
+                fatalError("Children relation not eager loaded, use $ prefix to access: \(self.name)")
+            }
+            return value
+        }
+        set {
+            fatalError("Children relation \(self.name) is get-only.")
+        }
+    }
+
+    public var projectedValue: CompositeChildrenProperty<From, To> { self }
+    
+    public var fromId: From.IDValue? {
+        get { return self.idValue }
+        set { self.idValue = newValue }
+    }
+
+    public func query(on database: Database) -> QueryBuilder<To> {
+        guard let id = self.idValue else {
+            fatalError("Cannot query children relation \(self.name) from unsaved model.")
+        }
+
+        /// Route the value through an instance of the child model's parent property. This ensures the
+        /// correct prefix and strategy for this specific relation are applied to the filter keys.
+        let parentProp = To()[keyPath: self.parentKey]
+        parentProp.id = id
+
+        /// Apply filters for each property of the ID to a query builder for the child model. See
+        /// the documentation for ``QueryFilterInput`` for details of how this works.
+        return To.query(on: database).group(.and) { parentProp.input(to: QueryFilterInput(builder: $0)) }
+    }
+}
+
+extension CompositeChildrenProperty: CustomStringConvertible {
+    public var description: String { self.name }
+}
+
+extension CompositeChildrenProperty: AnyProperty { }
+
+extension CompositeChildrenProperty: Property {
+    public typealias Model = From
+    public typealias Value = [To]
+}
+
+extension CompositeChildrenProperty: AnyDatabaseProperty {
+    public var keys: [FieldKey] { [] }
+    public func input(to input: DatabaseInput) {}
+    public func output(from output: DatabaseOutput) throws {
+        if From.IDValue.keys.reduce(true, { $0 && output.contains($1) }) { // don't output unless all keys are present
+            self.idValue = From.IDValue()
+            try self.idValue!.output(from: output)
+        }
+    }
+}
+
+extension CompositeChildrenProperty: AnyCodableProperty {
+    public func encode(to encoder: Encoder) throws {
+        if let value = self.value {
+            var container = encoder.singleValueContainer()
+            try container.encode(value)
+        }
+    }
+    public func decode(from decoder: Decoder) throws {}
+    public var skipPropertyEncoding: Bool { self.value == nil }
+}
+
+extension CompositeChildrenProperty: Relation {
+    public var name: String { "CompositeChildren<\(From.self), \(To.self)>(for: \(self.parentKey))" }
+    public func load(on database: Database) -> EventLoopFuture<Void> { self.query(on: database).all().map { self.value = $0 } }
+}
+
+extension CompositeChildrenProperty: EagerLoadable {
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, to builder: Builder)
+        where Builder: EagerLoadBuilder, Builder.Model == From
+    {
+        let loader = CompositeChildrenEagerLoader(relationKey: relationKey)
+        builder.add(loader: loader)
+    }
+
+
+    public static func eagerLoad<Loader, Builder>(_ loader: Loader, through: KeyPath<From, From.CompositeChildren<To>>, to builder: Builder)
+        where Loader: EagerLoader, Loader.Model == To, Builder: EagerLoadBuilder, Builder.Model == From
+    {
+        let loader = ThroughCompositeChildrenEagerLoader(relationKey: through, loader: loader)
+        builder.add(loader: loader)
+    }
+}
+
+private struct CompositeChildrenEagerLoader<From, To>: EagerLoader
+    where From: Model, To: Model, From.IDValue: Fields
+{
+    let relationKey: KeyPath<From, From.CompositeChildren<To>>
+
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        let ids = Set(models.map(\.id!))
+        let parentKey = From()[keyPath: self.relationKey].parentKey
+        let parentProp = To()[keyPath: parentKey]
+        let builder = To.query(on: database)
+        
+        builder.group(.or) { query in
+            _ = ids.reduce(query) { query, id in
+                query.group(.and) {
+                    parentProp.id = id
+                    parentProp.input(to: QueryFilterInput(builder: $0))
+                }
+            }
+        }
+        
+        return builder.all().map {
+            let indexedResults = Dictionary(grouping: $0, by: { $0[keyPath: parentKey].id })
+            
+            for model in models {
+                model[keyPath: self.relationKey].value = indexedResults[model[keyPath: self.relationKey].idValue!]
+            }
+        }
+    }
+}
+
+private struct ThroughCompositeChildrenEagerLoader<From, Through, Loader>: EagerLoader
+    where From: Model, From.IDValue: Fields, Loader: EagerLoader, Loader.Model == Through
+{
+    let relationKey: KeyPath<From, From.CompositeChildren<Through>>
+    let loader: Loader
+
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        let throughs = models.flatMap {
+            $0[keyPath: self.relationKey].value!
+        }
+        return self.loader.run(models: throughs, on: database)
+    }
+}

--- a/Sources/FluentKit/Properties/CompositeID.swift
+++ b/Sources/FluentKit/Properties/CompositeID.swift
@@ -75,12 +75,12 @@ extension CompositeIDProperty: AnyDatabaseProperty {
 extension CompositeIDProperty: AnyCodableProperty {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(self.value!)
+        try container.encode(self.value)
     }
 
     public func decode(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.value = try container.decode(Value.self)
+        self.value = try container.decode(Value?.self)
     }
 }
 

--- a/Sources/FluentKit/Properties/CompositeOptionalChild.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalChild.swift
@@ -55,7 +55,6 @@ extension Model {
 ///     }
 /// }
 /// ```
-
 @propertyWrapper
 public final class CompositeOptionalChildProperty<From, To>
     where From: Model, To: Model, From.IDValue: Fields

--- a/Sources/FluentKit/Properties/CompositeOptionalParent.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalParent.swift
@@ -1,0 +1,243 @@
+extension Model {
+    /// A convenience alias for ``CompositeOptionalParentProperty``. It is strongly recommended that callers
+    /// use this alias rather than referencing ``CompositeOptionalParentProperty`` directly whenever possible.
+    public typealias CompositeOptionalParent<To> = CompositeOptionalParentProperty<Self, To>
+        where To: Model, To.IDValue: Fields
+}
+
+/// Declares an _optional_ one-to-many relation between the referenced ("parent") model and the referencing
+/// ("child") model, where the parent model specifies its ID with ``CompositeIDProperty``.
+///
+/// ``CompositeOptionalParentProperty`` serves the same purpose for parent models which use `@CompositeID`
+/// that ``OptionalParentProperty`` serves for parent models which use `@ID`.
+///
+/// Unfortunately, while the type of ID used by the child model makes no difference, limitations of Swift's
+/// generics syntax make it impractical to support both `@ID`-using and `@CompositeID`-using models as the parent
+/// model with a single property type. A similar limitation applies in the opposite direction for
+/// ``ChildrenProperty`` and ``OptionalChildProperty``.
+///
+/// Example:
+///
+/// - Note: This example is somewhat contrived; in reality, this kind of metadata would have much more
+///   complex relationships.
+///
+/// ```
+/// final class TableMetadata: Model {
+///     static let schema = "table_metadata"
+///
+///     final class IDValue: Fields, Hashable {
+///         @Field(key: "table_schema") var schema: String
+///         @Field(key: "table_name")   var name: String
+///         init() {}
+///         static func ==(lhs: IDValue, rhs: IDValue) -> Bool { lhs.schema == rhs.schema && lhs.name == rhs.name }
+///         func hash(into hasher: inout Hasher) { hasher.combine(self.schema); hasher.combine(self.name) }
+///     }
+///
+///     @CompositeID var id: IDValue?
+///     // ...
+/// }
+///
+/// final class ForeignKeyMetadata: Model {
+///     static let schema = "foreign_key_metadata"
+///
+///     @ID(custom: "constraint_name") var id: String?
+///     @CompositeParent(prefix: "referenced") var referencedTable: TableMetadata
+///     @CompositeOptionalParent(prefix: "next_xref") var nextCrossReferencedTable: TableMetadata?
+///     // ...
+///
+///     struct CreateTableMigration: AsyncMigration {
+///         func prepare(on database: Database) async throws {
+///             try await database.schema(ForeignKeyMetadata.schema)
+///                 .field("constraint_name", .string, .required, .identifier(auto: false))
+///                 .field("referenced_table_schema", .string, .required)
+///                 .field("referenced_table_name", .string, .required)
+///                 .foreignKey(["referenced_table_schema", "referenced_table_name"], references: TableMetadata.schema, ["table_schema", "table_name"])
+///                 .field("next_xref_table_schema", .string)
+///                 .field("next_xref_table_name", .string)
+///                 .foreignKey(["next_xref_table_schema", "next_xref_table_name"], references: TableMetadata.schema, ["table_schema", "table_name"])
+///                 .constraint(.sql(.check(SQLBinaryExpression( // adds a check constraint to ensure that neither field is ever NULL when the other isn't
+///                     left: SQLBinaryExpression(left: SQLIdentifier("next_xref_table_schema"), .is, right: SQLLiteral.null),
+///                     .equal,
+///                     right: SQLBinaryExpression(left: SQLIdentifier("next_xref_table_name"), .is, right: SQLLiteral.null)
+///                 ))))
+///                 // ...
+///                 .create()
+///         }
+///     }
+/// }
+/// ```
+@propertyWrapper @dynamicMemberLookup
+public final class CompositeOptionalParentProperty<From, To>
+    where From: Model, To: Model, To.IDValue: Fields
+{
+    public let prefix: FieldKey
+    public let prefixingStrategy: KeyPrefixingStrategy
+    public var value: To??
+
+    var inputId: To.IDValue??
+    var outputId: To.IDValue??
+    public var id: To.IDValue? {
+        get { self.inputId ?? self.outputId ?? nil }
+        set { self.inputId = .some(newValue) }
+    }
+
+    public var wrappedValue: To? {
+        get { self.value ?? nil }
+        set { fatalError("use $ prefix to access \(self.name)") }
+    }
+
+    public var projectedValue: CompositeOptionalParentProperty<From, To> { self }
+    
+    /// Configure a ``CompositeOptionalParentProperty`` with a key prefix and prefix strategy.
+    ///
+    /// - Parameters:
+    ///   - prefix: A prefix to be applied to the key of each individual field of the referenced model's `IDValue`.
+    ///   - strategy: The strategy to use when applying prefixes to keys. ``KeyPrefixingStrategy/snakeCase`` is
+    ///     the default.
+    public init(prefix: FieldKey, strategy: KeyPrefixingStrategy = .snakeCase) {
+        self.prefix = prefix
+        self.prefixingStrategy = strategy
+    }
+
+    public func query(on database: Database) -> QueryBuilder<To> {
+        return To.query(on: database).group(.and) {
+            self.id?.input(to: QueryFilterInput(builder: $0)) ?? To.IDValue().input(to: QueryFilterInput(builder: $0).nullValueOveridden())
+        }
+    }
+
+    public subscript<Nested>(dynamicMember keyPath: KeyPath<To.IDValue, Nested>) -> Nested?
+        where Nested: Property
+    {
+        self.id?[keyPath: keyPath]
+    }
+}
+
+extension CompositeOptionalParentProperty: CustomStringConvertible {
+    public var description: String {
+        self.name
+    }
+}
+
+extension CompositeOptionalParentProperty: Relation {
+    public var name: String {
+        "CompositeOptionalParent<\(From.self), \(To.self)>(prefix: \(self.prefix), strategy: \(self.prefixingStrategy))"
+    }
+    
+    public func load(on database: Database) -> EventLoopFuture<Void> {
+        self.query(on: database)
+            .first()
+            .map {
+                self.value = $0
+            }
+    }
+}
+
+extension CompositeOptionalParentProperty: AnyProperty {}
+
+extension CompositeOptionalParentProperty: Property {
+    public typealias Model = From
+    public typealias Value = To?
+}
+
+extension CompositeOptionalParentProperty: AnyDatabaseProperty {
+    public var keys: [FieldKey] {
+        To.IDValue.keys.map {
+            self.prefixingStrategy.apply(prefix: self.prefix, to: $0)
+        }
+    }
+    
+    public func input(to input: DatabaseInput) {
+        let prefixedInput = input.prefixed(by: self.prefix, using: self.prefixingStrategy)
+        let id: To.IDValue?
+        
+        if input.wantsUnmodifiedKeys { id = self.id }
+        else if let inId = self.inputId { id = inId }
+        else { return }
+        
+        id?.input(to: prefixedInput) ?? To.IDValue().input(to: prefixedInput.nullValueOveridden())
+    }
+    
+    public func output(from output: DatabaseOutput) throws {
+        if self.keys.reduce(true, { $0 && output.contains($1) }) {
+            self.inputId = nil
+            if try self.keys.reduce(true, { try $0 && output.decodeNil($1) }) {
+                self.outputId = .some(.none)
+            } else {
+                let id = To.IDValue()
+                try id.output(from: output.prefixed(by: self.prefix, using: self.prefixingStrategy))
+                self.outputId = .some(.some(id))
+            }
+        }
+    }
+}
+
+extension CompositeOptionalParentProperty: AnyCodableProperty {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        if case .some(.some(let value)) = self.value {
+            try container.encode(value)
+        } else {
+            try container.encode(["id": self.id])
+        }
+    }
+
+    public func decode(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: SomeCodingKey.self)
+        self.id = try container.decode(To.IDValue?.self, forKey: .init(stringValue: "id"))
+    }
+}
+
+extension CompositeOptionalParentProperty: EagerLoadable {
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalParent<To>>, to builder: Builder)
+        where Builder: EagerLoadBuilder, Builder.Model == From
+    {
+        builder.add(loader: CompositeOptionalParentEagerLoader(relationKey: relationKey))
+    }
+
+    public static func eagerLoad<Loader, Builder>(_ loader: Loader, through: KeyPath<From, From.CompositeOptionalParent<To>>, to builder: Builder)
+        where Loader: EagerLoader, Loader.Model == To, Builder: EagerLoadBuilder, Builder.Model == From
+    {
+        builder.add(loader: ThroughCompositeOptionalParentEagerLoader(relationKey: through, loader: loader))
+    }
+}
+
+private struct CompositeOptionalParentEagerLoader<From, To>: EagerLoader
+    where From: Model, To: Model, To.IDValue: Fields
+{
+    let relationKey: KeyPath<From, From.CompositeOptionalParent<To>>
+    
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        var sets = Dictionary(grouping: models, by: { $0[keyPath: self.relationKey].id })
+        let nilParentModels = sets.removeValue(forKey: nil) ?? []
+
+        return To.query(on: database)
+            .group(.or) { _ = sets.keys.reduce($0) { query, id in query.group(.and) { id!.input(to: QueryFilterInput(builder: $0)) } } }
+            .all().flatMapThrowing {
+                let parents = Dictionary(uniqueKeysWithValues: $0.map { ($0.id!, $0) })
+
+                for (parentId, models) in sets {
+                    guard let parent = parents[parentId!] else {
+                        database.logger.debug(
+                            "Missing parent model in eager-load lookup results.",
+                            metadata: ["parent": "\(To.self)", "id": "\(parentId!)"]
+                        )
+                        throw FluentError.missingParentError(keyPath: self.relationKey, id: parentId!)
+                    }
+                    models.forEach { $0[keyPath: self.relationKey].value = .some(.some(parent)) }
+                }
+                nilParentModels.forEach { $0[keyPath: self.relationKey].value = .some(.none) }
+            }
+    }
+}
+
+private struct ThroughCompositeOptionalParentEagerLoader<From, Through, Loader>: EagerLoader
+    where From: Model, Loader: EagerLoader, Loader.Model == Through, Through.IDValue: Fields
+{
+    let relationKey: KeyPath<From, From.CompositeOptionalParent<Through>>
+    let loader: Loader
+    
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        self.loader.run(models: models.compactMap { $0[keyPath: self.relationKey].value! }, on: database)
+    }
+}

--- a/Sources/FluentKit/Properties/CompositeParent.swift
+++ b/Sources/FluentKit/Properties/CompositeParent.swift
@@ -155,14 +155,13 @@ extension CompositeParentProperty: AnyCodableProperty {
         if let value = self.value {
             try container.encode(value)
         } else {
-            try container.encode(self.id)
+            try container.encode(["id": self.id])
         }
     }
 
     public func decode(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        
-        self.id = try container.decode(To.IDValue.self)
+        let container = try decoder.container(keyedBy: SomeCodingKey.self)
+        self.id = try container.decode(To.IDValue.self, forKey: .init(stringValue: "id"))
     }
 }
 

--- a/Sources/FluentKit/Properties/CompositeParent.swift
+++ b/Sources/FluentKit/Properties/CompositeParent.swift
@@ -16,10 +16,6 @@ extension Model {
 /// model with a single property type. A similar limitation applies in the opposite direction for
 /// ``ChildrenProperty`` and ``OptionalChildProperty``.
 ///
-/// - Note: At the time of this writing, there are no corresponding composite ID-supporting counterparts for
-///   ``OptionalParentProperty``, ``ChildrenProperty``, or ``OptionalChildProperty``. These counterparts wlll
-///   be added to Fluent in the near future.
-///
 /// Example:
 ///
 /// - Note: This example is somewhat contrived; in reality, this kind of metadata would have much more
@@ -99,8 +95,7 @@ public final class CompositeParentProperty<From, To>
     }
 
     public func query(on database: Database) -> QueryBuilder<To> {
-        To.query(on: database)
-            .filter(id: self.id)
+        return To.query(on: database).group(.and) { self.id.input(to: QueryFilterInput(builder: $0)) }
     }
 
     public subscript<Nested>(dynamicMember keyPath: KeyPath<To.IDValue, Nested>) -> Nested
@@ -195,7 +190,7 @@ private struct CompositeParentEagerLoader<From, To>: EagerLoader
 
         return To.query(on: database)
             .group(.or) {
-                _ = sets.keys.map($0.filter(id:))
+                _ = sets.keys.reduce($0) { query, id in query.group(.and) { id.input(to: QueryFilterInput(builder: $0)) } }
             }
             .all()
             .flatMapThrowing {

--- a/Sources/FluentKit/Properties/Field.swift
+++ b/Sources/FluentKit/Properties/Field.swift
@@ -99,7 +99,9 @@ extension FieldProperty: AnyDatabaseProperty {
     }
 
     public func input(to input: DatabaseInput) {
-        if let inputValue = self.inputValue {
+        if input.wantsUnmodifiedKeys {
+            input.set(self.inputValue ?? self.outputValue.map { .bind($0) } ?? .default, at: self.key)
+        } else if let inputValue = self.inputValue {
             input.set(inputValue, at: self.key)
         }
     }

--- a/Sources/FluentKit/Properties/Group.swift
+++ b/Sources/FluentKit/Properties/Group.swift
@@ -90,6 +90,8 @@ extension GroupProperty: AnyCodableProperty {
         guard !container.decodeNil() else { return }
         self.value = .some(try container.decode(Value.self))
     }
+    
+    public var skipPropertyEncoding: Bool { self.value == nil }
 }
 
 

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -9,10 +9,7 @@ extension Model {
 public final class OptionalChildProperty<From, To>
     where From: Model, To: Model
 {
-    public enum Key {
-        case required(KeyPath<To, To.Parent<From>>)
-        case optional(KeyPath<To, To.OptionalParent<From>>)
-    }
+    public typealias Key = RelationParentKey<From, To>
 
     public let parentKey: Key
     var idValue: From.IDValue?
@@ -147,17 +144,6 @@ extension OptionalChildProperty: Relation {
     public func load(on database: Database) -> EventLoopFuture<Void> {
         self.query(on: database).first().map {
             self.value = $0
-        }
-    }
-}
-
-extension OptionalChildProperty.Key: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .optional(let keyPath):
-            return To.path(for: keyPath.appending(path: \.$id)).description
-        case .required(let keyPath):
-            return To.path(for: keyPath.appending(path: \.$id)).description
         }
     }
 }

--- a/Sources/FluentKit/Properties/OptionalField.swift
+++ b/Sources/FluentKit/Properties/OptionalField.swift
@@ -98,7 +98,9 @@ extension OptionalFieldProperty: AnyDatabaseProperty {
     }
 
     public func input(to input: DatabaseInput) {
-        if let inputValue = self.inputValue {
+        if input.wantsUnmodifiedKeys {
+            input.set(self.inputValue ?? self.outputValue.map { $0.map { .bind($0) } ?? .null } ?? .default, at: self.key)
+        } else if let inputValue = self.inputValue {
             input.set(inputValue, at: self.key)
         }
     }

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -58,8 +58,13 @@ public protocol AnyDatabaseProperty: AnyProperty {
 /// database, and to act as a container if it contains any additional properties
 /// which also wish to participate. Just about every property type is codable.
 ///
-/// - Warning: The various relation property types sometimes behave somewhat oddly
+/// > Warning: The various relation property types sometimes behave somewhat oddly
 ///   when encoded and/or decoded.
+///
+/// > TODO: When corresponding parent and child properties on their respective models
+///   refer to each other, such as due to both relations being eager-loaded, both
+///   encoding and decoding will crash due to infinite recursion. At some point, look
+///   into a way to at least error out rather than crashing.
 public protocol AnyCodableProperty: AnyProperty {
     /// Encode the property's data to an external representation.
     func encode(to encoder: Encoder) throws

--- a/Sources/FluentKit/Properties/Relation.swift
+++ b/Sources/FluentKit/Properties/Relation.swift
@@ -1,3 +1,8 @@
+/// A protocol which designates a conforming type as representing a database relation of any kind. Intended
+/// for use only by FluentKit property wrappers.
+///
+/// - Note: This protocol should probably require conformance to ``Property``, but adding that requirement
+///   wouldn't have enough value to be worth having to hand-wave a technically semver-major change.
 public protocol Relation {
     associatedtype RelatedValue
     var name: String { get }
@@ -6,12 +11,24 @@ public protocol Relation {
 }
 
 extension Relation {
+    /// Return the value of the relation, loading it first if necessary.
+    ///
+    /// If the value is loaded (including reloading), the value is set in the property before being returned.
+    ///
+    /// - Note: This API is strongly preferred over ``Relation/load(on:)``, even when the caller does not need
+    ///   the returned value, in order to minimize unnecessary database traffic.
+    ///
+    /// - Parameters:
+    ///   - reload: If `true`, load the value from the database unconditionally, overwriting any previously
+    ///     loaded value.
+    ///   - database: The database to use if the value needs to be loaded.
+    /// - Returns: The loaded value.
     public func get(reload: Bool = false, on database: Database) -> EventLoopFuture<RelatedValue> {
         if let value = self.value, !reload {
             return database.eventLoop.makeSucceededFuture(value)
         } else {
             return self.load(on: database).flatMapThrowing {
-                guard let value = self.value else {
+                guard let value = self.value else { // This should never actually happen, but just in case...
                     throw FluentError.relationNotLoaded(name: self.name)
                 }
                 return value

--- a/Sources/FluentKit/Properties/Relation.swift
+++ b/Sources/FluentKit/Properties/Relation.swift
@@ -37,3 +37,24 @@ extension Relation {
     }
 }
     
+/// A helper type used by ``ChildrenProperty`` and ``OptionalChildProperty`` to generically track the keypath
+/// of the property of the child model that defines the parent-child relationship.
+///
+/// This type was extracted from its original definitions as a subtype of the property types. A typealias is
+/// provided on the property types to maintain public API compatibility.
+public enum RelationParentKey<From, To>
+    where From: FluentKit.Model, To: FluentKit.Model
+{
+    case required(KeyPath<To, To.Parent<From>>)
+    case optional(KeyPath<To, To.OptionalParent<From>>)
+}
+
+extension RelationParentKey: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .optional(let keypath): return To.path(for: keypath.appending(path: \.$id)).description
+        case .required(let keypath): return To.path(for: keypath.appending(path: \.$id)).description
+        }
+    }
+}
+

--- a/Tests/FluentKitTests/AsyncTests/AsyncFilterQueryTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncFilterQueryTests.swift
@@ -1,12 +1,9 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
-#if !os(Linux)
 import FluentKit
 import FluentBenchmark
 import XCTest
 import Foundation
 import FluentSQL
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncFilterQueryTests: XCTestCase {
     override class func setUp() {
         super.setUp()
@@ -79,5 +76,3 @@ final class AsyncFilterQueryTests: XCTestCase {
         db.reset()
     }
 }
-#endif
-#endif

--- a/Tests/FluentKitTests/AsyncTests/AsyncFluentKitTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncFluentKitTests.swift
@@ -1,5 +1,3 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
-#if !os(Linux)
 import FluentKit
 import FluentBenchmark
 import XCTest
@@ -7,7 +5,6 @@ import Foundation
 import FluentSQL
 import XCTFluent
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncFluentKitTests: XCTestCase {
     override class func setUp() {
         super.setUp()
@@ -371,5 +368,3 @@ final class AsyncFluentKitTests: XCTestCase {
             .paginate(pageRequest2)
     }
 }
-#endif
-#endif

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -291,4 +291,14 @@ final class AsyncQueryBuilderTests: XCTestCase {
             XCTFail("no query")
         }
     }
+
+    func testComplexJoinOperators() async throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        
+        _ = try await Planet.query(on: db)
+            .join(Star.self, on: \Star.$id == \Planet.$star.$id && \Star.$name != \Planet.$name)
+            .all()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name""#)
+    }
 }

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -1,12 +1,9 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
-#if !os(Linux)
 import FluentKit
 import FluentBenchmark
 import XCTest
 import Foundation
 import XCTFluent
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncQueryBuilderTests: XCTestCase {
     override class func setUp() {
         super.setUp()
@@ -295,5 +292,3 @@ final class AsyncQueryBuilderTests: XCTestCase {
         }
     }
 }
-#endif
-#endif

--- a/Tests/FluentKitTests/CompositeIDTests.swift
+++ b/Tests/FluentKitTests/CompositeIDTests.swift
@@ -136,18 +136,185 @@ final class CompositeIDTests: XCTestCase {
         let db = DummyDatabaseForTestSQLSerializer()
         let systemId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
         
-        _ = try CompositeMoon(name: "", planetSolarSystemId: systemId, planetNormalizedOrdinal: 1).$orbitedPlanet.query(on: db).all().wait()
-        _ = try CompositePlanet(solarSystemId: systemId, normalizedOrdinal: 1).$moons.query(on: db).all().wait()
+        _ = try CompositeMoon(name: "", planetSolarSystemId: systemId, planetNormalizedOrdinal: 1).$orbiting.query(on: db).all().wait()
+        _ = try CompositeMoon(name: "", planetSolarSystemId: systemId, planetNormalizedOrdinal: 1, progenitorId: .init(solarSystemId: systemId, normalizedOrdinal: 2)).$progenitor.query(on: db).all().wait()
+        _ = try CompositeMoon(name: "", planetSolarSystemId: systemId, planetNormalizedOrdinal: 1, progenitorId: nil).$progenitor.query(on: db).all().wait()
+        _ = try CompositeMoon(name: "", planetSolarSystemId: systemId, planetNormalizedOrdinal: 1, progenitorId: nil, planetoidId: .init(solarSystemId: systemId, normalizedOrdinal: 3)).$planetoid.query(on: db).all().wait()
+        _ = try CompositeMoon(name: "", planetSolarSystemId: systemId, planetNormalizedOrdinal: 1, progenitorId: nil, planetoidId: nil).$planetoid.query(on: db).all().wait()
+        _ = try CompositePlanet(name: "", solarSystemId: systemId, normalizedOrdinal: 1).$moons.query(on: db).all().wait()
+        _ = try CompositePlanet(name: "", solarSystemId: systemId, normalizedOrdinal: 2).$moonsMade.query(on: db).all().wait()
+        _ = try CompositePlanet(name: "", solarSystemId: systemId, normalizedOrdinal: 3).$fragment.query(on: db).all().wait()
+                
+        let allPlanetFields = #""composite+planet"."system_id" AS "composite+planet_system_id", "composite+planet"."nrm_ord" AS "composite+planet_nrm_ord", "composite+planet"."name" AS "composite+planet_name" FROM "composite+planet""#
+        let allMoonFields = #""composite+moon"."id" AS "composite+moon_id", "composite+moon"."name" AS "composite+moon_name", "composite+moon"."planet_system_id" AS "composite+moon_planet_system_id", "composite+moon"."planet_nrm_ord" AS "composite+moon_planet_nrm_ord", "composite+moon"."progenitorSystem_id" AS "composite+moon_progenitorSystem_id", "composite+moon"."progenitorNrm_ord" AS "composite+moon_progenitorNrm_ord", "composite+moon"."planetoid_system_id" AS "composite+moon_planetoid_system_id", "composite+moon"."planetoid_nrm_ord" AS "composite+moon_planetoid_nrm_ord" FROM "composite+moon""#
         
-        XCTAssertEqual(db.sqlSerializers.count, 2)
+        let expectedQueries: [(String, [Encodable])] = [
+            (#"SELECT \#(allPlanetFields) WHERE ("composite+planet"."system_id" = $1 AND "composite+planet"."nrm_ord" = $2)"#,               [systemId, 1]),
+            (#"SELECT \#(allPlanetFields) WHERE ("composite+planet"."system_id" = $1 AND "composite+planet"."nrm_ord" = $2)"#,               [systemId, 2]),
+            (#"SELECT \#(allPlanetFields) WHERE ("composite+planet"."system_id" IS NULL AND "composite+planet"."nrm_ord" IS NULL)"#,         []),
+            (#"SELECT \#(allPlanetFields) WHERE ("composite+planet"."system_id" = $1 AND "composite+planet"."nrm_ord" = $2)"#,               [systemId, 3]),
+            (#"SELECT \#(allPlanetFields) WHERE ("composite+planet"."system_id" IS NULL AND "composite+planet"."nrm_ord" IS NULL)"#,         []),
+            (#"SELECT \#(allMoonFields) WHERE ("composite+moon"."planet_system_id" = $1 AND "composite+moon"."planet_nrm_ord" = $2)"#,       [systemId, 1]),
+            (#"SELECT \#(allMoonFields) WHERE ("composite+moon"."progenitorSystem_id" = $1 AND "composite+moon"."progenitorNrm_ord" = $2)"#, [systemId, 2]),
+            (#"SELECT \#(allMoonFields) WHERE ("composite+moon"."planetoid_system_id" = $1 AND "composite+moon"."planetoid_nrm_ord" = $2)"#, [systemId, 3]),
+        ]
+        XCTAssertEqual(db.sqlSerializers.count, expectedQueries.count)
+        for ((query, binds), serializer) in zip(expectedQueries, db.sqlSerializers) {
+            XCTAssertEqual(serializer.sql, query)
+            XCTAssertEqual(serializer.binds.count, binds.count)
+            for (lBind, rBind) in zip(binds, serializer.binds) {
+                XCTAssertEqual("\(lBind)", "\(rBind)")
+            }
+        }
+    }
+    
+    func testCompositeParentChildMutating() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        let sysId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!, sys2Id = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        
+        let planet1 = CompositePlanet(name: "A", solarSystemId: sysId, normalizedOrdinal: 1)
+        let moon1 = CompositeMoon(name: "B", planetSolarSystemId: sysId, planetNormalizedOrdinal: 1)
+        let moon2 = CompositeMoon(name: "C", planetSolarSystemId: sysId, planetNormalizedOrdinal: 1, progenitorId: .init(solarSystemId: sysId, normalizedOrdinal: 2))
+        let moon3 = CompositeMoon(name: "D", planetSolarSystemId: sysId, planetNormalizedOrdinal: 1)
+        let moon4 = CompositeMoon(name: "E", planetSolarSystemId: sysId, planetNormalizedOrdinal: 1, planetoidId: .init(solarSystemId: sysId, normalizedOrdinal: 3))
+        
+        try planet1.create(on: db).wait()
+        try [moon1, moon2, moon3, moon4].forEach { try $0.create(on: db).wait() }
+        
+        planet1.name = "AA"
+        try planet1.update(on: db).wait()
+        
+        moon1.$orbiting.id.$solarSystem.id = sys2Id
+        moon1.$orbiting.id.normalizedOrdinal = 2
+        moon2.$progenitor.id = nil
+        moon3.$planetoid.id = .init(solarSystemId: sys2Id, normalizedOrdinal: 3)
+        moon4.$planetoid.id = nil
+        try [moon1, moon2, moon3, moon4].forEach { try $0.update(on: db).wait() }
+        
+        let firstMoonCols = #""planet_system_id", "id""#, fourVals = "$1, $2, $3, $4", sixVals = "\(fourVals), $5, $6"
+        let expectedQueries: [(String, [Encodable])] = [
+            (#"INSERT INTO "composite+planet" ("system_id", "name", "nrm_ord") VALUES ($1, $2, $3)"#,                                                         [sysId, "A", 1]),
+            (#"INSERT INTO "composite+moon" (\#(firstMoonCols), "planet_nrm_ord", "name") VALUES (\#(fourVals))"#,                                            [sysId, moon1.id!, 1, "B"]),
+            (#"INSERT INTO "composite+moon" (\#(firstMoonCols), "progenitorSystem_id", "progenitorNrm_ord", "planet_nrm_ord", "name") VALUES (\#(sixVals))"#, [sysId, moon2.id!, sysId, 2, 1, "C"]),
+            (#"INSERT INTO "composite+moon" (\#(firstMoonCols), "planet_nrm_ord", "name") VALUES (\#(fourVals))"#,                                            [sysId, moon3.id!, 1, "D"]),
+            (#"INSERT INTO "composite+moon" (\#(firstMoonCols), "planetoid_nrm_ord", "planet_nrm_ord", "planetoid_system_id", "name") VALUES (\#(sixVals))"#, [sysId, moon4.id!, 3, 1, sysId, "E"]),
+            (#"UPDATE "composite+planet" SET "name" = $1 WHERE ("composite+planet"."system_id" = $2 AND "composite+planet"."nrm_ord" = $3)"#,                 ["AA", sysId, 1]),
+            (#"UPDATE "composite+moon" SET "planet_nrm_ord" = $1, "planet_system_id" = $2 WHERE "composite+moon"."id" = $3"#,                                 [2, sys2Id, moon1.id!]),
+            (#"UPDATE "composite+moon" SET "progenitorSystem_id" = NULL, "progenitorNrm_ord" = NULL WHERE "composite+moon"."id" = $1"#,                       [moon2.id!]),
+            (#"UPDATE "composite+moon" SET "planetoid_system_id" = $1, "planetoid_nrm_ord" = $2 WHERE "composite+moon"."id" = $3"#,                           [sys2Id, 3, moon3.id!]),
+            (#"UPDATE "composite+moon" SET "planetoid_system_id" = NULL, "planetoid_nrm_ord" = NULL WHERE "composite+moon"."id" = $1"#,                       [moon4.id!]),
+        ]
 
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "composite+planet"."solar_system_id" AS "composite+planet_solar_system_id", "composite+planet"."normalized_ordinal" AS "composite+planet_normalized_ordinal", "composite+planet"."name" AS "composite+planet_name" FROM "composite+planet" WHERE ("composite+planet"."solar_system_id" = $1 AND "composite+planet"."normalized_ordinal" = $2)"#)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).binds.xctAt(0) as? UUID, systemId)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).binds.xctAt(1) as? Int, 1)
+        XCTAssertEqual(db.sqlSerializers.count, expectedQueries.count)
+        for ((query, binds), serializer) in zip(expectedQueries, db.sqlSerializers) {
+            XCTAssertEqual(serializer.sql, query)
+            XCTAssertEqual(serializer.binds.count, binds.count)
+            for (lBind, rBind) in zip(binds, serializer.binds) {
+                XCTAssertEqual("\(lBind)", "\(rBind)")
+            }
+        }
+    }
+    
+    func testCompositeParentChildEncoding() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        func jsonString<E: Encodable>(_ value: E) throws -> String { try String(decoding: encoder.encode(value), as: UTF8.self) }
         
-        XCTAssertEqual(try db.sqlSerializers.xctAt(1).sql, #"SELECT "composite+moon"."id" AS "composite+moon_id", "composite+moon"."name" AS "composite+moon_name", "composite+moon"."planet_solar_system_id" AS "composite+moon_planet_solar_system_id", "composite+moon"."planet_normalized_ordinal" AS "composite+moon_planet_normalized_ordinal" FROM "composite+moon" WHERE ("composite+moon"."planet_solar_system_id" = $1 AND "composite+moon"."planet_normalized_ordinal" = $2)"#)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(1).binds.xctAt(0) as? UUID, systemId)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(1).binds.xctAt(1) as? Int, 1)
+        let sysId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!, moonId = UUID(), moonJId = #""\#(moonId.uuidString)""#
+        let planet = CompositePlanet(name: "A", solarSystemId: sysId, normalizedOrdinal: 1)
+        let moon = CompositeMoon(id: moonId, name: "B", planetSolarSystemId: sysId, planetNormalizedOrdinal: 1)
+        
+        let sysJId = #"{"normalizedOrdinal":1,"solarSystem":{"id":"\#(sysId.uuidString)"}}"#
+        let moonJDat = #"{"id":\#(moonJId),"name":"B","orbiting":{"id":\#(sysJId)},"planetoid":{"id":\#(sysJId)},"progenitor":{"id":\#(sysJId)}}"#
+        
+        // Unloaded children properties
+        XCTAssertEqual(try jsonString(planet), #"{"id":\#(sysJId),"name":"A"}"#)
+        // Unset optional parent properties
+        XCTAssertEqual(try jsonString(moon), #"{"id":\#(moonJId),"name":"B","orbiting":{"id":\#(sysJId)},"planetoid":{"id":null},"progenitor":{"id":null}}"#)
+
+        // OptionalChild loaded as NULL, Children properties loaded empty
+        (planet.$moons.value, planet.$moonsMade.value, planet.$fragment.value) = ([], [], .some(.none))
+        XCTAssertEqual(try jsonString(planet), #"{"fragment":null,"id":\#(sysJId),"moons":[],"moonsMade":[],"name":"A"}"#)
+        
+        // Parent unloaded, OptionalParent set with ID and unset/explicit null value respectively
+        moon.$orbiting.value = nil
+        (moon.$progenitor.id, moon.$progenitor.value) = (planet.id, .none)
+        (moon.$planetoid.id, moon.$planetoid.value) = (planet.id, .some(.none))
+        XCTAssertEqual(try jsonString(moon), moonJDat)
+        
+        // Children properties loaded with value(s)
+        (planet.$moons.value, planet.$moonsMade.value, planet.$fragment.value) = ([moon], [moon], .some(.some(moon)))
+        XCTAssertEqual(try jsonString(planet), #"{"fragment":\#(moonJDat),"id":\#(sysJId),"moons":[\#(moonJDat)],"moonsMade":[\#(moonJDat)],"name":"A"}"#)
+
+        // Parent properties set with IDs and values
+        (moon.$orbiting.value, planet.$moons.value) = (planet, nil)
+        (moon.$progenitor.value, planet.$moonsMade.value) = (.some(.some(planet)), nil)
+        (moon.$planetoid.value, planet.$fragment.value) = (.some(.some(planet)), .none)
+        XCTAssertEqual(try jsonString(moon), #"{"id":\#(moonJId),"name":"B","orbiting":{"id":\#(sysJId),"name":"A"},"planetoid":{"id":\#(sysJId),"name":"A"},"progenitor":{"id":\#(sysJId),"name":"A"}}"#)
+    }
+    
+    func testCompositeParentChildDecoding() throws {
+        let decoder = JSONDecoder()
+        func unjsonString<D: Decodable>(_ json: String, as: D.Type = D.self) throws -> D { try decoder.decode(D.self, from: json.data(using: .utf8)!) }
+        
+        let sysId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!, moonId = UUID(), sysJId = #""\#(sysId.uuidString)""#, moonJId = #""\#(moonId.uuidString)""#
+        
+        let planet1 = try unjsonString(#"{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}},"name":"A"}"#, as: CompositePlanet.self)
+        XCTAssertEqual(planet1.$id.$solarSystem.id, sysId)
+        XCTAssertEqual(planet1.id!.normalizedOrdinal, 1)
+        XCTAssertEqual(planet1.name, "A")
+        XCTAssertNil(planet1.$moons.fromId)
+        XCTAssertNil(planet1.$moons.value)
+        XCTAssertNil(planet1.$moonsMade.fromId)
+        XCTAssertNil(planet1.$moonsMade.value)
+        XCTAssertNil(planet1.$fragment.fromId)
+        XCTAssertNilNil(planet1.$fragment.value)
+        
+        let moon1 = try unjsonString(#"{"id":\#(moonJId),"name":"B","orbiting":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}}},"planetoid":{"id":null},"progenitor":{"id":null}}"#, as: CompositeMoon.self)
+        XCTAssertEqual(moon1.id, moonId)
+        XCTAssertEqual(moon1.name, "B")
+        XCTAssertEqual(moon1.$orbiting.id, planet1.id!)
+        XCTAssertNil(moon1.$orbiting.value)
+        XCTAssertNil(moon1.$progenitor.id)
+        XCTAssertNilNil(moon1.$progenitor.value)
+        XCTAssertNil(moon1.$planetoid.id)
+        XCTAssertNilNil(moon1.$planetoid.value)
+        let moon1_1 = try unjsonString(#"{"id":\#(moonJId),"name":"B","orbiting":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}},"name":"A"},"planetoid":{"id":null},"progenitor":{"id":null}}"#, as: CompositeMoon.self)
+        XCTAssertNil(moon1_1.$orbiting.value)
+
+        let moon2 = try unjsonString(#"{"id":\#(moonJId),"name":"B","orbiting":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}}},"planetoid":{"id":null},"progenitor":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}}}}"#, as: CompositeMoon.self)
+        XCTAssertEqual(moon2.id, moonId)
+        XCTAssertEqual(moon2.name, "B")
+        XCTAssertEqual(moon2.$orbiting.id, planet1.id!)
+        XCTAssertNil(moon2.$orbiting.value)
+        XCTAssertEqual(moon2.$progenitor.id, planet1.id!)
+        XCTAssertNilNil(moon2.$progenitor.value)
+        XCTAssertNil(moon2.$planetoid.id)
+        XCTAssertNilNil(moon2.$planetoid.value)
+        let moon2_1 = try unjsonString(#"{"id":\#(moonJId),"name":"B","orbiting":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}}},"planetoid":{"id":null},"progenitor":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}},"name":"A"}}"#, as: CompositeMoon.self)
+        XCTAssertNilNil(moon2_1.$progenitor.value)
+
+        let moon3 = try unjsonString(#"{"id":\#(moonJId),"name":"B","orbiting":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}}},"planetoid":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}}},"progenitor":{"id":null}}"#, as: CompositeMoon.self)
+        XCTAssertEqual(moon3.id, moonId)
+        XCTAssertEqual(moon3.name, "B")
+        XCTAssertEqual(moon3.$orbiting.id, planet1.id!)
+        XCTAssertNil(moon3.$orbiting.value)
+        XCTAssertNil(moon3.$progenitor.id)
+        XCTAssertNilNil(moon3.$progenitor.value)
+        XCTAssertEqual(moon3.$planetoid.id, planet1.id!)
+        XCTAssertNilNil(moon3.$planetoid.value)
+        let moon3_1 = try unjsonString(#"{"id":\#(moonJId),"name":"B","orbiting":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}}},"planetoid":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}},"name":"A"},"progenitor":{"id":null}}"#, as: CompositeMoon.self)
+        XCTAssertNilNil(moon3_1.$planetoid.value)
+    }
+}
+
+fileprivate func XCTAssertNilNil<V>(_ expression: @autoclosure () throws -> Optional<Optional<V>>, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+    func messageIfGiven() -> String { let m = message(); guard !m.isEmpty else { return m }; return " - \(m)" }
+    switch Result(catching: { try expression() }) {
+    case .success(.none): return
+    case .success(.some(.none)): return XCTFail("XCTAssertNilNil failed: \".some(nil)\"\(messageIfGiven())", file: file, line: line)
+    case .success(.some(.some(let value))): return XCTFail("XCTAssertNilNil failed: \".some(.some(\(value)))\"\(messageIfGiven())", file: file, line: line)
+    case .failure(let error): return XCTFail("XCTAssertNilNil failed: threw error \"\(error)\"\(messageIfGiven())", file: file, line: line)
     }
 }
 
@@ -223,6 +390,7 @@ final class SolarSystem: Model {
     init(id: IDValue? = nil, name: String) {
         if let id = id { self.id = id }
         self.name = name
+        self.$planets.fromId = self.id
     }
 }
 
@@ -231,8 +399,8 @@ final class CompositePlanet: Model {
     
     // Note for the curious: "normalized ordinal" means "how many orbits from the center if a unique value was chosen for every planet despite overlapping or shared orbits"
     final class IDValue: Fields, Hashable {
-        @Parent(key: "solar_system_id") var solarSystem: SolarSystem
-        @Field(key: "normalized_ordinal") var normalizedOrdinal: Int
+        @Parent(key: "system_id") var solarSystem: SolarSystem
+        @Field(key: "nrm_ord") var normalizedOrdinal: Int
         
         init() {}
         init(solarSystemId: SolarSystem.IDValue, normalizedOrdinal: Int) {
@@ -244,12 +412,17 @@ final class CompositePlanet: Model {
     
     @CompositeID var id: IDValue?
     @Field(key: "name") var name: String
-    @CompositeChildren(for: \.$orbitedPlanet) var moons: [CompositeMoon]
+    @CompositeChildren(for: \.$orbiting) var moons: [CompositeMoon]
+    @CompositeChildren(for: \.$progenitor) var moonsMade: [CompositeMoon]
+    @CompositeOptionalChild(for: \.$planetoid) var fragment: CompositeMoon?
     
     init() {}
-    init(solarSystemId: SolarSystem.IDValue, normalizedOrdinal: Int) {
+    init(name: String, solarSystemId: SolarSystem.IDValue, normalizedOrdinal: Int) {
         self.id = .init(solarSystemId: solarSystemId, normalizedOrdinal: normalizedOrdinal)
+        self.name = name
         self.$moons.fromId = self.id
+        self.$moonsMade.fromId = self.id
+        self.$fragment.fromId = self.id
     }
 }
 
@@ -258,12 +431,16 @@ final class CompositeMoon: Model {
     
     @ID(key: .id) var id: UUID?
     @Field(key: "name") var name: String
-    @CompositeParent(prefix: "planet") var orbitedPlanet: CompositePlanet
+    @CompositeParent(prefix: "planet") var orbiting: CompositePlanet
+    @CompositeOptionalParent(prefix: "progenitor", strategy: .camelCase) var progenitor: CompositePlanet?
+    @CompositeOptionalParent(prefix: "planetoid") var planetoid: CompositePlanet?
     
     init() {}
-    init(id: UUID? = nil, name: String, planetSolarSystemId: SolarSystem.IDValue, planetNormalizedOrdinal: Int) {
+    init(id: UUID? = nil, name: String, planetSolarSystemId: SolarSystem.IDValue, planetNormalizedOrdinal: Int, progenitorId: CompositePlanet.IDValue? = nil, planetoidId: CompositePlanet.IDValue? = nil) {
         if let id = id { self.id = id }
         self.name = name
-        self.$orbitedPlanet.id = .init(solarSystemId: planetSolarSystemId, normalizedOrdinal: planetNormalizedOrdinal)
+        self.$orbiting.id = .init(solarSystemId: planetSolarSystemId, normalizedOrdinal: planetNormalizedOrdinal)
+        if let progenitorId = progenitorId { self.$progenitor.id = progenitorId }
+        if let planetoidId = planetoidId { self.$planetoid.id = planetoidId }
     }
 }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -641,13 +641,11 @@ final class FluentKitTests: XCTestCase {
         let encoded = try encoder.encode(groupFoo)
         XCTAssertEqual(String(decoding: encoded, as: UTF8.self), #"{"group":{"string":"hi"},"id":"\#(groupFoo.id!.uuidString)"}"#)
         
-        // TODO: This currently causes a fatal error when the Codable conformance tries to encode the unset group members.
-        /*
         let missingGroupFoo = GroupFoo()
         missingGroupFoo.id = UUID()
+        missingGroupFoo.$group.value = nil
         let missingEncoded = try encoder.encode(missingGroupFoo)
-        XCTAssertEqual(String(decoding: missingEncoded, as: UTF8.self), #"{"id":"\#(groupFoo.id!.uuidString)"}"#)
-        */
+        XCTAssertEqual(String(decoding: missingEncoded, as: UTF8.self), #"{"id":"\#(missingGroupFoo.id!.uuidString)"}"#)
         
         let decoded = try decoder.decode(GroupFoo.self, from: encoded)
         XCTAssertEqual(decoded.id?.uuidString, groupFoo.id?.uuidString)

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -744,8 +744,9 @@ final class FluentKitTests: XCTestCase {
     
     func testFieldsPropertiesPerformance() throws {
         measure {
+            let model = LotsOfFields()
             for _ in 1 ... 10_000 {
-                XCTAssertEqual(LotsOfFields().properties.count, 21)
+                XCTAssertEqual(model.properties.count, 21)
             }
         }
     }

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -193,4 +193,14 @@ final class QueryBuilderTests: XCTestCase {
         XCTAssertEqual(db.sqlSerializers.count, 1)
         XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#)
     }
+    
+    func testComplexJoinOperators() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        
+        _ = try Planet.query(on: db)
+            .join(Star.self, on: \Star.$id == \Planet.$star.$id && \Star.$name != \Planet.$name)
+            .all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name""#)
+    }
 }

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -192,7 +192,5 @@ final class QueryBuilderTests: XCTestCase {
             .all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
         XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#)
-        print(db.sqlSerializers.first!.sql)
-        db.reset()
     }
 }


### PR DESCRIPTION
This update includes the following:

- `Model.joined(_:)` now works correctly with both aliased models and models with spaces.
- Lots more documentation comments in various places.
- `DatabaseInput` got a new flag to allow explicitly requesting that all properties - not just modified ones - be included. See the inline documentation for more details. All built-in FluentKit property types appropriately respect this flag.
- Fix completely incorrect implementation of `KeyPrefixingStrategy`'s `.camelCase` strategy, including adding unit tests.
- Removed outdated checks for Swift version and OS minimums in Concurrency support since we require those minimums already.
- `@Group` properties with unset values no longer crash when encoded.
- `@CompositeID` properties can now be encoded/decoded even when explicitly given `nil` value.
- Implemented `@CompositeOptionalParent`, `@CompositeChildren`, and `@CompositeOptionalChild` properties to go with `@CompositeParent`, all of which allow fully describing relations even when the parent side of the relationship has a composite ID.
- The minimum Swift version requirement has been bumped from 5.5 to 5.5.2. The recommended minimum version is 5.6.