### PR TITLE
Allow pivot editing closures to be async and throwing.

### DIFF
--- a/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
@@ -2,57 +2,104 @@ import NIOCore
 
 public extension SiblingsProperty {
     
-    func load(on database: Database) async throws {
+    func load(on database: any Database) async throws {
         try await self.load(on: database).get()
     }
     
     // MARK: Checking state
     
-    func isAttached(to: To, on database: Database) async throws -> Bool {
+    func isAttached(to: To, on database: any Database) async throws -> Bool {
         try await self.isAttached(to: to, on: database).get()
     }
     
-    func isAttached(toID: To.IDValue, on database: Database) async throws -> Bool {
+    func isAttached(toID: To.IDValue, on database: any Database) async throws -> Bool {
         try await self.isAttached(toID: toID, on: database).get()
     }
     
     // MARK: Operations
     
-    func attach(
-        _ tos: [To],
-        on database: Database,
-        _ edit: (Through) -> () = { _ in }
-    ) async throws {
+    /// Attach multiple models with plain edit closure.
+    func attach(_ tos: [To], on database: any Database, _ edit: (Through) -> () = { _ in }) async throws {
         try await self.attach(tos, on: database, edit).get()
     }
+
+    /// Attach single model with plain edit closure.
+    func attach(_ to: To, on database: any Database, _ edit: @escaping (Through) -> ()) async throws {
+        try await self.attach(to, method: .always, on: database, edit)
+    }
     
+    /// Attach single model by specific method with plain edit closure.
     func attach(
-        _ to: To,
-        method: AttachMethod,
-        on database: Database,
+        _ to: To, method: AttachMethod, on database: any Database,
         _ edit: @escaping (Through) -> () = { _ in }
     ) async throws {
         try await self.attach(to, method: method, on: database, edit).get()
     }
     
+    /// A version of ``attach(_:on:_:)-791gu`` whose edit closure is async and can throw.
+    ///
+    /// This method provides "all or none" semantics- if the edit closure throws an error, any already-
+    /// processed pivots are discarded. Only if all pivots are successfully edited are any of them saved.
+    ///
+    /// These semantics require us to reimplement, rather than calling through to, the ELF version.
     func attach(
-        _ to: To,
-        on database: Database,
-        _ edit: (Through) -> () = { _ in }
+        _ tos: [To],
+        on database: any Database,
+        _ edit: @Sendable @escaping (Through) async throws -> ()
     ) async throws {
-        try await self.attach(to, on: database, edit).get()
+        guard let fromID = self.idValue else {
+            throw SiblingsPropertyError.owningModelIdRequired(property: self.name)
+        }
+        
+        var pivots: [Through] = []
+        pivots.reserveCapacity(tos.count)
+        
+        for to in tos {
+            guard let toID = to.id else {
+                throw SiblingsPropertyError.operandModelIdRequired(property: self.name)
+            }
+            let pivot = Through()
+            pivot[keyPath: self.from].id = fromID
+            pivot[keyPath: self.to].id = toID
+            pivot[keyPath: self.to].value = to
+            try await edit(pivot)
+            pivots.append(pivot)
+        }
+        try await pivots.create(on: database)
+    }
+
+    /// A version of ``attach(_:on:_:)-791gu`` whose edit closure is async and can throw.
+    ///
+    /// These semantics require us to reimplement, rather than calling through to, the ELF version.
+    func attach(_ to: To, on database: any Database, _ edit: @Sendable @escaping (Through) async throws -> ()) async throws {
+        try await self.attach(to, method: .always, on: database, edit)
     }
     
+    /// A version of ``attach(_:method:on:_:)-20vs`` whose edit closure is async and can throw.
+    ///
+    /// These semantics require us to reimplement, rather than calling through to, the ELF version.
+    func attach(
+        _ to: To, method: AttachMethod, on database: any Database,
+        _ edit: @Sendable @escaping (Through) async throws -> ()
+    ) async throws {
+        switch method {
+        case .ifNotExists:
+            guard try await !self.isAttached(to: to, on: database) else { return }
+            fallthrough
+        case .always:
+            try await self.attach([to], on: database, edit)
+        }
+    }
     
-    func detach(_ tos: [To], on database: Database) async throws {
+    func detach(_ tos: [To], on database: any Database) async throws {
         try await self.detach(tos, on: database).get()
     }
     
-    func detach(_ to: To, on database: Database) async throws {
+    func detach(_ to: To, on database: any Database) async throws {
         try await self.detach(to, on: database).get()
     }
     
-    func detachAll(on database: Database) async throws {
+    func detachAll(on database: any Database) async throws {
         try await self.detachAll(on: database).get()
     }
 }

--- a/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Siblings+Concurrency.swift
@@ -24,7 +24,7 @@ public extension SiblingsProperty {
     }
 
     /// Attach single model with plain edit closure.
-    func attach(_ to: To, on database: any Database, _ edit: @escaping (Through) -> ()) async throws {
+    func attach(_ to: To, on database: any Database, _ edit: @escaping (Through) -> () = { _ in }) async throws {
         try await self.attach(to, method: .always, on: database, edit)
     }
     

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum FluentError: Error, LocalizedError, CustomNSError, CustomStringConvertible, CustomDebugStringConvertible {
+public enum FluentError: Error, LocalizedError, CustomStringConvertible, CustomDebugStringConvertible {
     case idRequired
     case invalidField(name: String, valueType: Any.Type, error: Error)
     case missingField(name: String)
@@ -45,29 +45,6 @@ public enum FluentError: Error, LocalizedError, CustomNSError, CustomStringConve
     public var failureReason: String? {
         self.description
     }
-    
-    // `CustomNSError` conformance
-    public static var errorDomain: String {
-        "codes.vapor.FluentKit.FluentErrorDomain"
-    }
-    
-    // `CustomNSError` conformance
-    public var errorCode: Int {
-        switch self {
-        case .idRequired: return 1
-        case .invalidField: return 2
-        case .missingField: return 3
-        case .relationNotLoaded: return 4
-        case .missingParent: return 5
-        case .noResults: return 6
-        }
-    }
-    
-    // `CustomNSError` conformance
-    public var errorUserInfo: [String: Any] { [
-        NSLocalizedDescriptionKey: self.description,
-        NSLocalizedFailureReasonErrorKey: self.description,
-    ] }
 }
 
 extension FluentError {
@@ -121,7 +98,7 @@ extension FluentError {
 /// > Note: This should just be another case on ``FluentError``, not a separate error type, but at the time
 ///   of this writing, non-frozen enums are still not available to non-stdlib packages, so to avoid source
 ///   breakage we chose this as the least annoying of the several annoying workarounds.
-public enum SiblingsPropertyError: Error, LocalizedError, CustomNSError, CustomStringConvertible, CustomDebugStringConvertible {
+public enum SiblingsPropertyError: Error, LocalizedError, CustomStringConvertible, CustomDebugStringConvertible {
     /// An attempt was made to query, attach to, or detach from a siblings property whose owning model's ID
     /// is not currently known (usually because that model has not yet been saved to the database).
     ///
@@ -156,24 +133,4 @@ public enum SiblingsPropertyError: Error, LocalizedError, CustomNSError, CustomS
 
     // `LocalizedError` conformance.
     public var failureReason: String? { self.description }
-
-    // `CustomNSError` conformance
-    public static var errorDomain: String {
-        // N.B.: Presents as FluentError, as far as the NSError machinery is concerned
-        "codes.vapor.FluentKit.FluentErrorDomain"
-    }
-    
-    // `CustomNSError` conformance
-    public var errorCode: Int {
-        switch self {
-        case .owningModelIdRequired: return 7
-        case .operandModelIdRequired: return 8
-        }
-    }
-    
-    // `CustomNSError` conformance
-    public var errorUserInfo: [String: Any] { [
-        NSLocalizedDescriptionKey: self.description,
-        NSLocalizedFailureReasonErrorKey: self.description,
-    ] }
 }

--- a/Sources/XCTFluent/DummyDatabase.swift
+++ b/Sources/XCTFluent/DummyDatabase.swift
@@ -97,6 +97,8 @@ public struct DummyRow: DatabaseOutput {
     {
         if T.self is UUID.Type {
             return UUID() as! T
+        } else if T.self is Int.Type, key == .aggregate {
+            return 1 as! T
         } else {
             return try T(from: DummyDecoder())
         }


### PR DESCRIPTION
When using the `attach(_:method:on:_:)` and `attach(_:on:_:)` methods of `SiblingsProperty`, the optional closure provided to allow editing new pivots before they are saved can now optionally be both `throws` and `async`.

Closes #581.

Additional changes:

- All versions of the `isAttached()`, `attach()`, and `detach()` methods of `SiblingsProperty` will now throw errors (specifically cases of the new `SiblingsPropertyError` enum) instead of calling `fatalError()` when an unsaved model is encountered.
- The `isAttached()` method now uses a much faster and more efficient query to check whether a pivot already exists for the given model.