### PR TITLE
Relax restrictions on ModelAlias use and join conditions

### DIFF
--- a/Sources/FluentBenchmark/Tests/JoinTests.swift
+++ b/Sources/FluentBenchmark/Tests/JoinTests.swift
@@ -224,6 +224,12 @@ extension FluentBenchmarker {
                 .all().wait()
             
             XCTAssertFalse(planets.isEmpty)
+            
+            let morePlanets = try Planet.query(on: self.database)
+                .join(Star.self, on: \Planet.$star.$id == \Star.$id && \Star.$name != "Sun")
+                .all().wait()
+            
+            XCTAssertEqual(morePlanets.count, 1)
         }
     }
 }

--- a/Sources/FluentKit/Database/Database+Logging.swift
+++ b/Sources/FluentKit/Database/Database+Logging.swift
@@ -61,5 +61,5 @@ extension LoggingOverrideDatabase: SQLDatabase where D: SQLDatabase {
         self.database.execute(sql: query, onRow)
     }
     var dialect: SQLDialect { self.database.dialect }
-    var version: SQLDatabaseReportedVersion? { self.database.version }
+    var version: (any SQLDatabaseReportedVersion)? { self.database.version }
 }

--- a/Sources/FluentKit/Operators/FieldOperators.swift
+++ b/Sources/FluentKit/Operators/FieldOperators.swift
@@ -177,7 +177,7 @@ public func !=~ <Left, Right, LeftField, RightField>(
 }
 
 public struct ModelFieldFilter<Left, Right>
-    where Left: FluentKit.Model, Right: FluentKit.Model
+    where Left: FluentKit.Schema, Right: FluentKit.Schema
 {
     public init<LeftField, RightField>(
         _ lhs: KeyPath<Left, LeftField>,

--- a/Sources/FluentKit/Operators/ValueOperators+Array.swift
+++ b/Sources/FluentKit/Operators/ValueOperators+Array.swift
@@ -1,7 +1,7 @@
 // MARK: Field.Value
 
 public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -> ModelValueFilter<Model>
-    where Model: FluentKit.Model,
+    where Model: FluentKit.Schema,
         Field: QueryableProperty,
         Values: Collection,
         Values.Element == Field.Value
@@ -10,7 +10,7 @@ public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
 }
 
 public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -> ModelValueFilter<Model>
-    where Model: FluentKit.Model,
+    where Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: Codable,
@@ -21,7 +21,7 @@ public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
 }
 
 public func !~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -> ModelValueFilter<Model>
-    where Model: FluentKit.Model,
+    where Model: FluentKit.Schema,
         Field: QueryableProperty,
         Values: Collection,
         Values.Element == Field.Value
@@ -30,7 +30,7 @@ public func !~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
 }
 
 public func !~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -> ModelValueFilter<Model>
-    where Model: FluentKit.Model,
+    where Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: Codable,
@@ -43,13 +43,13 @@ public func !~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
 // MARK: DatabaseQuery.Value
 
 public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
-    where Model: FluentKit.Model, Field: QueryableProperty
+    where Model: FluentKit.Schema, Field: QueryableProperty
 {
     .init(lhs, .subset(inverse: false), rhs)
 }
 
 public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
-    where Model: FluentKit.Model, Field: QueryableProperty
+    where Model: FluentKit.Schema, Field: QueryableProperty
 {
     .init(lhs, .subset(inverse: true), rhs)
 }

--- a/Sources/FluentKit/Operators/ValueOperators+String.swift
+++ b/Sources/FluentKit/Operators/ValueOperators+String.swift
@@ -2,7 +2,7 @@
 
 public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value == String
 {
@@ -11,7 +11,7 @@ public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelV
 
 public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped == String
@@ -21,7 +21,7 @@ public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelV
 
 public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value == String
 {
@@ -30,7 +30,7 @@ public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelV
 
 public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped == String
@@ -40,7 +40,7 @@ public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelV
 
 public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value == String
 {
@@ -49,7 +49,7 @@ public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelV
 
 public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped == String
@@ -59,7 +59,7 @@ public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelV
 
 public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value == String
 {
@@ -68,7 +68,7 @@ public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> Model
 
 public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped == String
@@ -78,7 +78,7 @@ public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> Model
 
 public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value == String
 {
@@ -87,7 +87,7 @@ public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelV
 
 public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped == String
@@ -97,7 +97,7 @@ public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelV
 
 public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value == String
 {
@@ -106,7 +106,7 @@ public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> Model
 
 public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped == String
@@ -118,7 +118,7 @@ public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: String) -> Model
 
 public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
 {
@@ -127,7 +127,7 @@ public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 
 public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: CustomStringConvertible
@@ -137,7 +137,7 @@ public func ~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 
 public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
 {
@@ -146,7 +146,7 @@ public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 
 public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: CustomStringConvertible
@@ -156,7 +156,7 @@ public func ~~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 
 public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
 {
@@ -165,7 +165,7 @@ public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 
 public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: CustomStringConvertible
@@ -175,7 +175,7 @@ public func =~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 
 public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
 {
@@ -184,7 +184,7 @@ public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Va
 
 public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: CustomStringConvertible
@@ -194,7 +194,7 @@ public func !~= <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Va
 
 public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
 {
@@ -203,7 +203,7 @@ public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 
 public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: CustomStringConvertible
@@ -213,7 +213,7 @@ public func !~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Val
 
 public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: CustomStringConvertible
 {
@@ -222,7 +222,7 @@ public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Va
 
 public func !=~ <Model, Field>(lhs: KeyPath<Model, Field>, rhs: DatabaseQuery.Value) -> ModelValueFilter<Model>
     where
-        Model: FluentKit.Model,
+        Model: FluentKit.Schema,
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: CustomStringConvertible

--- a/Sources/FluentSQL/DatabaseQuery+SQL.swift
+++ b/Sources/FluentSQL/DatabaseQuery+SQL.swift
@@ -71,6 +71,20 @@ extension DatabaseQuery.Filter {
     }
 }
 
+extension DatabaseQuery.Join {
+    public static func sql(raw: String) -> Self {
+        .sql(SQLRaw(raw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
 extension DatabaseQuery.Sort {
     public static func sql(raw: String) -> Self {
         .sql(SQLRaw(raw))

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -382,9 +382,9 @@ private struct EncodableDatabaseInput: Encodable {
     let input: [FieldKey: DatabaseQuery.Value]
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: SomeCodingKey.self)
+        var container = encoder.container(keyedBy: FluentKit.SomeCodingKey.self)
         for (key, value) in self.input {
-            try container.encode(EncodableDatabaseValue(value: value), forKey: SomeCodingKey(stringValue: key.description))
+            try container.encode(EncodableDatabaseValue(value: value), forKey: FluentKit.SomeCodingKey(stringValue: key.description))
         }
     }
 }


### PR DESCRIPTION
1. Relaxes most of Fluent's filter operators to only require `Schema` conformance rather than `Model`. This enables `ModelAlias` usage with all operators that it previously didn't work for.
2. Enables all model value filters in joins (e.g. `join(Foo.self, on: \Foo.$bar.$id == \Bar.$id && \Bar.$value > 4)`).
3. Adds `.sql(raw:)`, `.sql(embed:)`, and `.sql(_:)` for Fluent joins.

(Note: Not a semver-major break because the new generic requirements on operators are always strict supersets of the old ones.)

Supersedes #432. Fixes #431. Fixes #536.