### PR TITLE
make insert query column ordering deterministic

### DIFF
--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -81,7 +81,7 @@ public struct SQLQueryConverter {
         guard case .dictionary(let first) = query.input.first! else {
             fatalError("Unexpected query input: \(query.input)")
         }
-        let keys: [FieldKey] = Array(first.keys)
+        let keys: [FieldKey] = Array(first.keys).sorted { $0.description < $1.description }
         insert.columns = keys.map { key in
             SQLColumn(self.key(key))
         }


### PR DESCRIPTION
When composing insert queries, the order of the columns is non-deterministic. This hurts query monitoring and analytics.

In a Postgres database we work with, `SELECT * FROM pg_stat_statements WHERE query like 'INSERT INTO "my_insert_heavy_table"%';` returns more than 3,100 rows. The relevant table `my_insert_heavy_table` has many columns, thus many possible column orders when it's non-deterministic. I think if we make the order deterministic, these 3,100 different queries could be treated as one query for monitoring purposes.

Resolves https://github.com/vapor/fluent-kit/issues/543