### PR TITLE
Enforce correct @ID(key:) usage at compile time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request: { branches: ['*'] }
   push: { branches: ['main'] }
@@ -66,11 +69,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dependent:
-          - fluent-sqlite-driver
-          - fluent-postgres-driver
-          - fluent-mysql-driver
-          - fluent-mongo-driver
         include:
           - { dependent: 'fluent-sqlite-driver', ref: 'main' }
           - { dependent: 'fluent-postgres-driver', ref: 'main' }
@@ -97,5 +95,5 @@ jobs:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
     with:
       with_coverage: true
-      with_tsan: false
+      with_tsan: true
       coverage_ignores: '/Tests/|/Sources/FluentBenchmark/'

--- a/Sources/FluentBenchmark/Tests/ArrayTests.swift
+++ b/Sources/FluentBenchmark/Tests/ArrayTests.swift
@@ -147,7 +147,7 @@ private struct UserMigration: Migration {
 private final class FooSet: Model {
     static let schema = "foos"
 
-    @ID(key: "id")
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "bar")

--- a/Sources/FluentBenchmark/Tests/JoinTests.swift
+++ b/Sources/FluentBenchmark/Tests/JoinTests.swift
@@ -159,7 +159,7 @@ extension FluentBenchmarker {
         final class ChatParticipant: Model {
             static let schema = "chat_participants"
 
-            @ID(key: "id")
+            @ID(key: .id)
             var id: UUID?
 
             @Parent(key: "user_id")
@@ -169,7 +169,7 @@ extension FluentBenchmarker {
         final class User: Model {
             static let schema = "users"
 
-            @ID(key: "id")
+            @ID(key: .id)
             var id: UUID?
         }
 

--- a/Sources/FluentBenchmark/Tests/PerformanceTests+Siblings.swift
+++ b/Sources/FluentBenchmark/Tests/PerformanceTests+Siblings.swift
@@ -137,7 +137,7 @@ private struct PersonMigration: Migration {
 private final class Expedition: Model {
     static let schema = "expeditions"
 
-    @ID(key: "id")
+    @ID(key: .id)
     var id: UUID?
 
     @Field(key: "name")
@@ -191,7 +191,7 @@ private struct ExpeditionMigration: Migration {
 private final class ExpeditionOfficer: Model {
     static let schema = "expedition+officer"
 
-    @ID(key: "id")
+    @ID(key: .id)
     var id: UUID?
 
     @Parent(key: "expedition_id")
@@ -220,7 +220,7 @@ private struct ExpeditionOfficerMigration: Migration {
 private final class ExpeditionScientist: Model {
     static let schema = "expedition+scientist"
 
-    @ID(key: "id")
+    @ID(key: .id)
     var id: UUID?
 
     @Parent(key: "expedition_id")
@@ -250,7 +250,7 @@ private struct ExpeditionScientistMigration: Migration {
 private final class ExpeditionDoctor: Model {
     static let schema = "expedition+doctor"
 
-    @ID(key: "id")
+    @ID(key: .id)
     var id: UUID?
 
     @Parent(key: "expedition_id")

--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -89,7 +89,7 @@ internal struct _FastChildIterator: IteratorProtocol {
         }
         if var label = child.label {
             let nameC = label.withUTF8 {
-                let buf = UnsafeMutableBufferPointer<CChar>.allocate(capacity: $0.count)
+                let buf = UnsafeMutableBufferPointer<CChar>.allocate(capacity: $0.count + 1)
                 buf.initialize(repeating: 0)
                 _ = $0.withMemoryRebound(to: CChar.self) { buf.update(fromContentsOf: $0) }
                 return buf.baseAddress!

--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -1,10 +1,4 @@
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-import Darwin.C
-#elseif os(Linux) || os(FreeBSD) || os(Android)
-import Glibc
-#endif
-
-#if compiler(<5.8) && compiler(>=5.2)
+#if compiler(<5.9)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
@@ -30,7 +24,7 @@ internal struct _FastChildIterator: IteratorProtocol {
         deinit { self.freeFunc(self.ptr) }
     }
     
-#if compiler(<5.8) && compiler(>=5.2)
+#if compiler(<5.9)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -40,7 +34,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 #endif
     private var lastNameBox: _CStringBox?
     
-#if compiler(<5.8) && compiler(>=5.2)
+#if compiler(<5.9)
     fileprivate init(subject: AnyObject, type: Any.Type, childCount: Int) {
         self.subject = subject
         self.type = type
@@ -54,7 +48,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 #endif
     
     init(subject: AnyObject) {
-#if compiler(<5.8) && compiler(>=5.2)
+#if compiler(<5.9)
         let type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.init(
             subject: subject,
@@ -75,7 +69,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     /// - Note: Ironically, in the fallback case that uses `Mirror` directly, preserving this semantic actually imposes
     ///   an _additional_ performance penalty.
     mutating func next() -> (name: UnsafePointer<CChar>?, child: Any)? {
-#if compiler(<5.8) && compiler(>=5.2)
+#if compiler(<5.9)
         guard self.index < self.childCount else {
             self.lastNameBox = nil // ensure any lingering name gets freed
             return nil
@@ -94,9 +88,13 @@ internal struct _FastChildIterator: IteratorProtocol {
             return nil
         }
         if var label = child.label {
-            let nameC = calloc(label.utf8.count + 1, MemoryLayout<CChar>.size).bindMemory(to: CChar.self, capacity: label.utf8.count + 1)
-            label.withUTF8 { _ = memcpy(nameC, $0.baseAddress!, $0.count) }
-            self.lastNameBox = _CStringBox(ptr: UnsafePointer(nameC), freeFunc: { free($0.map { UnsafeMutableRawPointer(mutating: $0) }) })
+            let nameC = label.withUTF8 {
+                let buf = UnsafeMutableBufferPointer<CChar>.allocate(capacity: $0.count)
+                buf.initialize(repeating: 0)
+                _ = $0.withMemoryRebound(to: CChar.self) { buf.update(fromContentsOf: $0) }
+                return buf.baseAddress!
+            }
+            self.lastNameBox = _CStringBox(ptr: UnsafePointer(nameC), freeFunc: { $0?.deallocate() })
             return (name: UnsafePointer(nameC), child: child.value)
         } else {
             self.lastNameBox = nil
@@ -107,7 +105,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 }
 
 internal struct _FastChildSequence: Sequence {
-#if compiler(<5.8) && compiler(>=5.2)
+#if compiler(<5.9)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -116,7 +114,7 @@ internal struct _FastChildSequence: Sequence {
 #endif
 
     init(subject: AnyObject) {
-#if compiler(<5.8) && compiler(>=5.2)
+#if compiler(<5.9)
         self.subject = subject
         self.type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.childCount = _getChildCount(subject, type: self.type)
@@ -126,7 +124,7 @@ internal struct _FastChildSequence: Sequence {
     }
     
     func makeIterator() -> _FastChildIterator {
-#if compiler(<5.8) && compiler(>=5.2)
+#if compiler(<5.9)
         return _FastChildIterator(subject: self.subject, type: self.type, childCount: self.childCount)
 #else
         return _FastChildIterator(iterator: self.children.makeIterator())

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -60,27 +60,32 @@ public final class IDProperty<Model, Value>
 
     /// Initializes an `ID` property with the key `.id` and type `UUID`.
     ///
-    /// If the property's type is not `UUID` or the key is not `.id`, the initializer will
-    /// fatal error. This allows Fluent to natively support databases like MongoDB.
-    ///
     /// Use the `.init(custom:generatedBy:)` initializer to specify a custom ID key or type.
-    public convenience init(key: FieldKey = .id) {
-        guard Value.self is UUID.Type else {
-            // Ensure the default @ID type is using UUID which
-            // is the only identifier type supported by all drivers.
-            fatalError("@ID requires UUID, use @ID(custom:) for \(Value.self).")
-        }
-        guard key == .id else {
-            // Ensure the default @ID is using the special .id key
-            // which is the only identifier key supported by all drivers.
-            //
-            // Additional identifying fields can be added using @Field
-            // with a unique constraint.
-            fatalError("@ID requires .id key, use @ID(custom:) for key '\(key)'.")
-        }
+    public convenience init() where Value == UUID {
         self.init(custom: .id, generatedBy: .random)
     }
+    
+    /// Helper type for compatibility initializer syntax. Do not use this type directly.
+    public enum _DefaultIDFieldKey: ExpressibleByStringLiteral {
+        case id
+        
+        @available(*, deprecated, message: "The `@ID(key: \"id\")` syntax is deprecated. Use `@ID` or `@ID()` instead.")
+        public init(stringLiteral value: String) {
+            guard value == "id" else {
+                fatalError("@ID() may not specify a key; use @ID(custom:) for '\(value)'.")
+            }
+            self = .id
+        }
+    }
+    
+    /// Compatibility syntax for initializing an `ID` property.
+    ///
+    /// This syntax is no longer recommended; use `@ID` instead.
+    public convenience init(key _: _DefaultIDFieldKey) where Value == UUID {
+        self.init()
+    }
 
+    /// Create an `ID` property with a specific key, value type, and optional value generator.
     public init(custom key: FieldKey, generatedBy generator: Generator? = nil) {
         self.field = .init(key: key)
         self.generator = generator ?? .default(for: Value.self)
@@ -93,7 +98,7 @@ public final class IDProperty<Model, Value>
         switch self.inputValue {
         case .none, .null:
             break
-        case .bind(let value) where value.isNil:
+        case .bind(let value) where (value as? AnyOptionalType).map({ $0.wrappedValue == nil }) ?? false:
             break
         default:
             return
@@ -193,15 +198,4 @@ protocol AnyID: AnyObject {
     func generate()
     var exists: Bool { get set }
     var cachedOutput: DatabaseOutput? { get set }
-}
-
-
-private extension Encodable {
-    var isNil: Bool {
-        if let optional = self as? AnyOptionalType {
-            return optional.wrappedValue == nil
-        } else {
-            return false
-        }
-    }
 }


### PR DESCRIPTION
Using `@ID(key:)` with a key other than `.id` or a value that is not a `UUID` is now a compile-time error instead of a runtime crash.

Additional changes:

- The legacy `@ID(key: "id")` syntax, where the key is specified as a string rather than using the `.id` enumeration case, is hard-deprecated. Replace such usages with `@ID(key: .id)`. This deprecation does _not_ apply to custom IDs.
- The `@ID(key: .id)` syntax is now considered soft-deprecated. `@ID` is now the recommend usage.
- Minor CI improvements

## ⚠️ **IMPORTANT** ⚠️

1. Incorrect usage of `@ID(key: "...")` with any string other than `"id"` will still trigger a fatal error at runtime as well as the deprecation warning. This is unavoidable without a source-breaking change, since the contents of the string can not be checked at compile time.
2. Incorrect usage of `@ID` where the type of the property is not `UUID` - for example, `@ID var id: Int?` - usually results in the extremely unhelpful compiler error "`Type of expression is ambiguous without more context.`" Unfortunately, there doesn't seem to be a way to make this less opaque at the moment.