### PR TITLE
Allow eager-loading of deleted models

### DIFF
--- a/Sources/FluentBenchmark/SolarSystem/Planet.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Planet.swift
@@ -26,6 +26,9 @@ public final class Planet: Model {
 
     @Siblings(through: PlanetTag.self, from: \.$planet, to: \.$tag)
     public var tags: [Tag]
+    
+    @Timestamp(key: "deleted_at", on: .delete)
+    var deletedAt: Date?
 
     public init() { }
 
@@ -48,6 +51,7 @@ public struct PlanetMigration: Migration {
             .field("name", .string, .required)
             .field("star_id", .uuid, .required, .references("stars", "id"))
             .field("possible_star_id", .uuid, .references("stars", "id"))
+            .field("deleted_at", .datetime)
             .create()
     }
 
@@ -88,6 +92,6 @@ public struct PlanetSeed: Migration {
     }
 
     public func revert(on database: Database) -> EventLoopFuture<Void> {
-        Planet.query(on: database).delete()
+        Planet.query(on: database).delete(force: true)
     }
 }

--- a/Sources/FluentBenchmark/SolarSystem/Star.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Star.swift
@@ -17,6 +17,9 @@ public final class Star: Model {
 
     @Children(for: \.$star)
     public var planets: [Planet]
+    
+    @Timestamp(key: "deleted_at", on: .delete)
+    var deletedAt: Date?
 
     public init() { }
 
@@ -32,6 +35,7 @@ public struct StarMigration: Migration {
             .field("id", .uuid, .identifier(auto: false))
             .field("name", .string, .required)
             .field("galaxy_id", .uuid, .required, .references("galaxies", "id"))
+            .field("deleted_at", .datetime)
             .create()
     }
 
@@ -61,6 +65,6 @@ public final class StarSeed: Migration {
     }
 
     public func revert(on database: Database) -> EventLoopFuture<Void> {
-        Star.query(on: database).delete()
+        Star.query(on: database).delete(force: true)
     }
 }

--- a/Sources/FluentBenchmark/Tests/EagerLoadTests.swift
+++ b/Sources/FluentBenchmark/Tests/EagerLoadTests.swift
@@ -170,14 +170,14 @@ extension FluentBenchmarker {
                 .with(\.$planets, withDeleted: true)
                 .first().wait()
             )
-            XCTAssertEqual(Set(tag.planets.map(\.name)), ["Earth"])
+            XCTAssertEqual(Set(tag1.planets.map(\.name)), ["Earth"])
             
             let tag2 = try XCTUnwrap(Tag.query(on: self.database)
                 .filter(\.$name == "Inhabited")
                 .with(\.$planets)
                 .first().wait()
             )
-            XCTAssertEqual(Set(tag.planets.map(\.name)), [])
+            XCTAssertEqual(Set(tag2.planets.map(\.name)), [])
         }
     }
 

--- a/Sources/FluentBenchmark/Tests/OptionalParentTests.swift
+++ b/Sources/FluentBenchmark/Tests/OptionalParentTests.swift
@@ -76,8 +76,15 @@ extension FluentBenchmarker {
             
             XCTAssertThrowsError(try User.query(on: self.database)
                 .with(\.$bestFriend)
-                .all().wait())
-
+                .all().wait()
+            ) {
+                guard case let .missingParent(from, to, key, _) = error as? FluentError else {
+                    return XCTFail("Unexpected error \(error) thrown")
+                }
+                XCTAssertEqual(from, "User")
+                XCTAssertEqual(to, "User")
+                XCTAssertEqual(key, "bf_id")
+            }
         }
     }
 }

--- a/Sources/FluentBenchmark/Tests/OptionalParentTests.swift
+++ b/Sources/FluentBenchmark/Tests/OptionalParentTests.swift
@@ -77,7 +77,7 @@ extension FluentBenchmarker {
             XCTAssertThrowsError(try User.query(on: self.database)
                 .with(\.$bestFriend)
                 .all().wait()
-            ) {
+            ) { error in
                 guard case let .missingParent(from, to, key, _) = error as? FluentError else {
                     return XCTFail("Unexpected error \(error) thrown")
                 }

--- a/Sources/FluentBenchmark/Tests/SchemaTests.swift
+++ b/Sources/FluentBenchmark/Tests/SchemaTests.swift
@@ -78,7 +78,7 @@ extension FluentBenchmarker {
             XCTAssertThrowsError(
                 try Star.query(on: self.database)
                     .filter(\.$name == "Sun")
-                    .delete().wait()
+                    .delete(force: true).wait()
             )
         }
     }

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -221,6 +221,8 @@ extension FluentBenchmarker {
                 XCTAssertEqual(key, "bar")
                 XCTAssertEqual(id, "\(bar1.id!)")
             }
+            
+            XCTAssertNoThrow(try Foo.query(on: self.database).with(\.$bar, withDeleted: true).all().wait())
         }
     }
 }

