### PR TITLE
Improved error reporting and other cleanups

### DIFF
--- a/Sources/FluentBenchmark/Exports.swift
+++ b/Sources/FluentBenchmark/Exports.swift
@@ -1,4 +1,9 @@
-#if !BUILDING_DOCC
+#if swift(>=5.8)
+
+@_documentation(visibility: internal) @_exported import FluentKit
+@_documentation(visibility: internal) @_exported import XCTest
+
+#elseif !BUILDING_DOCC
 
 @_exported import FluentKit
 @_exported import XCTest

--- a/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
+++ b/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
@@ -12,11 +12,12 @@ extension FluentBenchmarker {
     }
     
     public func testMiddleware_methods() throws {
+        self.databases.middleware.use(UserMiddleware())
+        defer { self.databases.middleware.clear() }
+
         try self.runTest(#function, [
             UserMigration(),
         ]) {
-            self.databases.middleware.use(UserMiddleware())
-
             let user = User(name: "A")
             // create
             do {
@@ -62,11 +63,12 @@ extension FluentBenchmarker {
     }
 
     public func testAsyncMiddleware_methods() throws {
+        self.databases.middleware.use(AsyncUserMiddleware())
+        defer { self.databases.middleware.clear() }
+
         try self.runTest(#function, [
             UserMigration(),
         ]) {
-            self.databases.middleware.use(AsyncUserMiddleware())
-
             let user = User(name: "A")
             // create
             do {
@@ -112,12 +114,13 @@ extension FluentBenchmarker {
     }
     
     public func testMiddleware_batchCreationFail() throws {
+        self.databases.middleware.clear()
+        self.databases.middleware.use(UserBatchMiddleware())
+        defer { self.databases.middleware.clear() }
+
         try self.runTest(#function, [
             UserMigration(),
         ]) {
-            self.databases.middleware.clear()
-            self.databases.middleware.use(UserBatchMiddleware())
-
             let user = User(name: "A")
             let user2 = User(name: "B")
             let user3 = User(name: "C")

--- a/Sources/FluentBenchmark/Tests/PerformanceTests+Siblings.swift
+++ b/Sources/FluentBenchmark/Tests/PerformanceTests+Siblings.swift
@@ -3,6 +3,7 @@ import Dispatch
 import FluentKit
 import Foundation
 import NIOCore
+import SQLKit
 
 extension FluentBenchmarker {
     internal func testPerformance_siblings() throws {
@@ -24,7 +25,7 @@ extension FluentBenchmarker {
             PersonSeed(),
             ExpeditionSeed(),
             ExpeditionPeopleSeed(),
-        ], on: conn) {
+        ], on: conn) { conn in
             let start = Date()
             let expeditions = try Expedition.query(on: conn)
                 .with(\.$officers)
@@ -32,56 +33,112 @@ extension FluentBenchmarker {
                 .with(\.$doctors)
                 .all().wait()
             let time = Date().timeIntervalSince(start)
+            // Circa Swift 5.2:
             // Run took 24.121525049209595 seconds.
             // Run took 0.33231091499328613 seconds.
-            self.database.logger.info("Run took \(time) seconds.")
+            // Circa Swift 5.8:
+            // Run took 1.6426270008087158 seconds.
+            // Run took 0.40939199924468994 seconds.
+            conn.logger.info("Run took \(time) seconds.")
             XCTAssertEqual(expeditions.count, 300)
+            if let sqlConn = conn as? any SQLDatabase {
+                struct DTO1: Codable { let id: UUID; let name: String, area: String, objective: String }
+                struct DTO2: Codable { let id: UUID, expedition_id: UUID, person_id: UUID }
+                let start = Date()
+                let expeditions = try sqlConn.select().columns("id", "name", "area", "objective").from(Expedition.schema).all(decoding: DTO1.self).wait()
+                let officers = try sqlConn.select().columns("id", "expedition_id", "person_id").from(ExpeditionOfficer.schema).where(SQLIdentifier("expedition_id"), .in, expeditions.map(\.id)).all(decoding: DTO2.self).wait()
+                let scientists = try sqlConn.select().columns("id", "expedition_id", "person_id").from(ExpeditionScientist.schema).where(SQLIdentifier("expedition_id"), .in, expeditions.map(\.id)).all(decoding: DTO2.self).wait()
+                let doctors = try sqlConn.select().columns("id", "expedition_id", "person_id").from(ExpeditionDoctor.schema).where(SQLIdentifier("expedition_id"), .in, expeditions.map(\.id)).all(decoding: DTO2.self).wait()
+                let time = Date().timeIntervalSince(start)
+                // Run (SQLKit mode) took 0.6164050102233887 seconds.
+                // Run (SQLKit mode) took 0.050302982330322266 seconds.
+                conn.logger.info("Run (SQLKit mode) took \(time) seconds.")
+                XCTAssertEqual(expeditions.count, 300)
+                XCTAssertEqual(officers.count, 600)
+                XCTAssertEqual(scientists.count, 1500)
+                XCTAssertEqual(doctors.count, 900)
+            }
         }
     }
 }
 
 private struct PersonSeed: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        .andAllSucceed((1...600).map { i in
-            Person(firstName: "Foo #\(i)", lastName: "Bar")
-                .create(on: database)
-        }, on: database.eventLoop)
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        if let sqlDatabase = database as? any SQLDatabase {
+            struct DTO: Codable { let id: UUID; let first_name: String, last_name: String }
+            return try! sqlDatabase.insert(into: Person.schema)
+                .models((1...600).map { DTO(id: UUID(), first_name: "Foo #\($0)", last_name: "Bar") })
+                .run()
+        } else {
+            return .andAllSucceed((1...600).map { i in
+                Person(firstName: "Foo #\(i)", lastName: "Bar")
+                    .create(on: database)
+            }, on: database.eventLoop)
+        }
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
         Person.query(on: database).delete()
     }
 }
 
 private struct ExpeditionSeed: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        .andAllSucceed((1...300).map { i in
-            Expedition(name: "Baz #\(i)", area: "Qux", objective: "Quuz")
-                .create(on: database)
-        }, on: database.eventLoop)
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        if let sqlDatabase = database as? any SQLDatabase {
+            struct DTO: Codable { let id: UUID; let name: String, area: String, objective: String }
+            return try! sqlDatabase.insert(into: Expedition.schema)
+                .models((1...300).map { DTO(id: UUID(), name: "Baz #\($0)", area: "Qux", objective: "Quuz") })
+                .run()
+        } else {
+            return .andAllSucceed((1...300).map { i in
+                Expedition(name: "Baz #\(i)", area: "Qux", objective: "Quuz")
+                    .create(on: database)
+            }, on: database.eventLoop)
+        }
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
         Expedition.query(on: database).delete()
     }
 }
 
 private struct ExpeditionPeopleSeed: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        Expedition.query(on: database).all()
