### PR TITLE
Explicitly log migration errors

### DIFF
--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -206,6 +206,9 @@ private final class DatabaseMigrator {
         return migration.prepare(on: self.database).flatMap {
             self.database.logger.log(level: self.migrationLogLevel, "[Migrator] Finished prepare", metadata: ["migration": .string(migration.name)])
             return MigrationLog(name: migration.name, batch: batch).save(on: self.database)
+        }.flatMapErrorThrowing {
+            self.database.logger.error("[Migrator] Failed prepare: \(String(reflecting: $0))", metadata: ["migration": .string(migration.name)])
+            throw $0
         }
     }
 
@@ -214,6 +217,9 @@ private final class DatabaseMigrator {
         return migration.revert(on: self.database).flatMap {
             self.database.logger.log(level: self.migrationLogLevel, "[Migrator] Finished revert", metadata: ["migration": .string(migration.name)])
             return MigrationLog.query(on: self.database).filter(\.$name == migration.name).delete()
+        }.flatMapErrorThrowing {
+            self.database.logger.error("[Migrator] Failed revert: \(String(reflecting: $0))", metadata: ["migration": .string(migration.name)])
+            throw $0
         }
     }
 


### PR DESCRIPTION
This ensures errors thrown during migration (both prepare and revert) are fully logged regardless of the behavior of calling code.