### PR TITLE
Add possibility of nested eager load builder to throw

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+EagerLoad.swift
@@ -27,13 +27,13 @@ extension EagerLoadBuilder {
     @discardableResult
     public func with<Relation>(
         _ throughKey: KeyPath<Model, Relation>,
-        _ nested: (NestedEagerLoadBuilder<Self, Relation>) -> ()
-    ) -> Self
+        _ nested: (NestedEagerLoadBuilder<Self, Relation>) throws -> ()
+    ) rethrows -> Self
         where Relation: EagerLoadable, Relation.From == Model
     {
         Relation.eagerLoad(throughKey, to: self)
         let builder = NestedEagerLoadBuilder<Self, Relation>(builder: self, throughKey)
-        nested(builder)
+        try nested(builder)
         return self
     }
     
@@ -52,13 +52,13 @@ extension EagerLoadBuilder {
     public func with<Relation>(
         _ throughKey: KeyPath<Model, Relation>,
         withDeleted: Bool,
-        _ nested: (NestedEagerLoadBuilder<Self, Relation>) -> ()
-    ) -> Self
+        _ nested: (NestedEagerLoadBuilder<Self, Relation>) throws -> ()
+    ) rethrows -> Self
         where Relation: EagerLoadable, Relation.From == Model
     {
         Relation.eagerLoad(throughKey, withDeleted: withDeleted, to: self)
         let builder = NestedEagerLoadBuilder<Self, Relation>(builder: self, throughKey)
-        nested(builder)
+        try nested(builder)
         return self
     }
 }


### PR DESCRIPTION
This PR adds the possibility of throwing inside the block that adds nested eager loaders.
I need this because I add eager loading as needed depending on fields (user input), recursively, and I don’t know before it’s too late whether my fields are valid.

As the `with` functions that are modified are marked as `rethrows`, this should have no impact on existing code and should not require a major version bump.  