### PR TITLE
Remove limitations on nested relations in CompositeIDs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,6 @@ jobs:
           - { dependent: 'fluent-mysql-driver', ref: 'main' }
           - { dependent: 'fluent-mongo-driver', ref: 'main' }
     steps:
-      - name: Install SQLite dependency
-        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
-        if: ${{ contains(matrix.dependent, 'sqlite') }}
       - name: Check out package
         uses: actions/checkout@v3
         with:

--- a/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
+++ b/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
@@ -118,10 +118,10 @@ extension FluentBenchmarker {
     
     private func testCompositeParent_nestedInCompositeID() throws {
         try self.runTest(#function, [
-            CompositeParentTheFirst.ModelMigration(),
-            CompositeParentTheSecond.ModelMigration(),
             GalaxyMigration(),
             GalaxySeed(),
+            CompositeParentTheFirst.ModelMigration(),
+            CompositeParentTheSecond.ModelMigration(),
         ]) {
             let anyGalaxy = try XCTUnwrap(Galaxy.query(on: self.database).first().wait())
             

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -27,10 +27,6 @@ public final class ChildrenProperty<From, To>
     }
     
     private init(for parentKey: Key) {
-        guard !(From.IDValue.self is Fields.Type) /*From().anyId is AnyQueryAddressableProperty*/ else {
-            fatalError("Can not use @Children with a model whose ID is not addressable (this probably means '\(From.self)' uses `@CompositeID`).")
-        }
-
         self.parentKey = parentKey
     }
 

--- a/Sources/FluentKit/Properties/CompositeID.swift
+++ b/Sources/FluentKit/Properties/CompositeID.swift
@@ -21,13 +21,6 @@ public final class CompositeIDProperty<Model, Value>
     }
 
     public init() {
-        guard Value.init().properties.allSatisfy({ $0 is AnyQueryAddressableProperty }) else {
-            fatalError("""
-                All elements of a composite model ID must represent exactly one actual column in the database.
-                
-                This error is most often caused by trying to use @Children, @Siblings, or @Group inside a @CompositeID.
-                """)
-        }
         self.value = .init()
         self.exists = false
         self.cachedOutput = nil

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -27,10 +27,6 @@ public final class OptionalChildProperty<From, To>
     }
     
     private init(for parentKey: Key) {
-        guard !(From.IDValue.self is Fields.Type) /*From().anyId is AnyQueryAddressableProperty*/ else {
-            fatalError("Can not use @OptionalChild with a model whose ID is not addressable (this probably means '\(From.self)' uses `@CompositeID`).")
-        }
-
         self.parentKey = parentKey
     }
 

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -30,8 +30,8 @@ public final class OptionalParentProperty<From, To>
     public var value: To??
 
     public init(key: FieldKey) {
-        guard !(To.IDValue.self is Fields.Type) /*To().anyId is AnyQueryAddressableProperty*/ else {
-            fatalError("Can not use @OptionalParent to target a model whose ID is not addressable (this probably means '\(To.self)' uses `@CompositeID`).")
+        guard !(To.IDValue.self is Fields.Type) else {
+            fatalError("Can not use @OptionalParent to target a model with composite ID; use @CompositeOptionalParent instead.")
         }
 
         self._id = .init(key: key)

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -31,8 +31,8 @@ public final class ParentProperty<From, To>
     public var value: To?
 
     public init(key: FieldKey) {
-        guard !(To.IDValue.self is Fields.Type) /*To().anyId is AnyQueryAddressableProperty*/ else {
-            fatalError("Can not use @Parent to target a model whose ID is not addressable (this probably means '\(To.self)' uses `@CompositeID`).")
+        guard !(To.IDValue.self is Fields.Type) else {
+            fatalError("Can not use @Parent to target a model with composite ID; use @CompositeParent instead.")
         }
         
         self._id = .init(key: key)

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -41,10 +41,8 @@ public final class SiblingsProperty<From, To, Through>
         from: KeyPath<Through, Through.Parent<From>>,
         to: KeyPath<Through, Through.Parent<To>>
     ) {
-        guard !(From.IDValue.self is Fields.Type) /*From().anyId is AnyQueryAddressableProperty*/,
-              !(To.IDValue.self is Fields.Type) /*To().anyId is AnyQueryAddressableProperty*/
-        else {
-            fatalError("Can not use @Siblings with models whose IDs are not addressable (this probably means '\(From.self)' and/or '\(To.self)' uses `@CompositeID`).")
+        guard !(From.IDValue.self is Fields.Type), !(To.IDValue.self is Fields.Type) else {
+            fatalError("Can not use @Siblings with models which have composite IDs.")
         }
 
         self.from = from


### PR DESCRIPTION
This update enables embedding `@Composite[Optional]Parent` properties in a `@CompositeID`, as well as:

- Removes some more `fatalError()`s and uses of force-unwrapping from Fluent
- Improves suggestions in fatal errors from Parent/OptionalParent/Siblings
- More reliable behavior of `QueryBuilder.count()` when the queried model has a composite ID
- Minor performance improvements in `Collection<Model>.delete(force:on:)`