### PR TITLE
Added support for eager loading of soft deleted relations.

### DIFF
--- a/Sources/FluentBenchmark/SolarSystem/Planet.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Planet.swift
@@ -60,7 +60,7 @@ public struct PlanetSeed: Migration {
     public init() { }
 
     public func prepare(on database: Database) -> EventLoopFuture<Void> {
-        Star.query(on: database).all().flatMap { stars in
+        Star.query(on: database).withDeleted().all().flatMap { stars in
             .andAllSucceed(stars.map { star in
                 let planets: [Planet]
                 switch star.name {
@@ -78,6 +78,10 @@ public struct PlanetSeed: Migration {
                 case "Alpha Centauri":
                     planets = [
                         .init(name: "Proxima Centauri b")
+                    ]
+                case "SN 1604":
+                    planets = [
+                        .init(name: "Carida")
                     ]
                 default:
                     planets = []

--- a/Sources/FluentBenchmark/Tests/AggregateTests.swift
+++ b/Sources/FluentBenchmark/Tests/AggregateTests.swift
@@ -14,7 +14,7 @@ extension FluentBenchmarker {
             // whole table
             let count = try Planet.query(on: self.database)
                 .count().wait()
-            XCTAssertEqual(count, 9)
+            XCTAssertEqual(count, 10)
 
             // filtered w/ results
             let filteredCount = try Planet.query(on: self.database)

--- a/Sources/FluentBenchmark/Tests/FilterTests.swift
+++ b/Sources/FluentBenchmark/Tests/FilterTests.swift
@@ -125,7 +125,7 @@ extension FluentBenchmarker {
             let planets = try Planet.query(on: self.database)
                 .group(.or) { _ in }
                 .all().wait()
-            XCTAssertEqual(planets.count, 9)
+            XCTAssertEqual(planets.count, 10)
         }
     }
 

--- a/Sources/FluentBenchmark/Tests/PaginationTests.swift
+++ b/Sources/FluentBenchmark/Tests/PaginationTests.swift
@@ -14,11 +14,11 @@ extension FluentBenchmarker {
 
                 XCTAssertEqual(planetsPage1.metadata.page, 1)
                 XCTAssertEqual(planetsPage1.metadata.per, 2)
-                XCTAssertEqual(planetsPage1.metadata.total, 9)
+                XCTAssertEqual(planetsPage1.metadata.total, 10)
                 XCTAssertEqual(planetsPage1.metadata.pageCount, 5)
                 XCTAssertEqual(planetsPage1.items.count, 2)
-                XCTAssertEqual(planetsPage1.items[0].name, "Earth")
-                XCTAssertEqual(planetsPage1.items[1].name, "Jupiter")
+                XCTAssertEqual(planetsPage1.items[0].name, "Carida")
+                XCTAssertEqual(planetsPage1.items[1].name, "Earth")
             }
             do {
                 let planetsPage2 = try Planet.query(on: self.database)
@@ -28,11 +28,11 @@ extension FluentBenchmarker {
 
                 XCTAssertEqual(planetsPage2.metadata.page, 2)
                 XCTAssertEqual(planetsPage2.metadata.per, 2)
-                XCTAssertEqual(planetsPage2.metadata.total, 9)
+                XCTAssertEqual(planetsPage2.metadata.total, 10)
                 XCTAssertEqual(planetsPage2.metadata.pageCount, 5)
                 XCTAssertEqual(planetsPage2.items.count, 2)
-                XCTAssertEqual(planetsPage2.items[0].name, "Mars")
-                XCTAssertEqual(planetsPage2.items[1].name, "Mercury")
+                XCTAssertEqual(planetsPage2.items[0].name, "Jupiter")
+                XCTAssertEqual(planetsPage2.items[1].name, "Mars")
             }
             do {
                 let galaxiesPage = try Galaxy.query(on: self.database)

--- a/Sources/FluentBenchmark/Tests/ParentTests.swift
+++ b/Sources/FluentBenchmark/Tests/ParentTests.swift
@@ -30,6 +30,7 @@ extension FluentBenchmarker {
             SolarSystem()
         ]) {
             let planets = try Planet.query(on: self.database)
+                .filter(\.$name != "Carida") // eager loading will fail for planets with deleted stars
                 .all().wait()
 
             for planet in planets {

--- a/Sources/FluentBenchmark/Tests/RangeTests.swift
+++ b/Sources/FluentBenchmark/Tests/RangeTests.swift
@@ -16,7 +16,7 @@ extension FluentBenchmarker {
                     .sort(\.$name)
                     .all().wait()
                 XCTAssertEqual(planets.count, 3)
-                XCTAssertEqual(planets[0].name, "Mars")
+                XCTAssertEqual(planets[0].name, "Jupiter")
             }
             do {
                 let planets = try Planet.query(on: self.database)

--- a/Sources/FluentBenchmark/Tests/SchemaTests.swift
+++ b/Sources/FluentBenchmark/Tests/SchemaTests.swift
@@ -78,7 +78,7 @@ extension FluentBenchmarker {
             XCTAssertThrowsError(
                 try Star.query(on: self.database)
                     .filter(\.$name == "Sun")
-                    .delete().wait()
+                    .delete(force: true).wait()
             )
         }
     }

--- a/Sources/FluentKit/Model/EagerLoad.swift
+++ b/Sources/FluentKit/Model/EagerLoad.swift
@@ -2,6 +2,7 @@ import NIOCore
 
 public protocol EagerLoader: AnyEagerLoader {
     associatedtype Model: FluentKit.Model
+    var withDeleted: Bool { get }
     func run(models: [Model], on database: Database) -> EventLoopFuture<Void>
 }
 
@@ -21,13 +22,15 @@ public protocol EagerLoadable {
 
     static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, Self>,
-        to builder: Builder
+        to builder: Builder,
+        withDeleted: Bool
     ) where Builder: EagerLoadBuilder, Builder.Model == From
 
     static func eagerLoad<Loader, Builder>(
         _ loader: Loader,
         through: KeyPath<From, Self>,
-        to builder: Builder
+        to builder: Builder,
+        withDeleted: Bool
     ) where Loader: EagerLoader,
         Builder: EagerLoadBuilder,
         Loader.Model == To,

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -163,18 +163,18 @@ extension CompositeChildrenProperty: Relation {
 }
 
 extension CompositeChildrenProperty: EagerLoadable {
-    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, to builder: Builder)
+    public static func eagerLoad<Builder>(_ relationKey: KeyPath<From, From.CompositeChildren<To>>, to builder: Builder, withDeleted: Bool)
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
-        let loader = CompositeChildrenEagerLoader(relationKey: relationKey)
+        let loader = CompositeChildrenEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 
 
-    public static func eagerLoad<Loader, Builder>(_ loader: Loader, through: KeyPath<From, From.CompositeChildren<To>>, to builder: Builder)
+    public static func eagerLoad<Loader, Builder>(_ loader: Loader, through: KeyPath<From, From.CompositeChildren<To>>, to builder: Builder, withDeleted: Bool)
         where Loader: EagerLoader, Loader.Model == To, Builder: EagerLoadBuilder, Builder.Model == From
     {
-        let loader = ThroughCompositeChildrenEagerLoader(relationKey: through, loader: loader)
+        let loader = ThroughCompositeChildrenEagerLoader(relationKey: through, loader: loader, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 }
@@ -183,12 +183,17 @@ private struct CompositeChildrenEagerLoader<From, To>: EagerLoader
     where From: Model, To: Model, From.IDValue: Fields
 {
     let relationKey: KeyPath<From, From.CompositeChildren<To>>
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let ids = Set(models.map(\.id!))
         let parentKey = From()[keyPath: self.relationKey].parentKey
         let builder = To.query(on: database)
         
+        if withDeleted {
+            builder.withDeleted()
+        }
+
         builder.group(.or) { query in
             _ = parentKey.queryFilterIds(ids, in: query)
         }
@@ -208,6 +213,7 @@ private struct ThroughCompositeChildrenEagerLoader<From, Through, Loader>: Eager
 {
     let relationKey: KeyPath<From, From.CompositeChildren<Through>>
     let loader: Loader
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         return self.loader.run(models: models.flatMap { $0[keyPath: self.relationKey].value! }, on: database)

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -151,26 +151,27 @@ extension OptionalChildProperty: Relation {
 extension OptionalChildProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.OptionalChild<To>>,
-        to builder: Builder
+        to builder: Builder,
+        withDeleted: Bool
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
-        let loader = OptionalChildEagerLoader(relationKey: relationKey)
+        let loader = OptionalChildEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
-
 
     public static func eagerLoad<Loader, Builder>(
         _ loader: Loader,
         through: KeyPath<From, From.OptionalChild<To>>,
-        to builder: Builder
+        to builder: Builder,
+        withDeleted: Bool
     ) where
         Loader: EagerLoader,
         Loader.Model == To,
         Builder: EagerLoadBuilder,
         Builder.Model == From
     {
-        let loader = ThroughChildEagerLoader(relationKey: through, loader: loader)
+        let loader = ThroughChildEagerLoader(relationKey: through, loader: loader, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 }
@@ -179,11 +180,17 @@ private struct OptionalChildEagerLoader<From, To>: EagerLoader
     where From: Model, To: Model
 {
     let relationKey: KeyPath<From, From.OptionalChild<To>>
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let ids = models.compactMap { $0.id! }
 
         let builder = To.query(on: database)
+
+        if withDeleted {
+            builder.withDeleted()
+        }
+
         let parentKey = From()[keyPath: self.relationKey].parentKey
         switch parentKey {
         case .optional(let optional):
@@ -213,6 +220,7 @@ private struct ThroughChildEagerLoader<From, Through, Loader>: EagerLoader
 {
     let relationKey: KeyPath<From, From.OptionalChild<Through>>
     let loader: Loader
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let throughs = models.compactMap {

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -123,11 +123,12 @@ extension ParentProperty: AnyCodableProperty {
 extension ParentProperty: EagerLoadable {
     public static func eagerLoad<Builder>(
         _ relationKey: KeyPath<From, From.Parent<To>>,
-        to builder: Builder
+        to builder: Builder,
+        withDeleted: Bool
     )
         where Builder: EagerLoadBuilder, Builder.Model == From
     {
-        let loader = ParentEagerLoader(relationKey: relationKey)
+        let loader = ParentEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 
@@ -135,14 +136,15 @@ extension ParentProperty: EagerLoadable {
     public static func eagerLoad<Loader, Builder>(
         _ loader: Loader,
         through: KeyPath<From, From.Parent<To>>,
-        to builder: Builder
+        to builder: Builder,
+        withDeleted: Bool
     ) where
         Loader: EagerLoader,
         Loader.Model == To,
         Builder: EagerLoadBuilder,
         Builder.Model == From
     {
-        let loader = ThroughParentEagerLoader(relationKey: through, loader: loader)
+        let loader = ThroughParentEagerLoader(relationKey: through, loader: loader, withDeleted: withDeleted)
         builder.add(loader: loader)
     }
 }
@@ -151,11 +153,18 @@ private struct ParentEagerLoader<From, To>: EagerLoader
     where From: FluentKit.Model, To: FluentKit.Model
 {
     let relationKey: KeyPath<From, ParentProperty<From, To>>
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let sets = Dictionary(grouping: models, by: { $0[keyPath: self.relationKey].id })
 
-        return To.query(on: database).filter(\._$id ~~ Set(sets.keys)).all().flatMapThrowing {
+        let builder = To.query(on: database)
+
+        if withDeleted {
+            builder.withDeleted()
+        }
+
+        return builder.filter(\._$id ~~ Set(sets.keys)).all().flatMapThrowing {
             let parents = Dictionary(uniqueKeysWithValues: $0.map { ($0.id!, $0) })
 
             for (parentId, models) in sets {
@@ -177,6 +186,7 @@ private struct ThroughParentEagerLoader<From, Through, Loader>: EagerLoader
 {
     let relationKey: KeyPath<From, From.Parent<Through>>
     let loader: Loader
+    let withDeleted: Bool
 
     func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
         let throughs = models.map {

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -299,6 +299,6 @@ final class AsyncQueryBuilderTests: XCTestCase {
             .join(Star.self, on: \Star.$id == \Planet.$star.$id && \Star.$name != \Planet.$name)
             .all()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name""#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."deletedAt" AS "stars_deletedAt", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name" WHERE ("stars"."deletedAt" IS NULL OR "stars"."deletedAt" > $1)"#)
     }
 }

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -739,7 +739,7 @@ final class FluentKitTests: XCTestCase {
         XCTAssertEqual(db.sqlSerializers.dropFirst(2).first?.sql, #"INSERT INTO "mirror_universe"."planets" ("id", "createdAt", "updatedAt", "name") VALUES ($1, $2, $3, $4)"#)
         XCTAssertEqual(db.sqlSerializers.dropFirst(3).first?.sql, #"UPDATE "mirror_universe"."planets" SET "updatedAt" = $1, "name" = $2, "id" = $3 WHERE "mirror_universe"."planets"."id" = $4 AND ("mirror_universe"."planets"."deletedAt" IS NULL OR "mirror_universe"."planets"."deletedAt" > $5)"#)
         XCTAssertEqual(db.sqlSerializers.dropFirst(4).first?.sql, #"DELETE FROM "mirror_universe"."planets" WHERE "mirror_universe"."planets"."name" <> $1"#)
-        XCTAssertEqual(db.sqlSerializers.dropFirst(5).first?.sql, #"SELECT "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "stars" INNER JOIN "mirror_universe"."planets" ON "mirror_universe"."planets"."star_id" = "stars"."id" LIMIT 1"#)
+        XCTAssertEqual(db.sqlSerializers.dropFirst(5).first?.sql, #"SELECT "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."deletedAt" AS "stars_deletedAt", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "stars" INNER JOIN "mirror_universe"."planets" ON "mirror_universe"."planets"."star_id" = "stars"."id" LIMIT 1"#)
     }
 
     func testKeyPrefixingStrategies() throws {

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -191,7 +191,7 @@ final class QueryBuilderTests: XCTestCase {
                   on: .custom(#"LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#))
             .all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."deletedAt" AS "stars_deletedAt", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun' WHERE ("stars"."deletedAt" IS NULL OR "stars"."deletedAt" > $1)"#)
     }
     
     func testComplexJoinOperators() throws {
@@ -201,6 +201,6 @@ final class QueryBuilderTests: XCTestCase {
             .join(Star.self, on: \Star.$id == \Planet.$star.$id && \Star.$name != \Planet.$name)
             .all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name""#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."deletedAt" AS "stars_deletedAt", "stars"."galaxy_id" AS "stars_galaxy_id" FROM "planets" INNER JOIN "stars" ON "stars"."id" = "planets"."star_id" AND "stars"."name" <> "planets"."name" WHERE ("stars"."deletedAt" IS NULL OR "stars"."deletedAt" > $1)"#)
     }
 }


### PR DESCRIPTION
This change adds `withDeleted: Bool` parameter to the `with()` query building function. For example:

```
let galaxies = try Galaxy.query(on: self.database)
  .with(\.$stars, withDeleted: true)
  .all()
```

will also return stars that are soft deleted.

There are a few tests that I'd still add in EagerLoadTests, but I would like to check with the maintainers if such an approach would be welcome.

Technically it’s a breaking change as it adds the `withDeleted` property to the public `EagerLoader` protocol. In practice It seems to me few clients would be implementing it, so it shouldn't cause much grief if any.

