### PR TITLE
Handle aggregate types a very tiny bit better

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Aggregate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Aggregate.swift
@@ -25,48 +25,56 @@ extension QueryBuilder {
         self.aggregate(.count, key, as: Int.self)
     }
 
+    // TODO: `Field.Value` is not always the correct result type for `SUM()`, try `.aggregate(.sum, key, as: ...)` for now
     public func sum<Field>(_ key: KeyPath<Model, Field>) -> EventLoopFuture<Field.Value?>
         where Field: QueryableProperty, Field.Model == Model
     {
         self.aggregate(.sum, key)
     }
 
+    // TODO: `Field.Value` is not always the correct result type for `SUM()`, try `.aggregate(.sum, key, as: ...)` for now
     public func sum<Field>(_ key: KeyPath<Model, Field>) -> EventLoopFuture<Field.Value?>
         where Field: QueryableProperty, Field.Model == Model.IDValue
     {
         self.aggregate(.sum, key)
     }
 
+    // TODO: `Field.Value` is not always the correct result type for `SUM()`, try `.aggregate(.sum, key, as: ...)` for now
     public func sum<Field>(_ key: KeyPath<Model, Field>) -> EventLoopFuture<Field.Value>
         where Field: QueryableProperty, Field.Value: OptionalType, Field.Model == Model
     {
         self.aggregate(.sum, key)
     }
 
+    // TODO: `Field.Value` is not always the correct result type for `SUM()`, try `.aggregate(.sum, key, as: ...)` for now
     public func sum<Field>(_ key: KeyPath<Model, Field>) -> EventLoopFuture<Field.Value>
         where Field: QueryableProperty, Field.Value: OptionalType, Field.Model == Model.IDValue
     {
         self.aggregate(.sum, key)
     }
 
+    // TODO: `Field.Value` is not always the correct result type for `AVG()`, try `.aggregate(.average, key, as: ...)` for now
     public func average<Field>(_ key: KeyPath<Model, Field>) -> EventLoopFuture<Field.Value?>
         where Field: QueryableProperty, Field.Model == Model
     {
         self.aggregate(.average, key)
     }
 
+    // TODO: `Field.Value` is not always the correct result type for `AVG()`, try `.aggregate(.average, key, as: ...)` for now
     public func average<Field>(_ key: KeyPath<Model, Field>) -> EventLoopFuture<Field.Value?>
         where Field: QueryableProperty, Field.Model == Model.IDValue
     {
         self.aggregate(.average, key)
     }
 
+    // TODO: `Field.Value` is not always the correct result type for `AVG()`, try `.aggregate(.average, key, as: ...)` for now
     public func average<Field>(_ key: KeyPath<Model, Field>) -> EventLoopFuture<Field.Value>
         where Field: QueryableProperty, Field.Value: OptionalType, Field.Model == Model
     {
         self.aggregate(.average, key)
     }
 
+    // TODO: `Field.Value` is not always the correct result type for `AVG()`, try `.aggregate(.average, key, as: ...)` for now
     public func average<Field>(_ key: KeyPath<Model, Field>) -> EventLoopFuture<Field.Value>
         where Field: QueryableProperty, Field.Value: OptionalType, Field.Model == Model.IDValue
     {
@@ -124,7 +132,7 @@ extension QueryBuilder {
     public func aggregate<Field, Result>(
         _ method: DatabaseQuery.Aggregate.Method,
         _ field: KeyPath<Model, Field>,
-        as type: Result.Type = Result.self
+        as: Result.Type = Result.self
     ) -> EventLoopFuture<Result>
         where Field: QueryableProperty, Field.Model == Model, Result: Codable
     {
@@ -134,7 +142,7 @@ extension QueryBuilder {
     public func aggregate<Field, Result>(
         _ method: DatabaseQuery.Aggregate.Method,
         _ field: KeyPath<Model, Field>,
-        as type: Result.Type = Result.self
+        as: Result.Type = Result.self
     ) -> EventLoopFuture<Result>
         where Field: QueryableProperty, Field.Model == Model.IDValue, Result: Codable
     {
@@ -145,29 +153,32 @@ extension QueryBuilder {
     public func aggregate<Result>(
         _ method: DatabaseQuery.Aggregate.Method,
         _ field: FieldKey,
-        as type: Result.Type = Result.self
+        as: Result.Type = Result.self
     ) -> EventLoopFuture<Result>
         where Result: Codable
     {
-        self.aggregate(method, [field])
+        self.aggregate(method, [field], as: Result.self)
     }
 
     public func aggregate<Result>(
         _ method: DatabaseQuery.Aggregate.Method,
         _ path: [FieldKey],
-        as type: Result.Type = Result.self
+        as: Result.Type = Result.self
     ) -> EventLoopFuture<Result>
         where Result: Codable
     {
-        self.aggregate(.field(
-            .extendedPath(path, schema: Model.schemaOrAlias, space: Model.spaceIfNotAliased),
-            method
-        ))
+        self.aggregate(
+            .field(
+                .extendedPath(path, schema: Model.schemaOrAlias, space: Model.spaceIfNotAliased),
+                method
+            ),
+            as: Result.self
+        )
     }
     
     public func aggregate<Result>(
         _ aggregate: DatabaseQuery.Aggregate,
-        as type: Result.Type = Result.self
+        as: Result.Type = Result.self
     ) -> EventLoopFuture<Result>
         where Result: Codable
     {


### PR DESCRIPTION
This just adds explicit forwarding of the generic `Result` parameter of the two `QueryBuilder.aggregate()` variants which weren't doing so already. It was already being implicitly forwarded due to type inference, but better to do so explicitly.

Also adds notes to the `sum()` and `average()` sets of methods warning that the `Field.Value` return types are not always correct (usually only causes problems with Postgres) and giving the workaround. This is related to #379 and vapor/fluent-postgres-driver#166 but does NOT fix those issues; it only clarifies one of the ways to get around the problem.