### PR TITLE
Update minimum required versions for dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "XCTFluent", targets: ["XCTFluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.2"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.17.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
         .library(name: "XCTFluent", targets: ["XCTFluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.28.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.2"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.17.0"),
     ],
     targets: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "XCTFluent", targets: ["XCTFluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.2"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.17.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,9 +16,9 @@ let package = Package(
         .library(name: "XCTFluent", targets: ["XCTFluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.28.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.2"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.17.0"),
     ],
     targets: [


### PR DESCRIPTION
In the last minor version bump to this package, the minimum version requirement for SQLKit was accidentally not updated. We now require the version we actually need.