--- a/Sources/FluentKit/Model/EagerLoad.swift
+++ b/Sources/FluentKit/Model/EagerLoad.swift
@@ -26,7 +26,7 @@ public protocol EagerLoadable {
     
     static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, Self>,
-        withDeleted : Bool,
+        withDeleted: Bool,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From
 
@@ -51,7 +51,7 @@ extension EagerLoadable {
     // Default non functional implementation for non breaking API change
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, Self>,
-        withDeleted : Bool,
+        withDeleted: Bool,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From {
         return Self.eagerLoad(relationKey, to: builder)

--- a/Sources/FluentKit/Model/EagerLoad.swift
+++ b/Sources/FluentKit/Model/EagerLoad.swift
@@ -23,6 +23,12 @@ public protocol EagerLoadable {
         _ relationKey: KeyPath<From, Self>,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From
+    
+    static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, Self>,
+        withDeleted : Bool,
+        to builder: Builder
+    ) where Builder: EagerLoadBuilder, Builder.Model == From
 
     static func eagerLoad<Loader, Builder>(
         _ loader: Loader,
@@ -34,20 +40,20 @@ public protocol EagerLoadable {
         Builder.Model == From
 }
 
-// Protocol used to prevent breaking change to public API for conforming types
-public protocol EagerLoadableWithDeleted : EagerLoadable {
-    static func eagerLoad<Builder>(
-        _ relationKey: KeyPath<From, Self>,
-        withDeleted : Bool,
-        to builder: Builder
-    ) where Builder: EagerLoadBuilder, Builder.Model == From
-}
-
-extension EagerLoadableWithDeleted {
+extension EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, Self>,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From {
-        Self.eagerLoad(relationKey, withDeleted: false, to: builder)
+        return Self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
+    // Default non functional implementation for non breaking API change
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, Self>,
+        withDeleted : Bool,
+        to builder: Builder
+    ) where Builder: EagerLoadBuilder, Builder.Model == From {
+        return Self.eagerLoad(relationKey, to: builder)
     }
 }

--- a/Sources/FluentKit/Model/EagerLoad.swift
+++ b/Sources/FluentKit/Model/EagerLoad.swift
@@ -21,6 +21,7 @@ public protocol EagerLoadable {
 
     static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, Self>,
+        withDeleted : Bool,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From
 

--- a/Sources/FluentKit/Model/EagerLoad.swift
+++ b/Sources/FluentKit/Model/EagerLoad.swift
@@ -43,14 +43,6 @@ public protocol EagerLoadable {
 extension EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, Self>,
-        to builder: Builder
-    ) where Builder: EagerLoadBuilder, Builder.Model == From {
-        return Self.eagerLoad(relationKey, withDeleted: false, to: builder)
-    }
-    
-    // Default non functional implementation for non breaking API change
-    public static func eagerLoad<Builder>(
-        _ relationKey: KeyPath<From, Self>,
         withDeleted: Bool,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From {

--- a/Sources/FluentKit/Model/EagerLoad.swift
+++ b/Sources/FluentKit/Model/EagerLoad.swift
@@ -21,7 +21,6 @@ public protocol EagerLoadable {
 
     static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, Self>,
-        withDeleted : Bool,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From
 
@@ -33,4 +32,22 @@ public protocol EagerLoadable {
         Builder: EagerLoadBuilder,
         Loader.Model == To,
         Builder.Model == From
+}
+
+// Protocol used to prevent breaking change to public API for conforming types
+public protocol EagerLoadableWithDeleted : EagerLoadable {
+    static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, Self>,
+        withDeleted : Bool,
+        to builder: Builder
+    ) where Builder: EagerLoadBuilder, Builder.Model == From
+}
+
+extension EagerLoadableWithDeleted {
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, Self>,
+        to builder: Builder
+    ) where Builder: EagerLoadBuilder, Builder.Model == From {
+        Self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
 }

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -166,7 +166,7 @@ extension ChildrenProperty: Relation {
 extension ChildrenProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Children<To>>,
-        withDeleted : Bool,
+        withDeleted: Bool,
         to builder: Builder
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
@@ -208,7 +208,7 @@ private struct ChildrenEagerLoader<From, To>: EagerLoader
         case .required(let required):
             builder.filter(required.appending(path: \.$id) ~~ Set(ids))
         }
-        if (withDeleted) {
+        if (self.withDeleted) {
             builder.withDeleted()
         }
         return builder.all().map {

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -165,6 +165,15 @@ extension ChildrenProperty: Relation {
 
 extension ChildrenProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, ChildrenProperty<From, To>>,
+        to builder: Builder
+    )
+        where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
+    public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Children<To>>,
         withDeleted: Bool,
         to builder: Builder

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -163,7 +163,7 @@ extension ChildrenProperty: Relation {
 
 // MARK: Eager Loadable
 
-extension ChildrenProperty: EagerLoadable {
+extension ChildrenProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Children<To>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -163,7 +163,7 @@ extension ChildrenProperty: Relation {
 
 // MARK: Eager Loadable
 
-extension ChildrenProperty: EagerLoadableWithDeleted {
+extension ChildrenProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Children<To>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -163,6 +163,12 @@ extension CompositeChildrenProperty: Relation {
 }
 
 extension CompositeChildrenProperty: EagerLoadable {
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, CompositeChildrenProperty<From, To>>, to builder: Builder)
+        where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, withDeleted: Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -163,7 +163,7 @@ extension CompositeChildrenProperty: Relation {
 }
 
 extension CompositeChildrenProperty: EagerLoadable {
-    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, withDeleted : Bool, to builder: Builder)
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, withDeleted: Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
         let loader = CompositeChildrenEagerLoader(relationKey: relationKey, withDeleted: withDeleted)

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -163,10 +163,10 @@ extension CompositeChildrenProperty: Relation {
 }
 
 extension CompositeChildrenProperty: EagerLoadable {
-    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, to builder: Builder)
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
-        let loader = CompositeChildrenEagerLoader(relationKey: relationKey)
+        let loader = CompositeChildrenEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 
@@ -183,6 +183,7 @@ private struct CompositeChildrenEagerLoader<From, To>: EagerLoader
     where From: Model, To: Model, From.IDValue: Fields
 {
     let relationKey: KeyPath<From, From.CompositeChildren<To>>
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let ids = Set(models.map(\.id!))

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -162,7 +162,7 @@ extension CompositeChildrenProperty: Relation {
     public func load(on database: Database) -> EventLoopFuture<Void> { self.query(on: database).all().map { self.value = $0 } }
 }
 
-extension CompositeChildrenProperty: EagerLoadable {
+extension CompositeChildrenProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -162,7 +162,7 @@ extension CompositeChildrenProperty: Relation {
     public func load(on database: Database) -> EventLoopFuture<Void> { self.query(on: database).all().map { self.value = $0 } }
 }
 
-extension CompositeChildrenProperty: EagerLoadableWithDeleted {
+extension CompositeChildrenProperty: EagerLoadable {
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeOptionalChild.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalChild.swift
@@ -148,10 +148,10 @@ extension CompositeOptionalChildProperty: Relation {
 }
 
 extension CompositeOptionalChildProperty: EagerLoadable {
-    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalChild<To>>, to builder: Builder)
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalChild<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
-        let loader = CompositeOptionalChildEagerLoader(relationKey: relationKey)
+        let loader = CompositeOptionalChildEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 
@@ -168,6 +168,7 @@ private struct CompositeOptionalChildEagerLoader<From, To>: EagerLoader
     where From: Model, To: Model, From.IDValue: Fields
 {
     let relationKey: KeyPath<From, From.CompositeOptionalChild<To>>
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let ids = Set(models.map(\.id!))
@@ -177,7 +178,9 @@ private struct CompositeOptionalChildEagerLoader<From, To>: EagerLoader
         builder.group(.or) { query in
             _ = parentKey.queryFilterIds(ids, in: query)
         }
-        
+        if (withDeleted) {
+            builder.withDeleted()
+        }
         return builder.all().map {
             let indexedResults = Dictionary(grouping: $0, by: { parentKey.referencedId(in: $0)! })
             

--- a/Sources/FluentKit/Properties/CompositeOptionalChild.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalChild.swift
@@ -148,6 +148,12 @@ extension CompositeOptionalChildProperty: Relation {
 }
 
 extension CompositeOptionalChildProperty: EagerLoadable {
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, CompositeOptionalChildProperty<From, To>>, to builder: Builder)
+        where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalChild<To>>, withDeleted: Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeOptionalChild.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalChild.swift
@@ -147,7 +147,7 @@ extension CompositeOptionalChildProperty: Relation {
     public func load(on database: Database) -> EventLoopFuture<Void> { self.query(on: database).first().map { self.value = $0 } }
 }
 
-extension CompositeOptionalChildProperty: EagerLoadable {
+extension CompositeOptionalChildProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalChild<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeOptionalChild.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalChild.swift
@@ -148,7 +148,7 @@ extension CompositeOptionalChildProperty: Relation {
 }
 
 extension CompositeOptionalChildProperty: EagerLoadable {
-    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalChild<To>>, withDeleted : Bool, to builder: Builder)
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalChild<To>>, withDeleted: Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
         let loader = CompositeOptionalChildEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
@@ -178,7 +178,7 @@ private struct CompositeOptionalChildEagerLoader<From, To>: EagerLoader
         builder.group(.or) { query in
             _ = parentKey.queryFilterIds(ids, in: query)
         }
-        if (withDeleted) {
+        if (self.withDeleted) {
             builder.withDeleted()
         }
         return builder.all().map {

--- a/Sources/FluentKit/Properties/CompositeOptionalChild.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalChild.swift
@@ -147,7 +147,7 @@ extension CompositeOptionalChildProperty: Relation {
     public func load(on database: Database) -> EventLoopFuture<Void> { self.query(on: database).first().map { self.value = $0 } }
 }
 
-extension CompositeOptionalChildProperty: EagerLoadableWithDeleted {
+extension CompositeOptionalChildProperty: EagerLoadable {
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalChild<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeOptionalParent.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalParent.swift
@@ -190,7 +190,7 @@ extension CompositeOptionalParentProperty: AnyCodableProperty {
     }
 }
 
-extension CompositeOptionalParentProperty: EagerLoadableWithDeleted {
+extension CompositeOptionalParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalParent<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeOptionalParent.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalParent.swift
@@ -190,7 +190,7 @@ extension CompositeOptionalParentProperty: AnyCodableProperty {
     }
 }
 
-extension CompositeOptionalParentProperty: EagerLoadable {
+extension CompositeOptionalParentProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalParent<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeOptionalParent.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalParent.swift
@@ -191,7 +191,7 @@ extension CompositeOptionalParentProperty: AnyCodableProperty {
 }
 
 extension CompositeOptionalParentProperty: EagerLoadable {
-    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalParent<To>>, withDeleted : Bool, to builder: Builder)
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalParent<To>>, withDeleted: Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
         builder.add(loader: CompositeOptionalParentEagerLoader(relationKey: relationKey, withDeleted: withDeleted))
@@ -216,7 +216,7 @@ private struct CompositeOptionalParentEagerLoader<From, To>: EagerLoader
 
         let builder = To.query(on: database)
             .group(.or) { _ = sets.keys.reduce($0) { query, id in query.group(.and) { id!.input(to: QueryFilterInput(builder: $0)) } } }
-        if (withDeleted) {
+        if (self.withDeleted) {
             builder.withDeleted()
         }
         return builder.all().flatMapThrowing {

--- a/Sources/FluentKit/Properties/CompositeOptionalParent.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalParent.swift
@@ -191,6 +191,12 @@ extension CompositeOptionalParentProperty: AnyCodableProperty {
 }
 
 extension CompositeOptionalParentProperty: EagerLoadable {
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, CompositeOptionalParentProperty<From, To>>, to builder: Builder)
+        where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeOptionalParent<To>>, withDeleted: Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeParent.swift
+++ b/Sources/FluentKit/Properties/CompositeParent.swift
@@ -167,7 +167,7 @@ extension CompositeParentProperty: AnyCodableProperty {
     }
 }
 
-extension CompositeParentProperty: EagerLoadable {
+extension CompositeParentProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeParent<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeParent.swift
+++ b/Sources/FluentKit/Properties/CompositeParent.swift
@@ -168,6 +168,12 @@ extension CompositeParentProperty: AnyCodableProperty {
 }
 
 extension CompositeParentProperty: EagerLoadable {
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, CompositeParentProperty<From, To>>, to builder: Builder)
+    where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeParent<To>>, withDeleted: Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeParent.swift
+++ b/Sources/FluentKit/Properties/CompositeParent.swift
@@ -167,7 +167,7 @@ extension CompositeParentProperty: AnyCodableProperty {
     }
 }
 
-extension CompositeParentProperty: EagerLoadableWithDeleted {
+extension CompositeParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeParent<To>>, withDeleted : Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {

--- a/Sources/FluentKit/Properties/CompositeParent.swift
+++ b/Sources/FluentKit/Properties/CompositeParent.swift
@@ -168,7 +168,7 @@ extension CompositeParentProperty: AnyCodableProperty {
 }
 
 extension CompositeParentProperty: EagerLoadable {
-    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeParent<To>>, withDeleted : Bool, to builder: Builder)
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeParent<To>>, withDeleted: Bool, to builder: Builder)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
         builder.add(loader: CompositeParentEagerLoader(relationKey: relationKey, withDeleted: withDeleted))
@@ -194,7 +194,7 @@ private struct CompositeParentEagerLoader<From, To>: EagerLoader
             .group(.or) {
                 _ = sets.keys.reduce($0) { query, id in query.group(.and) { id.input(to: QueryFilterInput(builder: $0)) } }
             }
-        if (withDeleted) {
+        if (self.withDeleted) {
             builder.withDeleted()
         }
         return builder.all()

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -151,7 +151,7 @@ extension OptionalChildProperty: Relation {
 extension OptionalChildProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalChild<To>>,
-        withDeleted : Bool,
+        withDeleted: Bool,
         to builder: Builder
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
@@ -193,7 +193,7 @@ private struct OptionalChildEagerLoader<From, To>: EagerLoader
         case .required(let required):
             builder.filter(required.appending(path: \.$id) ~~ Set(ids))
         }
-        if (withDeleted) {
+        if (self.withDeleted) {
             builder.withDeleted()
         }
         return builder.all().map {

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -148,7 +148,7 @@ extension OptionalChildProperty: Relation {
 
 // MARK: Eager Loadable
 
-extension OptionalChildProperty: EagerLoadableWithDeleted {
+extension OptionalChildProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalChild<To>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -148,7 +148,7 @@ extension OptionalChildProperty: Relation {
 
 // MARK: Eager Loadable
 
-extension OptionalChildProperty: EagerLoadable {
+extension OptionalChildProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalChild<To>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -150,6 +150,15 @@ extension OptionalChildProperty: Relation {
 
 extension OptionalChildProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, OptionalChildProperty<From, To>>,
+        to builder: Builder
+    )
+        where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
+    public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalChild<To>>,
         withDeleted: Bool,
         to builder: Builder

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -129,11 +129,12 @@ extension OptionalParentProperty: AnyCodableProperty {
 extension OptionalParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalParent<To>>,
+        withDeleted : Bool,
         to builder: Builder
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
-        let loader = OptionalParentEagerLoader(relationKey: relationKey)
+        let loader = OptionalParentEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 
@@ -156,12 +157,17 @@ private struct OptionalParentEagerLoader<From, To>: EagerLoader
     where From: FluentKit.Model, To: FluentKit.Model
 {
     let relationKey: KeyPath<From, OptionalParentProperty<From, To>>
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         var sets = Dictionary(grouping: models, by: { $0[keyPath: self.relationKey].id })
         let nilParentModels = sets.removeValue(forKey: nil) ?? []
 
-        return To.query(on: database).filter(\._$id ~~ Set(sets.keys.compactMap { $0 })).all().flatMapThrowing {
+        let builder = To.query(on: database).filter(\._$id ~~ Set(sets.keys.compactMap { $0 }))
+        if (withDeleted) {
+            builder.withDeleted()
+        }
+        return builder.all().flatMapThrowing {
             let parents = Dictionary(uniqueKeysWithValues: $0.map { ($0.id!, $0) })
 
             for (parentId, models) in sets {

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -126,7 +126,7 @@ extension OptionalParentProperty: AnyCodableProperty {
 
 // MARK: Eager Loadable
 
-extension OptionalParentProperty: EagerLoadableWithDeleted {
+extension OptionalParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalParent<To>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -126,7 +126,7 @@ extension OptionalParentProperty: AnyCodableProperty {
 
 // MARK: Eager Loadable
 
-extension OptionalParentProperty: EagerLoadable {
+extension OptionalParentProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalParent<To>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -128,6 +128,16 @@ extension OptionalParentProperty: AnyCodableProperty {
 
 extension OptionalParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From,
+        OptionalParentProperty<From, To>>,
+        to builder: Builder
+    )
+        where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
+    public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalParent<To>>,
         withDeleted: Bool,
         to builder: Builder

--- a/Sources/FluentKit/Properties/OptionalParent.swift
+++ b/Sources/FluentKit/Properties/OptionalParent.swift
@@ -129,7 +129,7 @@ extension OptionalParentProperty: AnyCodableProperty {
 extension OptionalParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalParent<To>>,
-        withDeleted : Bool,
+        withDeleted: Bool,
         to builder: Builder
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
@@ -164,7 +164,7 @@ private struct OptionalParentEagerLoader<From, To>: EagerLoader
         let nilParentModels = sets.removeValue(forKey: nil) ?? []
 
         let builder = To.query(on: database).filter(\._$id ~~ Set(sets.keys.compactMap { $0 }))
-        if (withDeleted) {
+        if (self.withDeleted) {
             builder.withDeleted()
         }
         return builder.all().flatMapThrowing {

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -123,7 +123,7 @@ extension ParentProperty: AnyCodableProperty {
 extension ParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Parent<To>>,
-        withDeleted : Bool,
+        withDeleted: Bool,
         to builder: Builder
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
@@ -152,12 +152,12 @@ private struct ParentEagerLoader<From, To>: EagerLoader
     where From: FluentKit.Model, To: FluentKit.Model
 {
     let relationKey: KeyPath<From, ParentProperty<From, To>>
-    let withDeleted : Bool
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let sets = Dictionary(grouping: models, by: { $0[keyPath: self.relationKey].id })
         let builder = To.query(on: database).filter(\._$id ~~ Set(sets.keys))
-        if (withDeleted) {
+        if (self.withDeleted) {
             builder.withDeleted()
         }
         return builder.all().flatMapThrowing {

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -122,6 +122,15 @@ extension ParentProperty: AnyCodableProperty {
 
 extension ParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, ParentProperty<From, To>>,
+        to builder: Builder
+    )
+        where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
+    public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Parent<To>>,
         withDeleted: Bool,
         to builder: Builder

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -120,7 +120,7 @@ extension ParentProperty: AnyCodableProperty {
 
 // MARK: Eager Loadable
 
-extension ParentProperty: EagerLoadableWithDeleted {
+extension ParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Parent<To>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -120,7 +120,7 @@ extension ParentProperty: AnyCodableProperty {
 
 // MARK: Eager Loadable
 
-extension ParentProperty: EagerLoadable {
+extension ParentProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Parent<To>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -322,7 +322,7 @@ extension SiblingsProperty: Relation {
 
 // MARK: Eager Loadable
 
-extension SiblingsProperty: EagerLoadable {
+extension SiblingsProperty: EagerLoadableWithDeleted {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Siblings<To, Through>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -325,11 +325,12 @@ extension SiblingsProperty: Relation {
 extension SiblingsProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Siblings<To, Through>>,
+        withDeleted : Bool,
         to builder: Builder
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
-        let loader = SiblingsEagerLoader(relationKey: relationKey)
+        let loader = SiblingsEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 
@@ -354,16 +355,20 @@ private struct SiblingsEagerLoader<From, To, Through>: EagerLoader
     where From: Model, Through: Model, To: Model
 {
     let relationKey: KeyPath<From, From.Siblings<To, Through>>
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let ids = models.map { $0.id! }
 
         let from = From()[keyPath: self.relationKey].from
         let to = From()[keyPath: self.relationKey].to
-        return To.query(on: database)
+        let builder = To.query(on: database)
             .join(Through.self, on: \To._$id == to.appending(path: \.$id))
             .filter(Through.self, from.appending(path: \.$id) ~~ Set(ids))
-            .all()
+        if (withDeleted) {
+            builder.withDeleted()
+        }
+        return builder.all()
             .flatMapThrowing
         {
             var map: [From.IDValue: [To]] = [:]

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -322,7 +322,7 @@ extension SiblingsProperty: Relation {
 
 // MARK: Eager Loadable
 
-extension SiblingsProperty: EagerLoadableWithDeleted {
+extension SiblingsProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Siblings<To, Through>>,
         withDeleted : Bool,

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -325,7 +325,7 @@ extension SiblingsProperty: Relation {
 extension SiblingsProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Siblings<To, Through>>,
-        withDeleted : Bool,
+        withDeleted: Bool,
         to builder: Builder
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
@@ -365,7 +365,7 @@ private struct SiblingsEagerLoader<From, To, Through>: EagerLoader
         let builder = To.query(on: database)
             .join(Through.self, on: \To._$id == to.appending(path: \.$id))
             .filter(Through.self, from.appending(path: \.$id) ~~ Set(ids))
-        if (withDeleted) {
+        if (self.withDeleted) {
             builder.withDeleted()
         }
         return builder.all()

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -324,6 +324,15 @@ extension SiblingsProperty: Relation {
 
 extension SiblingsProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, SiblingsProperty<From, To, Through>>,
+        to builder: Builder
+    )
+    where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
+    public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Siblings<To, Through>>,
         withDeleted: Bool,
         to builder: Builder

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
@@ -17,10 +17,31 @@ extension EagerLoadBuilder {
     // MARK: Eager Load
 
     @discardableResult
-    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>,
-                               withDeleted : Bool = false
+    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>) -> Self
+        where Relation: EagerLoadable, Relation.From == Model
+    {
+        Relation.eagerLoad(relationKey, to: self)
+        return self
+    }
+
+    @discardableResult
+    public func with<Relation>(
+        _ throughKey: KeyPath<Model, Relation>,
+        _ nested: (NestedEagerLoadBuilder<Self, Relation>) -> ()
     ) -> Self
         where Relation: EagerLoadable, Relation.From == Model
+    {
+        Relation.eagerLoad(throughKey, to: self)
+        let builder = NestedEagerLoadBuilder<Self, Relation>(builder: self, throughKey)
+        nested(builder)
+        return self
+    }
+    
+    @discardableResult
+    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>,
+                               withDeleted : Bool
+    ) -> Self
+        where Relation: EagerLoadableWithDeleted, Relation.From == Model
     {
         Relation.eagerLoad(relationKey, withDeleted : withDeleted, to: self)
         return self
@@ -29,10 +50,10 @@ extension EagerLoadBuilder {
     @discardableResult
     public func with<Relation>(
         _ throughKey: KeyPath<Model, Relation>,
-        withDeleted : Bool = false,
+        withDeleted : Bool,
         _ nested: (NestedEagerLoadBuilder<Self, Relation>) -> ()
     ) -> Self
-        where Relation: EagerLoadable, Relation.From == Model
+        where Relation: EagerLoadableWithDeleted, Relation.From == Model
     {
         Relation.eagerLoad(throughKey, withDeleted : withDeleted, to: self)
         let builder = NestedEagerLoadBuilder<Self, Relation>(builder: self, throughKey)

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
@@ -38,24 +38,25 @@ extension EagerLoadBuilder {
     }
     
     @discardableResult
-    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>,
-                               withDeleted : Bool
+    public func with<Relation>(
+        _ relationKey: KeyPath<Model, Relation>,
+        withDeleted: Bool
     ) -> Self
         where Relation: EagerLoadable, Relation.From == Model
     {
-        Relation.eagerLoad(relationKey, withDeleted : withDeleted, to: self)
+        Relation.eagerLoad(relationKey, withDeleted: withDeleted, to: self)
         return self
     }
 
     @discardableResult
     public func with<Relation>(
         _ throughKey: KeyPath<Model, Relation>,
-        withDeleted : Bool,
+        withDeleted: Bool,
         _ nested: (NestedEagerLoadBuilder<Self, Relation>) -> ()
     ) -> Self
         where Relation: EagerLoadable, Relation.From == Model
     {
-        Relation.eagerLoad(throughKey, withDeleted : withDeleted, to: self)
+        Relation.eagerLoad(throughKey, withDeleted: withDeleted, to: self)
         let builder = NestedEagerLoadBuilder<Self, Relation>(builder: self, throughKey)
         nested(builder)
         return self

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
@@ -17,21 +17,24 @@ extension EagerLoadBuilder {
     // MARK: Eager Load
 
     @discardableResult
-    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>) -> Self
+    public func with<Relation>(_ relationKey: KeyPath<Model, Relation>,
+                               withDeleted : Bool = false
+    ) -> Self
         where Relation: EagerLoadable, Relation.From == Model
     {
-        Relation.eagerLoad(relationKey, to: self)
+        Relation.eagerLoad(relationKey, withDeleted : withDeleted, to: self)
         return self
     }
 
     @discardableResult
     public func with<Relation>(
         _ throughKey: KeyPath<Model, Relation>,
+        withDeleted : Bool = false,
         _ nested: (NestedEagerLoadBuilder<Self, Relation>) -> ()
     ) -> Self
         where Relation: EagerLoadable, Relation.From == Model
     {
-        Relation.eagerLoad(throughKey, to: self)
+        Relation.eagerLoad(throughKey, withDeleted : withDeleted, to: self)
         let builder = NestedEagerLoadBuilder<Self, Relation>(builder: self, throughKey)
         nested(builder)
         return self

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
@@ -41,7 +41,7 @@ extension EagerLoadBuilder {
     public func with<Relation>(_ relationKey: KeyPath<Model, Relation>,
                                withDeleted : Bool
     ) -> Self
-        where Relation: EagerLoadableWithDeleted, Relation.From == Model
+        where Relation: EagerLoadable, Relation.From == Model
     {
         Relation.eagerLoad(relationKey, withDeleted : withDeleted, to: self)
         return self
@@ -53,7 +53,7 @@ extension EagerLoadBuilder {
         withDeleted : Bool,
         _ nested: (NestedEagerLoadBuilder<Self, Relation>) -> ()
     ) -> Self
-        where Relation: EagerLoadableWithDeleted, Relation.From == Model
+        where Relation: EagerLoadable, Relation.From == Model
     {
         Relation.eagerLoad(throughKey, withDeleted : withDeleted, to: self)
         let builder = NestedEagerLoadBuilder<Self, Relation>(builder: self, throughKey)

--- a/Tests/FluentKitTests/AsyncTests/AsyncFluentKitTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncFluentKitTests.swift
@@ -100,7 +100,7 @@ final class AsyncFluentKitTests: XCTestCase {
 
         _ = try await Planet.query(on: db).all(\.$name)
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."name" AS "planets_name" FROM "planets""#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."name" AS "planets_name" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
         db.reset()
     }
 
@@ -109,7 +109,7 @@ final class AsyncFluentKitTests: XCTestCase {
 
         _ = try await Planet.query(on: db).unique().all(\.$name)
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT DISTINCT "planets"."name" AS "planets_name" FROM "planets""#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT DISTINCT "planets"."name" AS "planets_name" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
         db.reset()
 
         _ = try await Planet.query(on: db).unique().all()
@@ -119,12 +119,12 @@ final class AsyncFluentKitTests: XCTestCase {
 
         _ = try await Planet.query(on: db).unique().count(\.$name)
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT COUNT(DISTINCT("planets"."name")) AS "aggregate" FROM "planets""#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT COUNT(DISTINCT("planets"."name")) AS "aggregate" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
         db.reset()
 
         _ = try await Planet.query(on: db).unique().sum(\.$id)
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT SUM(DISTINCT("planets"."id")) AS "aggregate" FROM "planets""#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT SUM(DISTINCT("planets"."id")) AS "aggregate" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
         db.reset()
     }
 

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -299,6 +299,6 @@ final class AsyncQueryBuilderTests: XCTestCase {
             .join(Star.self, on: \Star.$id == \Planet.$star.$id && \Star.$name != \Planet.$name)
             .all()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name""#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "planets"."deleted_at" AS "planets_deleted_at", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id", "stars"."deleted_at" AS "stars_deleted_at" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1) AND ("stars"."deleted_at" IS NULL OR "stars"."deleted_at" > $2)"#)
     }
 }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -157,7 +157,7 @@ final class FluentKitTests: XCTestCase {
         
         _ = try Planet.query(on: db).all(\.$name).wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."name" AS "planets_name" FROM "planets""#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."name" AS "planets_name" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
         db.reset()
     }
     
@@ -166,7 +166,7 @@ final class FluentKitTests: XCTestCase {
         
         _ = try Planet.query(on: db).unique().all(\.$name).wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT DISTINCT "planets"."name" AS "planets_name" FROM "planets""#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT DISTINCT "planets"."name" AS "planets_name" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
         db.reset()
         
         _ = try Planet.query(on: db).unique().all().wait()
@@ -176,12 +176,12 @@ final class FluentKitTests: XCTestCase {
         
         _ = try? Planet.query(on: db).unique().count(\.$name).wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT COUNT(DISTINCT("planets"."name")) AS "aggregate" FROM "planets""#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT COUNT(DISTINCT("planets"."name")) AS "aggregate" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
         db.reset()
         
         _ = try? Planet.query(on: db).unique().sum(\.$id).wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT SUM(DISTINCT("planets"."id")) AS "aggregate" FROM "planets""#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT SUM(DISTINCT("planets"."id")) AS "aggregate" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
         db.reset()
     }
 
@@ -739,7 +739,7 @@ final class FluentKitTests: XCTestCase {
         XCTAssertEqual(db.sqlSerializers.dropFirst(2).first?.sql, #"INSERT INTO "mirror_universe"."planets" ("id", "createdAt", "updatedAt", "name") VALUES ($1, $2, $3, $4)"#)
         XCTAssertEqual(db.sqlSerializers.dropFirst(3).first?.sql, #"UPDATE "mirror_universe"."planets" SET "updatedAt" = $1, "name" = $2, "id" = $3 WHERE "mirror_universe"."planets"."id" = $4 AND ("mirror_universe"."planets"."deletedAt" IS NULL OR "mirror_universe"."planets"."deletedAt" > $5)"#)
         XCTAssertEqual(db.sqlSerializers.dropFirst(4).first?.sql, #"DELETE FROM "mirror_universe"."planets" WHERE "mirror_universe"."planets"."name" <> $1"#)
-        XCTAssertEqual(db.sqlSerializers.dropFirst(5).first?.sql, #"SELECT "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "stars" INNER JOIN "mirror_universe"."planets" ON "mirror_universe"."planets"."star_id" = "stars"."id" LIMIT 1"#)
+        XCTAssertEqual(db.sqlSerializers.dropFirst(5).first?.sql, #"SELECT "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id", "stars"."deleted_at" AS "stars_deleted_at" FROM "stars" INNER JOIN "mirror_universe"."planets" ON "mirror_universe"."planets"."star_id" = "stars"."id" LIMIT 1"#)
     }
 
     func testKeyPrefixingStrategies() throws {

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -191,7 +191,7 @@ final class QueryBuilderTests: XCTestCase {
                   on: .custom(#"LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#))
             .all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "planets"."deleted_at" AS "planets_deleted_at", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id", "stars"."deleted_at" AS "stars_deleted_at" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun' WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1) AND ("stars"."deleted_at" IS NULL OR "stars"."deleted_at" > $2)"#)
     }
     
     func testComplexJoinOperators() throws {
@@ -201,6 +201,6 @@ final class QueryBuilderTests: XCTestCase {
             .join(Star.self, on: \Star.$id == \Planet.$star.$id && \Star.$name != \Planet.$name)
             .all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name""#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "planets"."deleted_at" AS "planets_deleted_at", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id", "stars"."deleted_at" AS "stars_deleted_at" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1) AND ("stars"."deleted_at" IS NULL OR "stars"."deleted_at" > $2)"#)
     }
 }


### PR DESCRIPTION
Allows eager-loading of soft-deleted models. For maximum flexibility, choosing whether to load soft-deleted models or not is performed for each relation at each query call.

Usage is as follows: `let galaxies = try Galaxy.query(on: self.database).with(\.$stars, withDeleted: true)`

Use of default argument value of false requires no change to existing code to keep existing behaviour.

Fixes #375.
