### PR TITLE
added some missing `CustomStringConvertible` conformances

### DIFF
--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -54,6 +54,12 @@ extension EnumProperty: Property {
     }
 }
 
+extension EnumProperty: CustomStringConvertible {
+    public var description: String {
+        "@\(Model.self).Enum<\(Value.self)>(key: \(self.field.key))"
+    }
+}
+
 // MARK: Queryable
 
 extension EnumProperty: AnyQueryableProperty {

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -34,6 +34,12 @@ public final class OptionalEnumProperty<Model, WrappedValue>
     }
 }
 
+extension OptionalEnumProperty: CustomStringConvertible {
+    public var description: String {
+        "@\(Model.self).OptionalEnum<\(WrappedValue.self)>(key: \(self.field.key))"
+    }
+}
+
 // MARK: Property
 
 extension OptionalEnumProperty: AnyProperty { }

--- a/Sources/FluentKit/Properties/Boolean.swift
+++ b/Sources/FluentKit/Properties/Boolean.swift
@@ -68,6 +68,12 @@ public final class BooleanProperty<Model, Format>
     }
 }
 
+extension BooleanProperty: CustomStringConvertible {
+    public var description : String {
+        "@\(Model.self).Boolean(key: \(self.$field.key), format: \(self.format))"
+    }
+}
+
 extension BooleanProperty where Format == DefaultBooleanPropertyFormat {
     public convenience init(key: FieldKey) {
         self.init(key: key, format: .default)

--- a/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
+++ b/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
@@ -1,5 +1,5 @@
 /// A conversion between `Bool` and an arbitrary alternative storage format, usually a string.
-public protocol BooleanPropertyFormat {
+public protocol BooleanPropertyFormat : CustomStringConvertible {
     associatedtype Value: Codable
 
     init()
@@ -23,6 +23,10 @@ public struct DefaultBooleanPropertyFormat: BooleanPropertyFormat {
 
 extension BooleanPropertyFormat where Self == DefaultBooleanPropertyFormat {
     public static var `default`: Self { .init() }
+    
+    public var description: String {
+        return "default"
+    }
 }
 
 /// Represent a `Bool` as any integer type. Any value other than `0` or `1` is considered invalid.
@@ -43,6 +47,10 @@ public struct IntegerBooleanPropertyFormat<T: FixedWidthInteger & Codable>: Bool
     
     public func serialize(_ bool: Bool) -> T {
         return .zero.advanced(by: bool ? 1 : 0)
+    }
+    
+    public var description: String {
+        return "integer"
     }
 }
 
@@ -69,6 +77,10 @@ public struct OneZeroBooleanPropertyFormat: BooleanPropertyFormat {
 
 extension BooleanPropertyFormat where Self == OneZeroBooleanPropertyFormat {
     public static var oneZero: Self { .init() }
+    
+    public var description: String {
+        return "oneZero"
+    }
 }
 
 /// Represent a `Bool` as the strings "N" and "Y". Parsing is case-insensitive. Serialization always stores uppercase.
@@ -90,6 +102,10 @@ public struct YNBooleanPropertyFormat: BooleanPropertyFormat {
 
 extension BooleanPropertyFormat where Self == YNBooleanPropertyFormat {
     public static var yn: Self { .init() }
+    
+    public var description: String {
+        return "yn"
+    }
 }
 
 
@@ -112,6 +128,10 @@ public struct YesNoBooleanPropertyFormat: BooleanPropertyFormat {
 
 extension BooleanPropertyFormat where Self == YesNoBooleanPropertyFormat {
     public static var yesNo: Self { .init() }
+    
+    public var description: String {
+        return "yesNo"
+    }
 }
 
 /// Represent a `Bool` as the strings "OFF" and "ON". Parsing is case-insensitive. Serialization always stores uppercase.
@@ -133,6 +153,10 @@ public struct OnOffBooleanPropertyFormat: BooleanPropertyFormat {
 
 extension BooleanPropertyFormat where Self == OnOffBooleanPropertyFormat {
     public static var onOff: Self { .init() }
+    
+    public var description: String {
+        return "onOff"
+    }
 }
 
 /// Represent a `Bool` as the strings "false" and "true". Parsing is case-insensitive. Serialization always stores lowercase.
@@ -154,6 +178,10 @@ public struct TrueFalseBooleanPropertyFormat: BooleanPropertyFormat {
 
 extension BooleanPropertyFormat where Self == TrueFalseBooleanPropertyFormat {
     public static var trueFalse: Self { .init() }
+    
+    public var description: String {
+        return "trueFalse"
+    }
 }
 
 /// This is a workaround for Swift 5.4's inability to correctly infer the format type

--- a/Sources/FluentKit/Properties/OptionalBoolean.swift
+++ b/Sources/FluentKit/Properties/OptionalBoolean.swift
@@ -68,6 +68,12 @@ public final class OptionalBooleanProperty<Model, Format>
     }
 }
 
+extension OptionalBooleanProperty: CustomStringConvertible {
+    public var description : String {
+        "@\(Model.self).OptionalBoolean(key: \(self.$field.key), format: \(self.format))"
+    }
+}
+
 extension OptionalBooleanProperty where Format == DefaultBooleanPropertyFormat {
     public convenience init(key: FieldKey) {
         self.init(key: key, format: .default)

--- a/Sources/FluentKit/Properties/OptionalField.swift
+++ b/Sources/FluentKit/Properties/OptionalField.swift
@@ -31,6 +31,12 @@ public final class OptionalFieldProperty<Model, WrappedValue>
     }
 }
 
+extension OptionalFieldProperty: CustomStringConvertible {
+    public var description : String {
+        "@\(Model.self).OptionalField<\(WrappedValue.self)>(key: \(self.key))"
+    }
+}
+
 // MARK: Property
 
 extension OptionalFieldProperty: AnyProperty { }

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -16,13 +16,13 @@ public protocol AnyParentProperty : CustomStringConvertible,
     var id : To.IDValue { get set }
     var wrappedValue : To { get }
     var projectedValue : Self { get }
-    var value_type : To.Type { get }
+    var valueType : To.Type { get }
     
     init(key: FieldKey)
     func query(on database: Database) -> QueryBuilder<To>
 }
 public extension AnyParentProperty {
-    var value_type : To.Type {
+    var valueType : To.Type {
         return To.self
     }
     

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -7,89 +7,8 @@ extension Model {
 
 // MARK: Type
 
-public protocol AnyParentProperty : CustomStringConvertible,
-                                    AnyProperty, Property,
-                                    Relation,
-                                    AnyQueryAddressableProperty, QueryAddressableProperty, AnyDatabaseProperty, AnyCodableProperty,
-                                    EagerLoadable where Model == From, Value == To
-{
-    var id : To.IDValue { get set }
-    var wrappedValue : To { get }
-    var projectedValue : Self { get }
-    var valueType : To.Type { get }
-    
-    init(key: FieldKey)
-    func query(on database: Database) -> QueryBuilder<To>
-}
-public extension AnyParentProperty {
-    var valueType : To.Type {
-        return To.self
-    }
-    
-    // MARK: CustomStringConvertible
-    var description : String {
-        self.name
-    }
-    
-    // MARK: Relation
-    func load(on database: Database) -> EventLoopFuture<Void> {
-        self.query(on: database).first().map {
-            self.value = $0
-        }
-    }
-    
-    // MARK: AnyCodableProperty
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        if let parent:To = self.value {
-            try container.encode(parent)
-        } else {
-            try container.encode([
-                "id": self.id
-            ])
-        }
-    }
-    
-    // MARK: Eager Loadable
-    static func eagerLoad<Builder>(
-        _ relationKey: KeyPath<From, ParentProperty<From, To>>,
-        to builder: Builder
-    )
-        where Builder : EagerLoadBuilder, From == Builder.Model
-    {
-        self.eagerLoad(relationKey, withDeleted: false, to: builder)
-    }
-    
-    static func eagerLoad<Builder>(
-        _ relationKey: KeyPath<From, From.Parent<To>>,
-        withDeleted: Bool,
-        to builder: Builder
-    )
-        where Builder: EagerLoadBuilder, Builder.Model == From
-    {
-        let loader = ParentEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
-        builder.add(loader: loader)
-    }
-
-
-    static func eagerLoad<Loader, Builder>(
-        _ loader: Loader,
-        through: KeyPath<From, From.Parent<To>>,
-        to builder: Builder
-    ) where
-        Loader: EagerLoader,
-        Loader.Model == To,
-        Builder: EagerLoadBuilder,
-        Builder.Model == From
-    {
-        let loader = ThroughParentEagerLoader(relationKey: through, loader: loader)
-        builder.add(loader: loader)
-    }
-}
-
-
 @propertyWrapper
-public final class ParentProperty<From, To> : AnyParentProperty
+public final class ParentProperty<From, To>
     where From: Model, To: Model
 {
     @FieldProperty<From, To.IDValue>
@@ -125,12 +44,33 @@ public final class ParentProperty<From, To> : AnyParentProperty
     }
 }
 
+extension ParentProperty: CustomStringConvertible {
+    public var description: String {
+        self.name
+    }
+}
+
 // MARK: Relation
 
 extension ParentProperty: Relation {
     public var name: String {
         "Parent<\(From.self), \(To.self)>(key: \(self.$id.key))"
     }
+
+    public func load(on database: Database) -> EventLoopFuture<Void> {
+        self.query(on: database).first().map {
+            self.value = $0
+        }
+    }
+}
+
+// MARK: Property
+
+extension ParentProperty: AnyProperty { }
+
+extension ParentProperty: Property {
+    public typealias Model = From
+    public typealias Value = To
 }
 
 // MARK: Query-addressable
@@ -161,6 +101,17 @@ extension ParentProperty: AnyDatabaseProperty {
 }
 
 extension ParentProperty: AnyCodableProperty {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        if let parent = self.value {
+            try container.encode(parent)
+        } else {
+            try container.encode([
+                "id": self.id
+            ])
+        }
+    }
+
     public func decode(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: SomeCodingKey.self)
         try self.$id.decode(from: container.superDecoder(forKey: .init(stringValue: "id")))
@@ -168,6 +119,43 @@ extension ParentProperty: AnyCodableProperty {
 }
 
 // MARK: Eager Loadable
+
+extension ParentProperty: EagerLoadable {
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, ParentProperty<From, To>>,
+        to builder: Builder
+    )
+        where Builder : EagerLoadBuilder, From == Builder.Model
+    {
+        self.eagerLoad(relationKey, withDeleted: false, to: builder)
+    }
+    
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, From.Parent<To>>,
+        withDeleted: Bool,
+        to builder: Builder
+    )
+        where Builder: EagerLoadBuilder, Builder.Model == From
+    {
+        let loader = ParentEagerLoader(relationKey: relationKey, withDeleted: withDeleted)
+        builder.add(loader: loader)
+    }
+
+
+    public static func eagerLoad<Loader, Builder>(
+        _ loader: Loader,
+        through: KeyPath<From, From.Parent<To>>,
+        to builder: Builder
+    ) where
+        Loader: EagerLoader,
+        Loader.Model == To,
+        Builder: EagerLoadBuilder,
+        Builder.Model == From
+    {
+        let loader = ThroughParentEagerLoader(relationKey: through, loader: loader)
+        builder.add(loader: loader)
+    }
+}
 
 private struct ParentEagerLoader<From, To>: EagerLoader
     where From: FluentKit.Model, To: FluentKit.Model

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -7,8 +7,27 @@ extension Model {
 
 // MARK: Type
 
+public protocol AnyParentProperty {
+    associatedtype From : Model
+    associatedtype To : Model
+    
+    var id : To.IDValue { get set }
+    var wrappedValue : To { get }
+    var projectedValue : Self { get }
+    var value : To? { get set }
+    var value_type : To.Type { get }
+    
+    init(key: FieldKey)
+    func query(on database: Database) -> QueryBuilder<To>
+}
+public extension AnyParentProperty {
+    var value_type : To.Type {
+        return To.self
+    }
+}
+
 @propertyWrapper
-public final class ParentProperty<From, To>
+public final class ParentProperty<From, To> : AnyParentProperty
     where From: Model, To: Model
 {
     @FieldProperty<From, To.IDValue>


### PR DESCRIPTION
Some properties already conform to this protocol, but I found some that do not. This fixes a case where getting the description of an `AnyProperty` will not be in the correct format, and also missing the key.

## Changes
- updated 5 properties: `OptionalBooleanProperty`, `BooleanProperty`, `OptionalFieldProperty`, `EnumProperty`, and `OptionalEnumProperty`
- updated 1 protocol (and its default implementations): `BooleanPropertyFormat`

## Examples
- an `@Enum` would return `FluentKit.EnumProperty<X, Y>`. Now returns `@X.Enum<Y>(key: Z)`
- an `@OptionalField` would return `FluentKit.OptionalFieldProperty<X, Y>`. Now returns `@X.OptionalField<Y>(key: Z)`

## Unit Testing
- This commit passed unit tests, except sometimes `FluentKitTests.testAnyModelDescriptionFormatHasNotChanged`, even though the data is the same, just in a different order (this test also fails even before this commit)

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
