### PR TITLE
Fix a test migration missing an important deletion in its revert

### DIFF
--- a/Sources/FluentBenchmark/Tests/SetTests.swift
+++ b/Sources/FluentBenchmark/Tests/SetTests.swift
@@ -102,7 +102,9 @@ private struct Test2Migration: FluentKit.Migration {
     }
 
     func revert(on database: Database) -> EventLoopFuture<Void> {
-        database.schema("test").delete()
+        database.schema("test").delete().flatMap {
+            database.enum("foo").delete()
+        }
     }
 }
 


### PR DESCRIPTION
This bug was being hidden by a quirk of the old `EventLoopConnectionPool` implementation and MySQL's semantics, and was finally revealed by vapor/async-kit#102.