-            .and(Person.query(on: database).all())
-            .flatMap
-        { (expeditions, people) in
-            .andAllSucceed(expeditions.map { expedition in
-                expedition.$officers.attach(people.pickRandomly(2), on: database)
-                    .and(expedition.$scientists.attach(people.pickRandomly(5), on: database))
-                    .and(expedition.$doctors.attach(people.pickRandomly(3), on: database))
-                    .map { _ in }
-            }, on: database.eventLoop)
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        if let sqlDatabase = database as? any SQLDatabase {
+            return
+                sqlDatabase.select().column("id").from(Expedition.schema).all().flatMapEachThrowing { try $0.decode(column: "id", as: UUID.self) }
+                .and(sqlDatabase.select().column("id").from(Person.schema).all().flatMapEachThrowing { try $0.decode(column: "id", as: UUID.self) })
+                .flatMap { expeditions, people in
+                    struct DTO: Codable { let id: UUID, expedition_id: UUID, person_id: UUID }
+                    var officers: [DTO] = [], scientists: [DTO] = [], doctors: [DTO] = []
+                    
+                    for expedition in expeditions {
+                        officers.append(contentsOf: people.pickRandomly(2).map { DTO(id: UUID(), expedition_id: expedition, person_id: $0) })
+                        scientists.append(contentsOf: people.pickRandomly(5).map { DTO(id: UUID(), expedition_id: expedition, person_id: $0) })
+                        doctors.append(contentsOf: people.pickRandomly(3).map { DTO(id: UUID(), expedition_id: expedition, person_id: $0) })
+                    }
+                    return .andAllSucceed([
+                        try! sqlDatabase.insert(into: ExpeditionOfficer.schema).models(officers).run(),
+                        try! sqlDatabase.insert(into: ExpeditionScientist.schema).models(scientists).run(),
+                        try! sqlDatabase.insert(into: ExpeditionDoctor.schema).models(doctors).run(),
+                    ], on: sqlDatabase.eventLoop)
+                }
+        } else {
+            return Expedition.query(on: database).all()
+                .and(Person.query(on: database).all())
+                .flatMap
+            { (expeditions, people) in
+                .andAllSucceed(expeditions.map { expedition in
+                    expedition.$officers.attach(people.pickRandomly(2), on: database)
+                        .and(expedition.$scientists.attach(people.pickRandomly(5), on: database))
+                        .and(expedition.$doctors.attach(people.pickRandomly(3), on: database))
+                        .map { _ in }
+                }, on: database.eventLoop)
+            }
         }
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
         .andAllSucceed([
             ExpeditionOfficer.query(on: database).delete(),
             ExpeditionScientist.query(on: database).delete(),

--- a/Sources/FluentKit/Database/TransactionControlDatabase.swift
+++ b/Sources/FluentKit/Database/TransactionControlDatabase.swift
@@ -1,9 +1,9 @@
 import NIOCore
 
 /// Protocol for describing a database that allows fine-grained control over transcactions
-/// when you need more control than provided by `Database.transaction(_:)`
+/// when you need more control than provided by ``Database/transaction(_:)-1x3ds``
 ///
-/// ⚠️ **WARNING**: it is the developer's responsiblity to get hold of a `DatabaseConnection`,
+/// ⚠️ **WARNING**: it is the developer's responsiblity to get hold of a ``Database``,
 /// execute the transaction functions on that connection, and ensure that the functions aren't called across
 /// different conenctions. You are also responsible for ensuring that you commit or rollback queries
 /// when you're ready.

--- a/Sources/FluentKit/Exports.swift
+++ b/Sources/FluentKit/Exports.swift
@@ -1,4 +1,17 @@
-#if !BUILDING_DOCC
+#if swift(>=5.8)
+
+@_documentation(visibility: internal) @_exported import struct Foundation.Date
+@_documentation(visibility: internal) @_exported import struct Foundation.UUID
+
+@_documentation(visibility: internal) @_exported import Logging
+
+@_documentation(visibility: internal) @_exported import protocol NIO.EventLoop
+@_documentation(visibility: internal) @_exported import class NIO.EventLoopFuture
+@_documentation(visibility: internal) @_exported import struct NIO.EventLoopPromise
+@_documentation(visibility: internal) @_exported import protocol NIO.EventLoopGroup
+@_documentation(visibility: internal) @_exported import class NIO.NIOThreadPool
+
+#elseif !BUILDING_DOCC
 
 @_exported import struct Foundation.Date
 @_exported import struct Foundation.UUID

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -19,7 +19,7 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible, CustomD
         case .missingParent(let model, let parent, let key, let id):
             return "parent missing: \(model).\(key): \(parent).\(id)"
         case .invalidField(let name, let valueType, let error):
-            return "invalid field: \(name) type: \(valueType) error: \(String(describing: error))"
+            return "invalid field: '\(name)', type: \(valueType), error: \(String(describing: error))"
         case .noResults:
             return "Query returned no results"
         }
@@ -30,7 +30,7 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible, CustomD
         case .idRequired, .missingField(_), .relationNotLoaded(_), .missingParent(_, _, _, _), .noResults:
             return self.description
         case .invalidField(let name, let valueType, let error):
-            return "invalid field: \(name) type: \(valueType) error: \(String(reflecting: error))"
+            return "invalid field: '\(name)', type: \(valueType), error: \(String(reflecting: error))"
         }
     }
 

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum FluentError: Error, LocalizedError, CustomStringConvertible {
+public enum FluentError: Error, LocalizedError, CustomStringConvertible, CustomDebugStringConvertible {
     case idRequired
     case invalidField(name: String, valueType: Any.Type, error: Error)
     case missingField(name: String)
@@ -19,9 +19,18 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible {
         case .missingParent(let model, let parent, let key, let id):
             return "parent missing: \(model).\(key): \(parent).\(id)"
         case .invalidField(let name, let valueType, let error):
-            return "invalid field: \(name) type: \(valueType) error: \(error)"
+            return "invalid field: \(name) type: \(valueType) error: \(String(describing: error))"
         case .noResults:
             return "Query returned no results"
+        }
+    }
+
+    public var debugDescription: String {
+        switch self {
+        case .idRequired, .missingField(_), .relationNotLoaded(_), .missingParent(_, _, _, _), .noResults:
+            return self.description
+        case .invalidField(let name, let valueType, let error):
+            return "invalid field: \(name) type: \(valueType) error: \(String(reflecting: error))"
         }
     }
 

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -136,8 +136,7 @@ private final class DatabaseMigrator {
 
     func setupIfNeeded() -> EventLoopFuture<Void> {
         return MigrationLog.migration.prepare(on: self.database)
-            .flatMap(self.preventUnstableNames)
-            .flatMap(self.fixPrereleaseMigrationNames)
+            .map(self.preventUnstableNames)
     }
 
     /// An unstable name is a name that is not the same every time migrations
@@ -145,67 +144,15 @@ private final class DatabaseMigrator {
     ///
     /// For example, the default name for `Migrations` in private contexts
     /// will include an identifier that can change from one execution to the next.
-    private func preventUnstableNames() -> EventLoopFuture<Void> {
-        for migration in self.migrations {
-            let migrationName = migration.name
-            guard migration.name == migration.defaultName else { continue }
-            guard migrationName.contains("$") else { continue }
-
-            if migrationName.contains("unknown context at") {
-                self.database.logger.critical("The migration at \(migrationName) is in a private context. Either explicitly give it a name by adding the `var name: String` property or make the migration `internal` or `public` instead of `private`.")
+    private func preventUnstableNames() {
+        for migration in self.migrations
+            where migration.name == migration.defaultName && migration.name.contains("$")
+        {
+            if migration.name.contains("unknown context at") {
+                self.database.logger.critical("The migration at \(migration.name) is in a private context. Either explicitly give it a name by adding the `var name: String` property or make the migration `internal` or `public` instead of `private`.")
                 fatalError("Private migrations not allowed")
             }
-            self.database.logger.error("The migration at \(migrationName) has an unexpected default name. Consider giving it an explicit name by adding a `var name: String` property before applying these migrations.")
-        }
-        return self.database.eventLoop.makeSucceededFuture(())
-    }
-
-    // This migration just exists to smooth the gap between
-    // how migrations were named between the first FluentKit 1
-    // alpha and the FluentKit 1.0.0 release.
-    // TODO: Remove in future version.
-    private func fixPrereleaseMigrationNames() -> EventLoopFuture<Void> {
-        // map from old style default names
-        // to new style default names
-        var migrationNameMap = [String: String]()
-
-        // a set of names that are manually
-        // chosen by migration author.
-        var nameOverrides = Set<String>()
-
-        for migration in self.migrations {
-            // if the migration does not override the default name
-            // then it is a candidate for a name change.
-            if migration.name == migration.defaultName {
-                let releaseCandidateDefaultName = "\(type(of: migration))"
-
-                migrationNameMap[releaseCandidateDefaultName] = migration.defaultName
-            } else {
-                nameOverrides.insert(migration.name)
-            }
-        }
-        // we must not rename anything that has an overridden
-        // name that happens to be the same as the old-style
-        // of default name.
-        for overriddenName in nameOverrides {
-            migrationNameMap.removeValue(forKey: overriddenName)
-        }
-
-        self.database.logger.debug("Checking for pre-release migration names.")
-        return MigrationLog.query(on: self.database).filter(\.$name ~~ migrationNameMap.keys).count().flatMap { count in
-            if count > 0 {
-                self.database.logger.info("Fixing pre-release migration names")
-                let queries = migrationNameMap.map { oldName, newName -> EventLoopFuture<Void> in
-                    self.database.logger.info("Renaming migration \(oldName) to \(newName)")
-                    return MigrationLog.query(on: self.database)
-                        .filter(\.$name == oldName)
-                        .set(\.$name, to: newName)
-                        .update()
-                }
-                return self.database.eventLoop.flatten(queries)
-            } else {
-                return self.database.eventLoop.makeSucceededFuture(())
-            }
+            self.database.logger.error("The migration at \(migration.name) has an unexpected default name. Consider giving it an explicit name by adding a `var name: String` property before applying these migrations.")
         }
     }
 

--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -1,4 +1,4 @@
-#if compiler(<5.9)
+#if compiler(<5.10)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
@@ -24,7 +24,7 @@ internal struct _FastChildIterator: IteratorProtocol {
         deinit { self.freeFunc(self.ptr) }
     }
     
-#if compiler(<5.9)
+#if compiler(<5.10)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -34,7 +34,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 #endif
     private var lastNameBox: _CStringBox?
     
-#if compiler(<5.9)
+#if compiler(<5.10)
     fileprivate init(subject: AnyObject, type: Any.Type, childCount: Int) {
         self.subject = subject
         self.type = type
@@ -48,7 +48,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 #endif
     
     init(subject: AnyObject) {
-#if compiler(<5.9)
+#if compiler(<5.10)
         let type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.init(
             subject: subject,
@@ -69,7 +69,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     /// - Note: Ironically, in the fallback case that uses `Mirror` directly, preserving this semantic actually imposes
     ///   an _additional_ performance penalty.
     mutating func next() -> (name: UnsafePointer<CChar>?, child: Any)? {
-#if compiler(<5.9)
+#if compiler(<5.10)
         guard self.index < self.childCount else {
             self.lastNameBox = nil // ensure any lingering name gets freed
             return nil
@@ -105,7 +105,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 }
 
 internal struct _FastChildSequence: Sequence {
-#if compiler(<5.9)
+#if compiler(<5.10)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -114,7 +114,7 @@ internal struct _FastChildSequence: Sequence {
 #endif
 
     init(subject: AnyObject) {
-#if compiler(<5.9)
+#if compiler(<5.10)
         self.subject = subject
         self.type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.childCount = _getChildCount(subject, type: self.type)
@@ -124,7 +124,7 @@ internal struct _FastChildSequence: Sequence {
     }
     
     func makeIterator() -> _FastChildIterator {
-#if compiler(<5.9)
+#if compiler(<5.10)
         return _FastChildIterator(subject: self.subject, type: self.type, childCount: self.childCount)
 #else
         return _FastChildIterator(iterator: self.children.makeIterator())

--- a/Sources/FluentSQL/Exports.swift
+++ b/Sources/FluentSQL/Exports.swift
@@ -1,4 +1,9 @@
-#if !BUILDING_DOCC
+#if swift(>=5.8)
+
+@_documentation(visibility: internal) @_exported import FluentKit
+@_documentation(visibility: internal) @_exported import SQLKit
+
+#elseif !BUILDING_DOCC
 
 @_exported import FluentKit
 @_exported import SQLKit


### PR DESCRIPTION
Changes:

- `FluentError` is now `CustomDebugStringConvertible`
- Fixes #542 by conditionally conforming `LoggingOverrideDatabase` to `SQLDatabase`
- Migration no longer spends time checking for prerelease migration names or allocating excess futures
- The `Mirror` bypass is now enabled for Swift 5.9
- Fluent benchmark suite now has much better error handling
- Fluent benchmarks now run ~5-10% faster (15% for all db drivers except MongoDB)