### PR TITLE
Explicitly set all columns when creating arrays of models

### DIFF
--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -156,8 +156,8 @@ private final class HasChangesInput: DatabaseInput {
 extension Fields {
     /// Returns a dictionary of field keys and associated values representing all "pending"
     /// data - e.g. all fields (if any) which have been changed by something other than Fluent.
-    internal func collectInput() -> [FieldKey: DatabaseQuery.Value] {
-        let input = DictionaryInput()
+    internal func collectInput(withDefaultedValues defaultedValues: Bool = false) -> [FieldKey: DatabaseQuery.Value] {
+        let input = DictionaryInput(wantsUnmodifiedKeys: defaultedValues)
         self.input(to: input)
         return input.storage
     }
@@ -166,6 +166,11 @@ extension Fields {
 /// Helper type for the implementation of `Fields.collectInput()`.
 private final class DictionaryInput: DatabaseInput {
     var storage: [FieldKey: DatabaseQuery.Value] = [:]
+    let wantsUnmodifiedKeys: Bool
+    
+    init(wantsUnmodifiedKeys: Bool = false) {
+        self.wantsUnmodifiedKeys = wantsUnmodifiedKeys
+    }
 
     func set(_ value: DatabaseQuery.Value, at key: FieldKey) {
         self.storage[key] = value

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -22,7 +22,7 @@ extension Model {
             self.anyID.generate()
             let promise = database.eventLoop.makePromise(of: DatabaseOutput.self)
             Self.query(on: database)
-                .set(self.collectInput())
+                .set(self.collectInput(withDefaultedValues: true))
                 .action(.create)
                 .run { promise.succeed($0) }
                 .cascadeFailure(to: promise)
@@ -36,7 +36,7 @@ extension Model {
             }
         } else {
             return Self.query(on: database)
-                .set(self.collectInput())
+                .set(self.collectInput(withDefaultedValues: true))
                 .action(.create)
                 .run()
                 .flatMapThrowing {
@@ -179,7 +179,7 @@ extension Collection where Element: FluentKit.Model {
             }.create(model, on: database)
         }, on: database.eventLoop).flatMap {
             Element.query(on: database)
-                .set(self.map { $0.collectInput() })
+                .set(self.map { $0.collectInput(withDefaultedValues: true) })
                 .create()
         }.map {
             for model in self {

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -1,4 +1,5 @@
 import NIOCore
+import protocol SQLKit.SQLDatabase
 
 extension Model {
     public func save(on database: Database) -> EventLoopFuture<Void> {
@@ -22,7 +23,7 @@ extension Model {
             self.anyID.generate()
             let promise = database.eventLoop.makePromise(of: DatabaseOutput.self)
             Self.query(on: database)
-                .set(self.collectInput(withDefaultedValues: true))
+                .set(self.collectInput(withDefaultedValues: database is SQLDatabase))
                 .action(.create)
                 .run { promise.succeed($0) }
                 .cascadeFailure(to: promise)
@@ -36,7 +37,7 @@ extension Model {
             }
         } else {
             return Self.query(on: database)
-                .set(self.collectInput(withDefaultedValues: true))
+                .set(self.collectInput(withDefaultedValues: database is SQLDatabase))
                 .action(.create)
                 .run()
                 .flatMapThrowing {
@@ -179,7 +180,7 @@ extension Collection where Element: FluentKit.Model {
             }.create(model, on: database)
         }, on: database.eventLoop).flatMap {
             Element.query(on: database)
-                .set(self.map { $0.collectInput(withDefaultedValues: true) })
+                .set(self.map { $0.collectInput(withDefaultedValues: database is SQLDatabase) })
                 .create()
         }.map {
             for model in self {

--- a/Tests/FluentKitTests/CompositeIDTests.swift
+++ b/Tests/FluentKitTests/CompositeIDTests.swift
@@ -49,7 +49,7 @@ final class CompositeIDTests: XCTestCase {
         try model.delete(force: true, on: db).wait()
 
         XCTAssertEqual(db.sqlSerializers.count, 6)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt") VALUES ($1, $2, $3, $4, $5)"#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt", "deletedAt") VALUES ($1, $2, $3, $4, $5, DEFAULT)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(1).sql, #"UPDATE "composite+planet+tag" SET "notation" = $1, "updatedAt" = $2 WHERE ("composite+planet+tag"."planet_id" = $3 AND "composite+planet+tag"."tag_id" = $4) AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $5)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(2).sql, #"UPDATE "composite+planet+tag" SET "planet_id" = $1, "updatedAt" = $2 WHERE ("composite+planet+tag"."planet_id" = $3 AND "composite+planet+tag"."tag_id" = $4) AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $5)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(3).sql, #"UPDATE "composite+planet+tag" SET "updatedAt" = $1, "deletedAt" = $2 WHERE ("composite+planet+tag"."planet_id" = $3 AND "composite+planet+tag"."tag_id" = $4) AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $5)"#)
@@ -112,8 +112,8 @@ final class CompositeIDTests: XCTestCase {
         XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id" FROM "planets" WHERE "planets"."id" = $1 LIMIT 1"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(1).sql, #"SELECT "composite+planet+tag"."planet_id" AS "composite+planet+tag_planet_id", "composite+planet+tag"."tag_id" AS "composite+planet+tag_tag_id", "composite+planet+tag"."notation" AS "composite+planet+tag_notation", "composite+planet+tag"."createdAt" AS "composite+planet+tag_createdAt", "composite+planet+tag"."updatedAt" AS "composite+planet+tag_updatedAt", "composite+planet+tag"."deletedAt" AS "composite+planet+tag_deletedAt" FROM "composite+planet+tag" WHERE "composite+planet+tag"."planet_id" = $1 AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $2)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(2).sql, #"SELECT "tags"."id" AS "tags_id", "tags"."name" AS "tags_name", "composite+planet+tag"."planet_id" AS "composite+planet+tag_planet_id", "composite+planet+tag"."tag_id" AS "composite+planet+tag_tag_id", "composite+planet+tag"."notation" AS "composite+planet+tag_notation", "composite+planet+tag"."createdAt" AS "composite+planet+tag_createdAt", "composite+planet+tag"."updatedAt" AS "composite+planet+tag_updatedAt", "composite+planet+tag"."deletedAt" AS "composite+planet+tag_deletedAt" FROM "tags" INNER JOIN "composite+planet+tag" ON "tags"."id" = "composite+planet+tag"."tag_id" WHERE "composite+planet+tag"."planet_id" = $1 AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $2)"#)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(3).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "createdAt", "updatedAt") VALUES ($1, $2, $3, $4)"#)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(4).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "createdAt", "updatedAt") VALUES ($1, $2, $3, $4)"#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(3).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt", "deletedAt") VALUES ($1, $2, DEFAULT, $3, $4, DEFAULT)"#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(4).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt", "deletedAt") VALUES ($1, $2, DEFAULT, $3, $4, DEFAULT)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(5).sql, #"SELECT COUNT("composite+planet+tag"."planet_id") AS "aggregate" FROM "composite+planet+tag" WHERE "composite+planet+tag"."planet_id" = $1 AND "composite+planet+tag"."tag_id" = $2 AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $3)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(6).sql, #"SELECT COUNT("composite+planet+tag"."planet_id") AS "aggregate" FROM "composite+planet+tag" WHERE "composite+planet+tag"."planet_id" = $1 AND "composite+planet+tag"."tag_id" = $2 AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $3)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(7).sql, #"UPDATE "composite+planet+tag" SET "updatedAt" = $1, "deletedAt" = $2 WHERE "composite+planet+tag"."planet_id" = $3 AND "composite+planet+tag"."tag_id" = $4 AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $5)"#)
@@ -147,11 +147,11 @@ final class CompositeIDTests: XCTestCase {
         }
         
         XCTAssertEqual(db.sqlSerializers.count, 6)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "createdAt", "updatedAt") VALUES ($1, $2, $3, $4)"#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(0).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt", "deletedAt") VALUES ($1, $2, DEFAULT, $3, $4, DEFAULT)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(1).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "planets"."deleted_at" AS "planets_deleted_at" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(2).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt") VALUES ($1, $2, $3, $4, $5)"#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(2).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt", "deletedAt") VALUES ($1, $2, $3, $4, $5, DEFAULT)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(3).sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "planets"."deleted_at" AS "planets_deleted_at" FROM "planets" WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1)"#)
-        XCTAssertEqual(try db.sqlSerializers.xctAt(4).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt") VALUES ($1, $2, $3, $4, $5)"#)
+        XCTAssertEqual(try db.sqlSerializers.xctAt(4).sql, #"INSERT INTO "composite+planet+tag" ("planet_id", "tag_id", "notation", "createdAt", "updatedAt", "deletedAt") VALUES ($1, $2, $3, $4, $5, DEFAULT)"#)
         XCTAssertEqual(try db.sqlSerializers.xctAt(5).sql, #"SELECT COUNT("composite+planet+tag"."planet_id") AS "aggregate" FROM "composite+planet+tag" WHERE "composite+planet+tag"."planet_id" = $1 AND "composite+planet+tag"."tag_id" = $2 AND ("composite+planet+tag"."deletedAt" IS NULL OR "composite+planet+tag"."deletedAt" > $3)"#)
         
         planet.$tags.fromId = nil
@@ -234,26 +234,28 @@ final class CompositeIDTests: XCTestCase {
         moon4.$planetoid.id = nil
         try [moon1, moon2, moon3, moon4].forEach { try $0.update(on: db).wait() }
         
-        let moonCols = #""id", "name", "planet_system_id", "planet_nrm_ord""#, fourVals = "$1, $2, $3, $4", sixVals = "\(fourVals), $5, $6"
-        let expectedQueries: [(String, [Encodable])] = [
-            (#"INSERT INTO "composite+planet" ("system_id", "nrm_ord", "name") VALUES ($1, $2, $3)"#,                                         [sysId, 1, "A"]),
-            (#"INSERT INTO "composite+moon" (\#(moonCols)) VALUES (\#(fourVals))"#,                                                           [moon1.id!, "B", sysId, 1]),
-            (#"INSERT INTO "composite+moon" (\#(moonCols), "progenitorSystem_id", "progenitorNrm_ord") VALUES (\#(sixVals))"#,                [moon2.id!, "C", sysId, 1, sysId, 2]),
-            (#"INSERT INTO "composite+moon" (\#(moonCols)) VALUES (\#(fourVals))"#,                                                           [moon3.id!, "D", sysId, 1]),
-            (#"INSERT INTO "composite+moon" (\#(moonCols), "planetoid_system_id", "planetoid_nrm_ord") VALUES (\#(sixVals))"#,                [moon4.id!, "E", sysId, 1, sysId, 3]),
-            (#"UPDATE "composite+planet" SET "name" = $1 WHERE ("composite+planet"."system_id" = $2 AND "composite+planet"."nrm_ord" = $3)"#, ["AA", sysId, 1]),
-            (#"UPDATE "composite+moon" SET "planet_system_id" = $1, "planet_nrm_ord" = $2 WHERE "composite+moon"."id" = $3"#,                 [sys2Id, 2, moon1.id!]),
-            (#"UPDATE "composite+moon" SET "progenitorSystem_id" = NULL, "progenitorNrm_ord" = NULL WHERE "composite+moon"."id" = $1"#,       [moon2.id!]),
-            (#"UPDATE "composite+moon" SET "planetoid_system_id" = $1, "planetoid_nrm_ord" = $2 WHERE "composite+moon"."id" = $3"#,           [sys2Id, 3, moon3.id!]),
-            (#"UPDATE "composite+moon" SET "planetoid_system_id" = NULL, "planetoid_nrm_ord" = NULL WHERE "composite+moon"."id" = $1"#,       [moon4.id!]),
+        let moonCols = #""id", "name", "planet_system_id", "planet_nrm_ord", "progenitorSystem_id", "progenitorNrm_ord", "planetoid_system_id", "planetoid_nrm_ord""#
+        let fourVals = "$1, $2, $3, $4, NULL, NULL, NULL, NULL"
+        let sixVals1 = "$1, $2, $3, $4, $5, $6, NULL, NULL", sixVals2 = "$1, $2, $3, $4, NULL, NULL, $5, $6"
+        let expectedQueries: [(String, [Encodable], UInt)] = [
+            (#"INSERT INTO "composite+planet" ("system_id", "nrm_ord", "name") VALUES ($1, $2, $3)"#,                                         [sysId, 1, "A"],                      #line),
+            (#"INSERT INTO "composite+moon" (\#(moonCols)) VALUES (\#(fourVals))"#,                                                           [moon1.id!, "B", sysId, 1],           #line),
+            (#"INSERT INTO "composite+moon" (\#(moonCols)) VALUES (\#(sixVals1))"#,                                                           [moon2.id!, "C", sysId, 1, sysId, 2], #line),
+            (#"INSERT INTO "composite+moon" (\#(moonCols)) VALUES (\#(fourVals))"#,                                                           [moon3.id!, "D", sysId, 1],           #line),
+            (#"INSERT INTO "composite+moon" (\#(moonCols)) VALUES (\#(sixVals2))"#,                                                           [moon4.id!, "E", sysId, 1, sysId, 3], #line),
+            (#"UPDATE "composite+planet" SET "name" = $1 WHERE ("composite+planet"."system_id" = $2 AND "composite+planet"."nrm_ord" = $3)"#, ["AA", sysId, 1],                     #line),
+            (#"UPDATE "composite+moon" SET "planet_system_id" = $1, "planet_nrm_ord" = $2 WHERE "composite+moon"."id" = $3"#,                 [sys2Id, 2, moon1.id!],               #line),
+            (#"UPDATE "composite+moon" SET "progenitorSystem_id" = NULL, "progenitorNrm_ord" = NULL WHERE "composite+moon"."id" = $1"#,       [moon2.id!],                          #line),
+            (#"UPDATE "composite+moon" SET "planetoid_system_id" = $1, "planetoid_nrm_ord" = $2 WHERE "composite+moon"."id" = $3"#,           [sys2Id, 3, moon3.id!],               #line),
+            (#"UPDATE "composite+moon" SET "planetoid_system_id" = NULL, "planetoid_nrm_ord" = NULL WHERE "composite+moon"."id" = $1"#,       [moon4.id!],                          #line),
         ]
 
         XCTAssertEqual(db.sqlSerializers.count, expectedQueries.count)
-        for ((query, binds), serializer) in zip(expectedQueries, db.sqlSerializers) {
-            XCTAssertEqual(serializer.sql, query)
-            XCTAssertEqual(serializer.binds.count, binds.count)
+        for ((query, binds, line), serializer) in zip(expectedQueries, db.sqlSerializers) {
+            XCTAssertEqual(serializer.sql, query, file: #filePath, line: line)
+            XCTAssertEqual(serializer.binds.count, binds.count, file: #filePath, line: line)
             for (lBind, rBind) in zip(binds, serializer.binds) {
-                XCTAssertEqual("\(lBind)", "\(rBind)")
+                XCTAssertEqual("\(lBind)", "\(rBind)", file: #filePath, line: line)
             }
         }
     }


### PR DESCRIPTION
When performing an insert query (the "create" model action), we now explicitly emit `DEFAULT` as the value for fields which have not been set. This ensures that when creating an array of models, the column count for each individual model is the same even if not all fields are set on each one, avoiding a fatal error.

Fixes #594.