### PR TITLE
add filter to eager-loading.

### DIFF
--- a/Sources/FluentKit/Model/EagerLoad.swift
+++ b/Sources/FluentKit/Model/EagerLoad.swift
@@ -21,6 +21,12 @@ public protocol EagerLoadable {
         _ relationKey: KeyPath<From, Self>,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From
+    
+    static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, Self>,
+        filter: QueryBuilderFilterBlock<To>?,
+        to builder: Builder
+    ) where Builder: EagerLoadBuilder, Builder.Model == From
 
     static func eagerLoad<Loader, Builder>(
         _ loader: Loader,
@@ -30,4 +36,17 @@ public protocol EagerLoadable {
         Builder: EagerLoadBuilder,
         Loader.Model == To,
         Builder.Model == From
+    
+}
+
+extension EagerLoadable {
+    
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, Self>,
+        filter: QueryBuilderFilterBlock<To>?,
+        to builder: Builder
+    ) where Builder: EagerLoadBuilder, Builder.Model == From {
+       eagerLoad(relationKey, to: builder)
+    }
+    
 }

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -134,6 +134,17 @@ extension OptionalParentProperty: EagerLoadable {
         let loader = OptionalParentEagerLoader(relationKey: relationKey)
         builder.add(loader: loader)
     }
+    
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, From.OptionalParent<To>>,
+        filter: QueryBuilderFilterBlock<To>?,
+        to builder: Builder
+    )
+        where Builder: EagerLoadBuilder, Builder.Model == From
+    {
+        let loader = OptionalParentEagerLoader(relationKey: relationKey, filter: filter)
+        builder.add(loader: loader)
+    }
 
     public static func eagerLoad<Loader, Builder>(
         _ loader: Loader,
@@ -154,12 +165,15 @@ private struct OptionalParentEagerLoader<From, To>: EagerLoader
     where From: FluentKit.Model, To: FluentKit.Model
 {
     let relationKey: KeyPath<From, OptionalParentProperty<From, To>>
+    var filter: QueryBuilderFilterBlock<To>?
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         var sets = Dictionary(grouping: models, by: { $0[keyPath: self.relationKey].id })
         let nilParentModels = sets.removeValue(forKey: nil) ?? []
 
-        return To.query(on: database).filter(\._$id ~~ Set(sets.keys.compactMap { $0 })).all().flatMapThrowing {
+        let query = To.query(on: database).filter(\._$id ~~ Set(sets.keys.compactMap { $0 }))
+        filter?(query)
+        return query.all().flatMapThrowing {
             let parents = Dictionary(uniqueKeysWithValues: $0.map { ($0.id!, $0) })
 
             for (parentId, models) in sets {

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
@@ -12,26 +12,36 @@ public protocol EagerLoadBuilder {
         where Loader: EagerLoader, Loader.Model == Model
 }
 
+public typealias QueryBuilderFilterBlock<T: Model> = (QueryBuilder<T>) -> Void
 
 extension EagerLoadBuilder {
     // MARK: Eager Load
 
+//    @discardableResult
+//    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>) -> Self
+//        where Relation: EagerLoadable, Relation.From == Model
+//    {
+//        Relation.eagerLoad(relationKey, to: self)
+//        return self
+//    }
+    
     @discardableResult
-    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>) -> Self
-        where Relation: EagerLoadable, Relation.From == Model
+    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>, filter: QueryBuilderFilterBlock<Relation.To>? = nil) -> Self
+    where Relation: EagerLoadable, Relation.From == Model
     {
-        Relation.eagerLoad(relationKey, to: self)
+        Relation.eagerLoad(relationKey, filter: filter, to: self)
         return self
     }
 
     @discardableResult
     public func with<Relation>(
         _ throughKey: KeyPath<Model, Relation>,
+        filter: QueryBuilderFilterBlock<Relation.To>? = nil,
         _ nested: (NestedEagerLoadBuilder<Self, Relation>) -> ()
     ) -> Self
         where Relation: EagerLoadable, Relation.From == Model
     {
-        Relation.eagerLoad(throughKey, to: self)
+        Relation.eagerLoad(throughKey, filter: filter, to: self)
         let builder = NestedEagerLoadBuilder<Self, Relation>(builder: self, throughKey)
         nested(builder)
         return self


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Add a filter param to `with` method of QueryBuilder+EeagerLoad to filter the eager-load result.
for example:
``` swift
    //sort person by name and nest eager load person‘s cats.
    // the tail closure is the nest eager load.
    let catesWithFilter = try Category.query(on: app.db).with(\.$persons, filter: {qb in
        _ = qb.sort(\.$name, .descending)
    }) { (qb) in
            qb.with(\.$cats)
        }.all()
        .wait()
```
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
