### PR TITLE
Enable using the attached model during pivot editing

### DIFF
--- a/.api-breakage/allowlist-branch-make-pivot-rhs-available-during-array-attach.txt
+++ b/.api-breakage/allowlist-branch-make-pivot-rhs-available-during-array-attach.txt
@@ -1,0 +1,1 @@
+API breakage: constructor PlanetTag.init(id:planetID:tagID:) has been removed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   push: { branches: [ main ] }
 
 env:
-  LOG_LEVEL: debug
+  LOG_LEVEL: info
   SWIFT_DETERMINISTIC_HASHING: 1
   POSTGRES_HOSTNAME: 'psql-a'
   POSTGRES_HOSTNAME_A: 'psql-a'

--- a/Sources/FluentBenchmark/SolarSystem/PlanetTag.swift
+++ b/Sources/FluentBenchmark/SolarSystem/PlanetTag.swift
@@ -14,13 +14,17 @@ public final class PlanetTag: Model {
 
     @Parent(key: "tag_id")
     public var tag: Tag
+    
+    @OptionalField(key: "comments")
+    public var comments: String?
 
     public init() { }
 
-    public init(id: IDValue? = nil, planetID: Planet.IDValue, tagID: Tag.IDValue) {
+    public init(id: IDValue? = nil, planetID: Planet.IDValue, tagID: Tag.IDValue, comments: String? = nil) {
         self.id = id
         self.$planet.id = planetID
         self.$tag.id = tagID
+        self.comments = comments
     }
 }
 
@@ -28,15 +32,18 @@ public struct PlanetTagMigration: Migration {
     public init() { }
 
     public func prepare(on database: Database) -> EventLoopFuture<Void> {
-        database.schema("planet+tag")
-            .field("id", .uuid, .identifier(auto: false))
-            .field("planet_id", .uuid, .required, .references("planets", "id"))
-            .field("tag_id", .uuid, .required, .references("tags", "id"))
+        database.schema(PlanetTag.schema)
+            .id()
+            .field("planet_id", .uuid, .required)
+            .field("tag_id", .uuid, .required)
+            .field("comments", .string)
+            .foreignKey("planet_id", references: Planet.schema, .id)
+            .foreignKey("tag_id", references: Tag.schema, .id)
             .create()
     }
 
     public func revert(on database: Database) -> EventLoopFuture<Void> {
-        database.schema("planet+tag").delete()
+        database.schema(PlanetTag.schema).delete()
     }
 }
 

--- a/Sources/FluentKit/Properties/Siblings.swift
+++ b/Sources/FluentKit/Properties/Siblings.swift
@@ -127,6 +127,7 @@ public final class SiblingsProperty<From, To, Through>
             let pivot = Through()
             pivot[keyPath: self.from].id = fromID
             pivot[keyPath: self.to].id = toID
+            pivot[keyPath: self.to].value = to
             edit(pivot)
             return pivot
         }.create(on: database)
@@ -180,6 +181,7 @@ public final class SiblingsProperty<From, To, Through>
         let pivot = Through()
         pivot[keyPath: self.from].id = fromID
         pivot[keyPath: self.to].id = toID
+        pivot[keyPath: self.to].value = to
         edit(pivot)
         return pivot.save(on: database)
     }


### PR DESCRIPTION
When using `Siblings.attach(_:on:_:)` with an editing closure, this code would historically crash with a fatal error:
```swift
planet.$tags.attach([tag1, tag2], on: database) { pivot in
    print(pivot.tag.name)
    // fatal error: Parent relation not eager loaded, use $ prefix to access: Parent<PlanetTag, Tag>(key: "tag_id")
}
```
The `attach()` methods now provide the "right-hand" side of the relation (e.g. `left.$siblings.attach([right1, right2])`) on the pivot model passed to the editing closure.

Unfortunately, due to limitations of Fluent's design and of property wrappers, it is not possible to also provide the "left-hand" side of the relation, but this is usually less of a concern. The expected use case for having the right-hand model available is to be able to get data from the right-hand model for setting properties of the pivot when attaching an array of siblings in one call. Without this change, this was only possible by matching the right-hand model's ID with one from the original input array. (This being said, this change affects the single-model version of `attach()` as well, since there is no drawback to doing so.)

This is a solely additive change; it has no effect whatsoever on what data goes into the database, and does not incur any additional speed or memory overhead.