### PR TITLE
Add `@discardableResult` to QueryBuilder's range and sort methods

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Range.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Range.swift
@@ -6,6 +6,7 @@ extension QueryBuilder {
     ///     query.range(2..<5) // returns at most 3 results, offset by 2
     ///
     /// - returns: Query builder for chaining.
+    @discardableResult
     public func range(_ range: Range<Int>) -> Self {
         return self.range(lower: range.lowerBound, upper: range.upperBound - 1)
     }
@@ -15,6 +16,7 @@ extension QueryBuilder {
     ///     query.range(...5) // returns at most 6 results
     ///
     /// - returns: Query builder for chaining.
+    @discardableResult
     public func range(_ range: PartialRangeThrough<Int>) -> Self {
         return self.range(upper: range.upperBound)
     }
@@ -24,6 +26,7 @@ extension QueryBuilder {
     ///     query.range(..<5) // returns at most 5 results
     ///
     /// - returns: Query builder for chaining.
+    @discardableResult
     public func range(_ range: PartialRangeUpTo<Int>) -> Self {
         return self.range(upper: range.upperBound - 1)
     }
@@ -33,6 +36,7 @@ extension QueryBuilder {
     ///     query.range(5...) // offsets the result by 5
     ///
     /// - returns: Query builder for chaining.
+    @discardableResult
     public func range(_ range: PartialRangeFrom<Int>) -> Self {
         return self.range(lower: range.lowerBound)
     }
@@ -42,6 +46,7 @@ extension QueryBuilder {
     ///     query.range(2..<5) // returns at most 3 results, offset by 2
     ///
     /// - returns: Query builder for chaining.
+    @discardableResult
     public func range(_ range: ClosedRange<Int>) -> Self {
         return self.range(lower: range.lowerBound, upper: range.upperBound)
     }
@@ -52,6 +57,7 @@ extension QueryBuilder {
     ///     - lower: Amount to offset the query by.
     ///     - upper: `upper` - `lower` = maximum results.
     /// - returns: Query builder for chaining.
+    @discardableResult
     public func range(lower: Int = 0, upper: Int? = nil) -> Self {
         self.query.offsets.append(.count(lower))
         upper.flatMap { upper in

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Sort.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Sort.swift
@@ -1,6 +1,7 @@
 extension QueryBuilder {
     // MARK: Sort
 
+    @discardableResult
     public func sort<Field>(
         _ field: KeyPath<Model, Field>,
         _ direction: DatabaseQuery.Sort.Direction = .ascending
@@ -12,6 +13,7 @@ extension QueryBuilder {
         self.sort(Model.path(for: field), direction)
     }
 
+    @discardableResult
     public func sort<Field>(
         _ field: KeyPath<Model, GroupPropertyPath<Model, Field>>,
         _ direction: DatabaseQuery.Sort.Direction = .ascending
@@ -21,6 +23,7 @@ extension QueryBuilder {
         self.sort(Model.path(for: field), direction)
     }
 
+    @discardableResult
     public func sort(
         _ path: FieldKey,
         _ direction: DatabaseQuery.Sort.Direction = .ascending
@@ -28,6 +31,7 @@ extension QueryBuilder {
         self.sort([path], direction)
     }
 
+    @discardableResult
     public func sort(
         _ path: [FieldKey],
         _ direction: DatabaseQuery.Sort.Direction = .ascending
@@ -35,6 +39,7 @@ extension QueryBuilder {
         self.sort(.extendedPath(path, schema: Model.schemaOrAlias, space: Model.spaceIfNotAliased), direction)
     }
 
+    @discardableResult
     public func sort<Joined, Field>(
         _ joined: Joined.Type,
         _ field: KeyPath<Joined, Field>,
@@ -49,6 +54,7 @@ extension QueryBuilder {
         self.sort(Joined.self, Joined.path(for: field), direction, alias: alias)
     }
     
+    @discardableResult
     public func sort<Joined>(
         _ model: Joined.Type,
         _ path: FieldKey,
@@ -60,6 +66,7 @@ extension QueryBuilder {
         self.sort(Joined.self, [path], direction)
     }
 
+    @discardableResult
     public func sort<Joined>(
         _ model: Joined.Type,
         _ path: [FieldKey],
@@ -71,6 +78,7 @@ extension QueryBuilder {
         self.sort(.extendedPath(path, schema: Joined.schemaOrAlias, space: Joined.spaceIfNotAliased), direction)
     }
 
+    @discardableResult
     public func sort(
         _ field: DatabaseQuery.Field,
         _ direction: DatabaseQuery.Sort.Direction
@@ -79,6 +87,7 @@ extension QueryBuilder {
         return self
     }
 
+    @discardableResult
     public func sort(_ sort: DatabaseQuery.Sort) -> Self {
         self.query.sorts.append(sort)
         return self


### PR DESCRIPTION
This Pull Request addresses an issue where calling the sort methods in the QueryBuilder class would result in a "Result of call to 'sort' is unused" warning. To resolve this, I have added the @discardableResult attribute to these methods, allowing users to call them without triggering the warning when the result is not explicitly used.