### PR TITLE
conform FieldKey to Sendable

### DIFF
--- a/Sources/FluentKit/Properties/FieldKey.swift
+++ b/Sources/FluentKit/Properties/FieldKey.swift
@@ -34,3 +34,5 @@ extension FieldKey: CustomStringConvertible {
 extension FieldKey: Equatable { }
 
 extension FieldKey: Hashable { }
+
+extension FieldKey: Sendable { }


### PR DESCRIPTION
There are perhaps other types that should be audited for `Sendable`-ity, but I'm not sure if there's a coordinated effort around that. I'm updating a Vapor app getting it ready for Swift 6 with all concurrency warnings turned to the max, and seeing warnings related to my usage of `FieldKey`, seems like an obvious candidate to be Sendable, although I could be missing some subtle nuance of Semver or something like that.
