### PR TITLE
Restore support for pre-Concurrency migrations

### DIFF
--- a/Sources/FluentKit/Enum/EnumMetadata.swift
+++ b/Sources/FluentKit/Enum/EnumMetadata.swift
@@ -26,9 +26,9 @@ final class EnumMetadata: Model, @unchecked Sendable {
     }
 }
 
-private struct EnumMetadataMigration: AsyncMigration {
-    func prepare(on database: any Database) async throws {
-        try await database.schema(EnumMetadata.schema)
+private struct EnumMetadataMigration: Migration {
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        database.schema(EnumMetadata.schema)
             .id()
             .field("name", .string, .required)
             .field("case", .string, .required)
@@ -37,7 +37,7 @@ private struct EnumMetadataMigration: AsyncMigration {
             .create()
     }
 
-    func revert(on database: any Database) async throws {
-        try await database.schema(EnumMetadata.schema).delete()
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
+        database.schema(EnumMetadata.schema).delete()
     }
 }

--- a/Sources/FluentKit/Migration/MigrationLog.swift
+++ b/Sources/FluentKit/Migration/MigrationLog.swift
@@ -6,7 +6,7 @@ public final class MigrationLog: Model, @unchecked Sendable {
     public static let schema = "_fluent_migrations"
 
     public static var migration: any Migration {
-        return MigrationLogMigration()
+        MigrationLogMigration()
     }
 
     @ID(key: .id)
@@ -35,9 +35,9 @@ public final class MigrationLog: Model, @unchecked Sendable {
     }
 }
 
-private struct MigrationLogMigration: AsyncMigration {
-    func prepare(on database: any Database) async throws {
-        try await database.schema(MigrationLog.schema)
+private struct MigrationLogMigration: Migration {
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        database.schema(MigrationLog.schema)
             .field(.id, .uuid, .identifier(auto: false))
             .field("name", .string, .required)
             .field("batch", .int, .required)
@@ -48,7 +48,7 @@ private struct MigrationLogMigration: AsyncMigration {
             .create()
     }
 
-    func revert(on database: any Database) async throws {
-        try await database.schema(MigrationLog.schema).delete()
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
+        database.schema(MigrationLog.schema).delete()
     }
 }


### PR DESCRIPTION
Reverts and tweaks a few of the changes in the recent `Sendable` update in order to (hopefully) restore functionality for users still using legacy (pre-Concurrency) app entry points.

Fixes #602. (Hopefully.)