### PR TITLE
sketch up of hypotetical functionality

### DIFF
--- a/Sources/FluentKit/Migration/Migrations.swift
+++ b/Sources/FluentKit/Migration/Migrations.swift
@@ -17,4 +17,13 @@ public final class Migrations {
     public func add(_ migrations: [Migration], to id: DatabaseID? = nil) {
         self.storage[id, default: []].append(contentsOf: migrations)
     }
+  
+    public func top(_ id: DatabaseID? = nil) -> String? {
+        return self.storage[id, default: []].last?.defaultName
+    }
+  
+    public func pop(_ id: DatabaseID? = nil) -> Migration? {
+        return self.storage[id, default: []].popLast()
+    }
+  
 }


### PR DESCRIPTION
implement stack like behaviour for migrations.

possible usecase: to micro manage db state inbetween unit tests


this is completely wip and i just wanted to get some feedback before i flesh something out.

example code:
```swift

// use case isolated within its own "testworld", implying a baseline of data for "functionality"
  func testContract() async throws {
    var testWorld = testWorld(app)
    let baseURI = RouteMap.contractRoute
    let baseURIString = baseURI.description
    
    let _app = testWorld.app
    // use case related migrations
    _app.migrations.add(Person.MigrationTestWorldUser())
    try await _app.autoMigrate()
    
    // tests
    try await contractRegister(&testWorld, uri: baseURIString)
    try await contractSearch(testWorld, uri: baseURIString)
    try await contractFind(testWorld, uri: baseURIString)
    try await contractModify(testWorld, uri: baseURIString)
    try await contractRemove(testWorld, uri: baseURIString)
   
    // checkout the name of your last migration added to stack
    let lastMigrationName = _app.migrations.top()
    // pop your last migration from migrations stack
    let lastMigrationValue = _app.migrations.pop()
    // revert your last migration before you start next test which is supposed to have a different state or whatever
    try await lastMigrationValue?.revert(on: app.db).get()
    
  }
  ```