### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -53,7 +53,7 @@ public final class FluentBenchmarker {
 
     // MARK: Utilities
 
-    internal func runTest(
+    func runTest(
         _ name: String, 
         _ migrations: [any Migration], 
         _ test: () throws -> ()
@@ -61,7 +61,7 @@ public final class FluentBenchmarker {
         try self.runTest(name, migrations, { _ in try test() })
     }
     
-    internal func runTest(
+    func runTest(
         _ name: String,
         _ migrations: [any Migration],
         _ test: (any Database) throws -> ()
@@ -74,7 +74,7 @@ public final class FluentBenchmarker {
         try self.runTest(name, migrations, on: self.database, test)
     }
     
-    internal func runTest(
+    func runTest(
         _ name: String,
         _ migrations: [any Migration],
         on database: any Database,

--- a/Sources/FluentBenchmark/SolarSystem/Planet.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Planet.swift
@@ -68,7 +68,7 @@ public struct PlanetSeed: Migration {
             .andAllSucceed(stars.map { star in
                 let planets: [Planet]
                 switch star.name {
-                case "Sun":
+                case "Sol":
                     planets = [
                         .init(name: "Mercury"),
                         .init(name: "Venus"),

--- a/Sources/FluentBenchmark/SolarSystem/Star.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Star.swift
@@ -6,7 +6,7 @@ import XCTest
 public final class Star: Model, @unchecked Sendable {
     public static let schema = "stars"
 
-    @ID(key: .id)
+    @ID
     public var id: UUID?
 
     @Field(key: "name")
@@ -23,48 +23,53 @@ public final class Star: Model, @unchecked Sendable {
 
     public init() { }
 
-    public init(id: IDValue? = nil, name: String) {
+    public init(id: IDValue? = nil, name: String, galaxyId: Galaxy.IDValue? = nil) {
         self.id = id
         self.name = name
+        if let galaxyId {
+            self.$galaxy.id = galaxyId
+        }
     }
 }
 
-public struct StarMigration: Migration {
-    public func prepare(on database: any Database) -> EventLoopFuture<Void> {
-        database.schema("stars")
-            .field("id", .uuid, .identifier(auto: false))
+public struct StarMigration: AsyncMigration {
+    public func prepare(on database: any Database) async throws {
+        try await database.schema("stars")
+            .id()
             .field("name", .string, .required)
             .field("galaxy_id", .uuid, .required, .references("galaxies", "id"))
             .field("deleted_at", .datetime)
             .create()
     }
 
-    public func revert(on database: any Database) -> EventLoopFuture<Void> {
-        database.schema("stars").delete()
+    public func revert(on database: any Database) async throws {
+        try await database.schema("stars").delete()
     }
 }
 
-public final class StarSeed: Migration {
-    public init() { }
+public final class StarSeed: AsyncMigration {
+    public init() {}
 
-    public func prepare(on database: any Database) -> EventLoopFuture<Void> {
-        Galaxy.query(on: database).all().flatMap { galaxies in
-            .andAllSucceed(galaxies.map { galaxy in
-                let stars: [Star]
-                switch galaxy.name {
-                case "Milky Way":
-                    stars = [.init(name: "Sun"), .init(name: "Alpha Centauri")]
-                case "Andromeda":
-                    stars = [.init(name: "Alpheratz")]
-                default:
-                    stars = []
-                }
-                return galaxy.$stars.create(stars, on: database)
-            }, on: database.eventLoop)
+    public func prepare(on database: any Database) async throws {
+        var stars: [Star] = []
+        
+        for galaxy in try await Galaxy.query(on: database).all() {
+            switch galaxy.name {
+            case "Milky Way":
+                stars.append(contentsOf: [
+                    .init(name: "Sol", galaxyId: galaxy.id!),
+                    .init(name: "Alpha Centauri", galaxyId: galaxy.id!)
+                ])
+            case "Andromeda":
+                stars.append(.init(name: "Alpheratz", galaxyId: galaxy.id!))
+            default:
+                break
+            }
         }
+        try await stars.create(on: database)
     }
 
-    public func revert(on database: any Database) -> EventLoopFuture<Void> {
-        Star.query(on: database).delete(force: true)
+    public func revert(on database: any Database) async throws {
+        try await Star.query(on: database).delete(force: true)
     }
 }

--- a/Sources/FluentBenchmark/Tests/EagerLoadTests.swift
+++ b/Sources/FluentBenchmark/Tests/EagerLoadTests.swift
@@ -48,7 +48,7 @@ extension FluentBenchmarker {
                 switch galaxy.name {
                 case "Milky Way":
                     XCTAssertEqual(
-                        galaxy.stars.contains { $0.name == "Sun" },
+                        galaxy.stars.contains { $0.name == "Sol" },
                         true
                     )
                     XCTAssertEqual(
@@ -68,7 +68,7 @@ extension FluentBenchmarker {
             try Planet.query(on: self.database).filter(\.$name == "Jupiter").delete().wait()
             
             let sun1 = try XCTUnwrap(Star.query(on: self.database)
-                .filter(\.$name == "Sun")
+                .filter(\.$name == "Sol")
                 .with(\.$planets, withDeleted: true)
                 .first().wait()
             )
@@ -76,7 +76,7 @@ extension FluentBenchmarker {
             XCTAssertTrue(sun1.planets.contains { $0.name == "Jupiter" })
             
             let sun2 = try XCTUnwrap(Star.query(on: self.database)
-                .filter(\.$name == "Sun")
+                .filter(\.$name == "Sol")
                 .with(\.$planets)
                 .first().wait()
             )
@@ -96,7 +96,7 @@ extension FluentBenchmarker {
             for planet in planets {
                 switch planet.name {
                 case "Earth":
-                    XCTAssertEqual(planet.star.name, "Sun")
+                    XCTAssertEqual(planet.star.name, "Sol")
                 case "Proxima Centauri b":
                     XCTAssertEqual(planet.star.name, "Alpha Centauri")
                 default: break
@@ -109,14 +109,14 @@ extension FluentBenchmarker {
         try self.runTest(#function, [
             SolarSystem()
         ]) {
-            try Star.query(on: self.database).filter(\.$name == "Sun").delete().wait()
+            try Star.query(on: self.database).filter(\.$name == "Sol").delete().wait()
             
             let planet = try XCTUnwrap(Planet.query(on: self.database)
                 .filter(\.$name == "Earth")
                 .with(\.$star, withDeleted: true)
                 .first().wait()
             )
-            XCTAssertEqual(planet.star.name, "Sun")
+            XCTAssertEqual(planet.star.name, "Sol")
             
             XCTAssertThrowsError(
                 try Planet.query(on: self.database)
@@ -145,13 +145,13 @@ extension FluentBenchmarker {
             for planet in planets {
                 switch planet.name {
                 case "Earth":
-                    XCTAssertEqual(planet.star.name, "Sun")
+                    XCTAssertEqual(planet.star.name, "Sol")
                     XCTAssertEqual(planet.tags.map { $0.name }.sorted(), ["Inhabited", "Small Rocky"])
                 case "Proxima Centauri b":
                     XCTAssertEqual(planet.star.name, "Alpha Centauri")
                     XCTAssertEqual(planet.tags.map { $0.name }, ["Small Rocky"])
                 case "Jupiter":
-                    XCTAssertEqual(planet.star.name, "Sun")
+                    XCTAssertEqual(planet.star.name, "Sol")
                     XCTAssertEqual(planet.tags.map { $0.name }, ["Gas Giant"])
                 default: break
                 }

--- a/Sources/FluentBenchmark/Tests/GroupTests.swift
+++ b/Sources/FluentBenchmark/Tests/GroupTests.swift
@@ -26,7 +26,7 @@ extension FluentBenchmarker {
             XCTAssertEqual(moon.name, "Moon")
             XCTAssertEqual(moon.planet.name, "Earth")
             XCTAssertEqual(moon.planet.type, .smallRocky)
-            XCTAssertEqual(moon.planet.star.name, "Sun")
+            XCTAssertEqual(moon.planet.star.name, "Sol")
             XCTAssertEqual(moon.planet.star.galaxy.name, "Milky Way")
 
             // Test JSON
@@ -36,7 +36,7 @@ extension FluentBenchmarker {
             XCTAssertEqual(decoded.name, "Moon")
             XCTAssertEqual(decoded.planet.name, "Earth")
             XCTAssertEqual(decoded.planet.type, .smallRocky)
-            XCTAssertEqual(decoded.planet.star.name, "Sun")
+            XCTAssertEqual(decoded.planet.star.name, "Sol")
             XCTAssertEqual(decoded.planet.star.galaxy.name, "Milky Way")
 
             // Test deeper filter
@@ -66,7 +66,7 @@ extension FluentBenchmarker {
 //            XCTAssertEqual(moon.name, "Moon")
 //            XCTAssertEqual(moon.planet.name, "Earth")
 //            XCTAssertEqual(moon.planet.type, .smallRocky)
-//            XCTAssertEqual(moon.planet.star.name, "Sun")
+//            XCTAssertEqual(moon.planet.star.name, "Sol")
 //            XCTAssertEqual(moon.planet.star.galaxy.name, "Milky Way")
 //
 //            // Test JSON
@@ -75,7 +75,7 @@ extension FluentBenchmarker {
 //            XCTAssertEqual(decoded.name, "Moon")
 //            XCTAssertEqual(decoded.planet.name, "Earth")
 //            XCTAssertEqual(decoded.planet.type, .smallRocky)
-//            XCTAssertEqual(decoded.planet.star.name, "Sun")
+//            XCTAssertEqual(decoded.planet.star.name, "Sol")
 //            XCTAssertEqual(decoded.planet.star.galaxy.name, "Milky Way")
 //
 //            // Test deeper filter
@@ -189,7 +189,7 @@ private struct FlatMoonSeed: Migration {
                 name: "Earth",
                 type: .smallRocky,
                 star: .init(
-                    name: "Sun",
+                    name: "Sol",
                     galaxy: .init(name: "Milky Way")
                 )
             )
@@ -200,7 +200,7 @@ private struct FlatMoonSeed: Migration {
                 name: "Jupiter",
                 type: .gasGiant,
                 star: .init(
-                    name: "Sun",
+                    name: "Sol",
                     galaxy: .init(name: "Milky Way")
                 )
             )
@@ -313,7 +313,7 @@ private struct FlatMoonSeed: Migration {
 //                name: "Earth",
 //                type: .smallRocky,
 //                star: .init(
-//                    name: "Sun",
+//                    name: "Sol",
 //                    galaxy: .init(name: "Milky Way")
 //                )
 //            )
@@ -324,7 +324,7 @@ private struct FlatMoonSeed: Migration {
 //                name: "Jupiter",
 //                type: .gasGiant,
 //                star: .init(
-//                    name: "Sun",
+//                    name: "Sol",
 //                    galaxy: .init(name: "Milky Way")
 //                )
 //            )

--- a/Sources/FluentBenchmark/Tests/JoinTests.swift
+++ b/Sources/FluentBenchmark/Tests/JoinTests.swift
@@ -27,7 +27,7 @@ extension FluentBenchmarker {
                 let star = try planet.joined(Star.self)
                 switch planet.name {
                 case "Earth":
-                    XCTAssertEqual(star.name, "Sun")
+                    XCTAssertEqual(star.name, "Sol")
                 case "Proxima Centauri b":
                     XCTAssertEqual(star.name, "Alpha Centauri")
                 default: break
@@ -42,7 +42,7 @@ extension FluentBenchmarker {
             for galaxy in galaxies {
                 let star = try galaxy.joined(Star.self)
                 switch star.name {
-                case "Sun", "Alpha Centauri":
+                case "Sol", "Alpha Centauri":
                     XCTAssertEqual(galaxy.name, "Milky Way")
                 case "Alpheratz":
                     XCTAssertEqual(galaxy.name, "Andromeda")
@@ -193,7 +193,7 @@ extension FluentBenchmarker {
             let planets = try Planet.query(on: self.database)
                 .field(\.$name)
                 .join(Star.self, on: \Planet.$star.$id == \Star.$id)
-                .filter(Star.self, \.$name ~~ ["Sun", "Alpha Centauri"])
+                .filter(Star.self, \.$name ~~ ["Sol", "Alpha Centauri"])
                 .field(Star.self, \.$name)
                 .all().wait()
 
@@ -203,7 +203,7 @@ extension FluentBenchmarker {
                 XCTAssertNil(star.$id.value)
                 switch planet.name {
                 case "Earth":
-                    XCTAssertEqual(star.name, "Sun")
+                    XCTAssertEqual(star.name, "Sol")
                 case "Proxima Centauri b":
                     XCTAssertEqual(star.name, "Alpha Centauri")
                 default: break
@@ -226,7 +226,7 @@ extension FluentBenchmarker {
             XCTAssertFalse(planets.isEmpty)
             
             let morePlanets = try Planet.query(on: self.database)
-                .join(Star.self, on: \Planet.$star.$id == \Star.$id && \Star.$name != "Sun")
+                .join(Star.self, on: \Planet.$star.$id == \Star.$id && \Star.$name != "Sol")
                 .all().wait()
             
             XCTAssertEqual(morePlanets.count, 1)

--- a/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
+++ b/Sources/FluentBenchmark/Tests/MiddlewareTests.swift
@@ -216,7 +216,7 @@ private struct UserMiddleware: ModelMiddleware {
         model.name = "B"
         
         return next.create(model, on: db).flatMap {
-            return db.eventLoop.makeFailedFuture(TestError(string: "didCreate"))
+            db.eventLoop.makeFailedFuture(TestError(string: "didCreate"))
         }
     }
 
@@ -224,7 +224,7 @@ private struct UserMiddleware: ModelMiddleware {
         model.name = "D"
 
         return next.update(model, on: db).flatMap {
-            return db.eventLoop.makeFailedFuture(TestError(string: "didUpdate"))
+            db.eventLoop.makeFailedFuture(TestError(string: "didUpdate"))
         }
     }
 
@@ -232,7 +232,7 @@ private struct UserMiddleware: ModelMiddleware {
         model.name = "E"
 
         return next.softDelete(model, on: db).flatMap {
-            return db.eventLoop.makeFailedFuture(TestError(string: "didSoftDelete"))
+            db.eventLoop.makeFailedFuture(TestError(string: "didSoftDelete"))
         }
     }
 
@@ -240,7 +240,7 @@ private struct UserMiddleware: ModelMiddleware {
         model.name = "F"
 
         return next.restore(model , on: db).flatMap {
-            return db.eventLoop.makeFailedFuture(TestError(string: "didRestore"))
+            db.eventLoop.makeFailedFuture(TestError(string: "didRestore"))
         }
     }
 
@@ -248,7 +248,7 @@ private struct UserMiddleware: ModelMiddleware {
         model.name = "G"
 
         return next.delete(model, force: force, on: db).flatMap {
-            return db.eventLoop.makeFailedFuture(TestError(string: "didDelete"))
+            db.eventLoop.makeFailedFuture(TestError(string: "didDelete"))
         }
     }
 }

--- a/Sources/FluentBenchmark/Tests/PaginationTests.swift
+++ b/Sources/FluentBenchmark/Tests/PaginationTests.swift
@@ -17,8 +17,8 @@ extension FluentBenchmarker {
                 XCTAssertEqual(planetsPage1.metadata.total, 9)
                 XCTAssertEqual(planetsPage1.metadata.pageCount, 5)
                 XCTAssertEqual(planetsPage1.items.count, 2)
-                XCTAssertEqual(planetsPage1.items[0].name, "Earth")
-                XCTAssertEqual(planetsPage1.items[1].name, "Jupiter")
+                XCTAssertEqual(planetsPage1.items.dropFirst(0).first?.name, "Earth")
+                XCTAssertEqual(planetsPage1.items.dropFirst(1).first?.name, "Jupiter")
             }
             do {
                 let planetsPage2 = try Planet.query(on: self.database)
@@ -31,8 +31,8 @@ extension FluentBenchmarker {
                 XCTAssertEqual(planetsPage2.metadata.total, 9)
                 XCTAssertEqual(planetsPage2.metadata.pageCount, 5)
                 XCTAssertEqual(planetsPage2.items.count, 2)
-                XCTAssertEqual(planetsPage2.items[0].name, "Mars")
-                XCTAssertEqual(planetsPage2.items[1].name, "Mercury")
+                XCTAssertEqual(planetsPage2.items.dropFirst(0).first?.name, "Mars")
+                XCTAssertEqual(planetsPage2.items.dropFirst(1).first?.name, "Mercury")
             }
             do {
                 let galaxiesPage = try Galaxy.query(on: self.database)
@@ -45,9 +45,9 @@ extension FluentBenchmarker {
                 XCTAssertEqual(galaxiesPage.metadata.page, 1)
                 XCTAssertEqual(galaxiesPage.metadata.per, 1)
 
-                let milkyWay = galaxiesPage.items[0]
-                XCTAssertEqual(milkyWay.name, "Milky Way")
-                XCTAssertEqual(milkyWay.stars.count, 2)
+                let milkyWay = galaxiesPage.items.first
+                XCTAssertEqual(milkyWay?.name, "Milky Way")
+                XCTAssertEqual(milkyWay?.stars.count, 2)
             }
         }
     }

--- a/Sources/FluentBenchmark/Tests/ParentTests.swift
+++ b/Sources/FluentBenchmark/Tests/ParentTests.swift
@@ -36,7 +36,7 @@ extension FluentBenchmarker {
                 let star = try planet.$star.get(on: self.database).wait()
                 switch planet.name {
                 case "Earth", "Jupiter":
-                    XCTAssertEqual(star.name, "Sun")
+                    XCTAssertEqual(star.name, "Sol")
                 case "Proxima Centauri b":
                     XCTAssertEqual(star.name, "Alpha Centauri")
                 default: break
@@ -61,7 +61,7 @@ extension FluentBenchmarker {
             XCTAssertNil(earth.$star.value)
             try earth.$star.load(on: self.database).wait()
             XCTAssertNotNil(earth.$star.value)
-            XCTAssertEqual(earth.star.name, "Sun")
+            XCTAssertEqual(earth.star.name, "Sol")
 
             let test = Star(name: "Foo")
             earth.$star.value = test
@@ -69,14 +69,14 @@ extension FluentBenchmarker {
             // test get uses cached value
             try XCTAssertEqual(earth.$star.get(on: self.database).wait().name, "Foo")
             // test get can reload relation
-            try XCTAssertEqual(earth.$star.get(reload: true, on: self.database).wait().name, "Sun")
+            try XCTAssertEqual(earth.$star.get(reload: true, on: self.database).wait().name, "Sol")
 
             // test clearing loaded relation
             earth.$star.value = nil
             XCTAssertNil(earth.$star.value)
 
             // test get loads relation if nil
-            try XCTAssertEqual(earth.$star.get(on: self.database).wait().name, "Sun")
+            try XCTAssertEqual(earth.$star.get(on: self.database).wait().name, "Sol")
         }
     }
 }

--- a/Sources/FluentBenchmark/Tests/ParentTests.swift
+++ b/Sources/FluentBenchmark/Tests/ParentTests.swift
@@ -14,14 +14,14 @@ extension FluentBenchmarker {
         try self.runTest(#function, [
             SolarSystem()
         ]) {
-            let galaxies = try Galaxy.query(on: self.database)
-                .all().wait()
+            let stars = try Star.query(on: self.database).all().wait()
 
-            let encoded = try JSONEncoder().encode(galaxies)
-            self.database.logger.debug("\(String(decoding: encoded, as: UTF8.self)))")
-            let decoded = try JSONDecoder().decode([GalaxyJSON].self, from: encoded)
-            XCTAssertEqual(galaxies.map { $0.id }, decoded.map { $0.id })
-            XCTAssertEqual(galaxies.map { $0.name }, decoded.map { $0.name })
+            let encoded = try JSONEncoder().encode(stars)
+            self.database.logger.trace("\(String(decoding: encoded, as: UTF8.self)))")
+            let decoded = try JSONDecoder().decode([StarJSON].self, from: encoded)
+            XCTAssertEqual(stars.map { $0.id }, decoded.map { $0.id })
+            XCTAssertEqual(stars.map { $0.name }, decoded.map { $0.name })
+            XCTAssertEqual(stars.map { $0.$galaxy.id }, decoded.map { $0.galaxy.id })
         }
     }
     
@@ -81,33 +81,9 @@ extension FluentBenchmarker {
     }
 }
 
-private struct GalaxyKey: CodingKey, ExpressibleByStringLiteral {
-    var stringValue: String
-    var intValue: Int? {
-        return Int(self.stringValue)
-    }
-
-    init(stringLiteral value: String) {
-        self.stringValue = value
-    }
-
-    init?(stringValue: String) {
-        self.stringValue = stringValue
-    }
-
-    init?(intValue: Int) {
-        self.stringValue = intValue.description
-    }
-}
-
-private struct GalaxyJSON: Codable {
+private struct StarJSON: Codable {
     var id: UUID
     var name: String
-
-    init(from decoder: any Decoder) throws {
-        let keyed = try decoder.container(keyedBy: GalaxyKey.self)
-        self.id = try keyed.decode(UUID.self, forKey: "id")
-        self.name = try keyed.decode(String.self, forKey: "name")
-        XCTAssertEqual(keyed.allKeys.count, 2)
-    }
+    struct GalaxyJSON: Codable { var id: UUID }
+    var galaxy: GalaxyJSON
 }

--- a/Sources/FluentBenchmark/Tests/PerformanceTests.swift
+++ b/Sources/FluentBenchmark/Tests/PerformanceTests.swift
@@ -1,5 +1,9 @@
 import FluentKit
+#if !canImport(Darwin)
+@preconcurrency import Foundation
+#else
 import Foundation
+#endif
 import NIOCore
 import XCTest
 

--- a/Sources/FluentBenchmark/Tests/RangeTests.swift
+++ b/Sources/FluentBenchmark/Tests/RangeTests.swift
@@ -16,7 +16,7 @@ extension FluentBenchmarker {
                     .sort(\.$name)
                     .all().wait()
                 XCTAssertEqual(planets.count, 3)
-                XCTAssertEqual(planets[0].name, "Mars")
+                XCTAssertEqual(planets.first?.name, "Mars")
             }
             do {
                 let planets = try Planet.query(on: self.database)

--- a/Sources/FluentBenchmark/Tests/SchemaTests.swift
+++ b/Sources/FluentBenchmark/Tests/SchemaTests.swift
@@ -77,7 +77,7 @@ extension FluentBenchmarker {
         ]) {
             XCTAssertThrowsError(
                 try Star.query(on: self.database)
-                    .filter(\.$name == "Sun")
+                    .filter(\.$name == "Sol")
                     .delete(force: true).wait()
             )
         }

--- a/Sources/FluentBenchmark/Tests/SiblingsTests.swift
+++ b/Sources/FluentBenchmark/Tests/SiblingsTests.swift
@@ -13,15 +13,18 @@ extension FluentBenchmarker {
         try self.runTest(#function, [
             SolarSystem()
         ]) {
-            let inhabited = try Tag.query(on: self.database)
+            let inhabited = try XCTUnwrap(try Tag.query(on: self.database)
                 .filter(\.$name == "Inhabited")
-                .first().wait()!
-            let smallRocky = try Tag.query(on: self.database)
+                .first().wait()
+            )
+            let smallRocky = try XCTUnwrap(try Tag.query(on: self.database)
                 .filter(\.$name == "Small Rocky")
-                .first().wait()!
-            let earth = try Planet.query(on: self.database)
+                .first().wait()
+            )
+            let earth = try XCTUnwrap(try Planet.query(on: self.database)
                 .filter(\.$name == "Earth")
-                .first().wait()!
+                .first().wait()
+            )
 
             // check tag has expected planet
             do {

--- a/Sources/FluentBenchmark/Tests/TransactionTests.swift
+++ b/Sources/FluentBenchmark/Tests/TransactionTests.swift
@@ -16,10 +16,11 @@ extension FluentBenchmarker {
                 Star.query(on: transaction)
                     .filter(\.$name == "Sol")
                     .first()
-                    .flatMap
-                { sun -> EventLoopFuture<Planet> in
+                    .flatMapWithEventLoop
+                { sun, eventLoop -> EventLoopFuture<Planet> in
+                    guard let sun else { return eventLoop.makeFailedFuture(FluentError.missingField(name: "Sol")) }
                     let pluto = Planet(name: "Pluto")
-                    return sun!.$planets.create(pluto, on: transaction).map {
+                    return sun.$planets.create(pluto, on: transaction).map {
                         pluto
                     }
                 }.flatMap { pluto -> EventLoopFuture<(Planet, Tag)> in

--- a/Sources/FluentBenchmark/Tests/TransactionTests.swift
+++ b/Sources/FluentBenchmark/Tests/TransactionTests.swift
@@ -14,7 +14,7 @@ extension FluentBenchmarker {
         ]) {
             let result = self.database.transaction { transaction in
                 Star.query(on: transaction)
-                    .filter(\.$name == "Sun")
+                    .filter(\.$name == "Sol")
                     .first()
                     .flatMap
                 { sun -> EventLoopFuture<Planet> in

--- a/Sources/FluentKit/Concurrency/AsyncModelMiddleware.swift
+++ b/Sources/FluentKit/Concurrency/AsyncModelMiddleware.swift
@@ -17,7 +17,7 @@ extension AsyncModelMiddleware {
         on db: any Database,
         chainingTo next: any AnyModelResponder
     ) -> EventLoopFuture<Void> {
-        guard let modelType = (model as? Model).map({ UnsafeTransfer(wrappedValue: $0) }) else {
+        guard let modelType = (model as? Model) else {
             return next.handle(event, model, on: db)
         }
 
@@ -28,15 +28,15 @@ extension AsyncModelMiddleware {
 
             switch event {
             case .create:
-                try await self.create(model: modelType.wrappedValue, on: db, next: responder)
+                try await self.create(model: modelType, on: db, next: responder)
             case .update:
-                try await self.update(model: modelType.wrappedValue, on: db, next: responder)
+                try await self.update(model: modelType, on: db, next: responder)
             case .delete(let force):
-                try await self.delete(model: modelType.wrappedValue, force: force, on: db, next: responder)
+                try await self.delete(model: modelType, force: force, on: db, next: responder)
             case .softDelete:
-                try await self.softDelete(model: modelType.wrappedValue, on: db, next: responder)
+                try await self.softDelete(model: modelType, on: db, next: responder)
             case .restore:
-                try await self.restore(model: modelType.wrappedValue, on: db, next: responder)
+                try await self.restore(model: modelType, on: db, next: responder)
             }
         }
     }

--- a/Sources/FluentKit/Concurrency/Model+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/Model+Concurrency.swift
@@ -30,7 +30,7 @@ public extension Model {
     }
 }
 
-public extension Collection where Element: FluentKit.Model {
+public extension Collection where Element: FluentKit.Model, Self: Sendable {
     func delete(force: Bool = false, on database: any Database) async throws {
         try await self.delete(force: force, on: database).get()
     }

--- a/Sources/FluentKit/Concurrency/ModelResponder+Concurrency.swift
+++ b/Sources/FluentKit/Concurrency/ModelResponder+Concurrency.swift
@@ -10,10 +10,8 @@ public protocol AnyAsyncModelResponder: AnyModelResponder {
 
 extension AnyAsyncModelResponder {
     func handle(_ event: ModelEvent, _ model: any AnyModel, on db: any Database) -> EventLoopFuture<Void> {
-        let model = UnsafeTransfer(wrappedValue: model)
-        
-        return db.eventLoop.makeFutureWithTask {
-            try await self.handle(event, model.wrappedValue, on: db)
+        db.eventLoop.makeFutureWithTask {
+            try await self.handle(event, model, on: db)
         }
     }
 }

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -141,7 +141,7 @@ private final class DatabaseMigrator: Sendable {
                 self.database.logger.critical("The migration at \(migration.name) is in a private context. Either explicitly give it a name by adding the `var name: String` property or make the migration `internal` or `public` instead of `private`.")
                 fatalError("Private migrations not allowed")
             }
-            self.database.logger.error("The migration at \(migration.name) has an unexpected default name. Consider giving it an explicit name by adding a `var name: String` property before applying these migrations.")
+            self.database.logger.error("The migration has an unexpected default name. Consider giving it an explicit name by adding a `var name: String` property before applying these migrations.", metadata: ["migration": .string(migration.name)])
         }
     }
 
@@ -197,7 +197,7 @@ private final class DatabaseMigrator: Sendable {
         
             return MigrationLog(name: migration.name, batch: batch).save(on: self.database)
         }.flatMapErrorThrowing {
-            self.database.logger.error("[Migrator] Failed prepare: \(String(reflecting: $0))", metadata: ["migration": .string(migration.name)])
+            self.database.logger.error("[Migrator] Failed prepare", metadata: ["migration": .string(migration.name), "error": .string(String(reflecting: $0))])
         
             throw $0
         }
@@ -211,7 +211,7 @@ private final class DatabaseMigrator: Sendable {
         
             return MigrationLog.query(on: self.database).filter(\.$name == migration.name).delete()
         }.flatMapErrorThrowing {
-            self.database.logger.error("[Migrator] Failed revert: \(String(reflecting: $0))", metadata: ["migration": .string(migration.name)])
+            self.database.logger.error("[Migrator] Failed revert", metadata: ["migration": .string(migration.name), "error": .string(String(reflecting: $0))])
         
             throw $0
         }

--- a/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
+++ b/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
@@ -13,11 +13,11 @@ public struct DefaultBooleanPropertyFormat: BooleanPropertyFormat {
     public init() {}
     
     public func parse(_ value: Bool) -> Bool? {
-        return value
+        value
     }
     
     public func serialize(_ bool: Bool) -> Bool {
-        return bool
+        bool
     }
 }
 
@@ -42,7 +42,7 @@ public struct IntegerBooleanPropertyFormat<T: FixedWidthInteger & Codable & Send
     }
     
     public func serialize(_ bool: Bool) -> T {
-        return .zero.advanced(by: bool ? 1 : 0)
+        .zero.advanced(by: bool ? 1 : 0)
     }
 }
 
@@ -63,7 +63,7 @@ public struct OneZeroBooleanPropertyFormat: BooleanPropertyFormat {
     }
     
     public func serialize(_ bool: Bool) -> String {
-        return bool ? "1" : "0"
+        bool ? "1" : "0"
     }
 }
 
@@ -84,7 +84,7 @@ public struct YNBooleanPropertyFormat: BooleanPropertyFormat {
     }
     
     public func serialize(_ bool: Bool) -> String {
-        return bool ? "Y" : "N"
+        bool ? "Y" : "N"
     }
 }
 
@@ -106,7 +106,7 @@ public struct YesNoBooleanPropertyFormat: BooleanPropertyFormat {
     }
     
     public func serialize(_ bool: Bool) -> String {
-        return bool ? "YES" : "NO"
+        bool ? "YES" : "NO"
     }
 }
 
@@ -127,7 +127,7 @@ public struct OnOffBooleanPropertyFormat: BooleanPropertyFormat {
     }
         
     public func serialize(_ bool: Bool) -> String {
-        return bool ? "ON" : "OFF"
+        bool ? "ON" : "OFF"
     }
 }
 
@@ -148,7 +148,7 @@ public struct TrueFalseBooleanPropertyFormat: BooleanPropertyFormat {
     }
     
     public func serialize(_ bool: Bool) -> String {
-        return bool ? "true" : "false"
+        bool ? "true" : "false"
     }
 }
 

--- a/Sources/FluentKit/Properties/Children.swift
+++ b/Sources/FluentKit/Properties/Children.swift
@@ -1,5 +1,4 @@
 import NIOCore
-import NIOConcurrencyHelpers
 
 extension Model {
     public typealias Children<To> = ChildrenProperty<Self, To>
@@ -44,11 +43,11 @@ public final class ChildrenProperty<From, To>: @unchecked Sendable
     }
 
     public var projectedValue: ChildrenProperty<From, To> {
-        return self
+        self
     }
     
     public var fromId: From.IDValue? {
-        get { return self.idValue }
+        get { self.idValue }
         set { self.idValue = newValue }
     }
 
@@ -221,9 +220,8 @@ private struct ChildrenEagerLoader<From, To>: EagerLoader
         if (self.withDeleted) {
             builder.withDeleted()
         }
-        let models = UnsafeTransfer(wrappedValue: models)
         return builder.all().map {
-            for model in models.wrappedValue {
+            for model in models {
                 let id = model[keyPath: self.relationKey].idValue!
                 model[keyPath: self.relationKey].value = $0.filter { child in
                     switch parentKey {

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -199,6 +199,9 @@ private struct CompositeChildrenEagerLoader<From, To>: EagerLoader
         builder.group(.or) { query in
             _ = parentKey.queryFilterIds(ids, in: query)
         }
+        if self.withDeleted {
+            builder.withDeleted()
+        }
         
         return builder.all().map {
             let indexedResults = Dictionary(grouping: $0, by: { parentKey.referencedId(in: $0)! })

--- a/Sources/FluentKit/Properties/CompositeChildren.swift
+++ b/Sources/FluentKit/Properties/CompositeChildren.swift
@@ -1,5 +1,4 @@
 import NIOCore
-import NIOConcurrencyHelpers
 
 extension Model {
     /// A convenience alias for ``CompositeChildrenProperty``. It is strongly recommended that callers use this
@@ -107,7 +106,7 @@ public final class CompositeChildrenProperty<From, To>: @unchecked Sendable
     public var projectedValue: CompositeChildrenProperty<From, To> { self }
     
     public var fromId: From.IDValue? {
-        get { return self.idValue }
+        get { self.idValue }
         set { self.idValue = newValue }
     }
 
@@ -201,11 +200,10 @@ private struct CompositeChildrenEagerLoader<From, To>: EagerLoader
             _ = parentKey.queryFilterIds(ids, in: query)
         }
         
-        let models = UnsafeTransfer(wrappedValue: models)
         return builder.all().map {
             let indexedResults = Dictionary(grouping: $0, by: { parentKey.referencedId(in: $0)! })
             
-            for model in models.wrappedValue {
+            for model in models {
                 model[keyPath: self.relationKey].value = indexedResults[model[keyPath: self.relationKey].idValue!] ?? []
             }
         }

--- a/Sources/FluentKit/Properties/CompositeID.swift
+++ b/Sources/FluentKit/Properties/CompositeID.swift
@@ -18,7 +18,7 @@ public final class CompositeIDProperty<Model, Value>: @unchecked Sendable
     public var projectedValue: CompositeIDProperty<Model, Value> { self }
     
     public var wrappedValue: Value? {
-        get { return self.value }
+        get { self.value }
         set { self.value = newValue }
     }
 
@@ -29,7 +29,7 @@ public final class CompositeIDProperty<Model, Value>: @unchecked Sendable
     ) -> Nested
         where Nested: Property
     {
-        return self.value![keyPath: keyPath]
+        self.value![keyPath: keyPath]
     }
 }
 

--- a/Sources/FluentKit/Properties/CompositeOptionalChild.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalChild.swift
@@ -1,5 +1,4 @@
 import NIOCore
-import NIOConcurrencyHelpers
 
 extension Model {
     /// A convenience alias for ``CompositeOptionalChildProperty``. It is strongly recommended that callers use this
@@ -92,7 +91,7 @@ public final class CompositeOptionalChildProperty<From, To>: @unchecked Sendable
     public var projectedValue: CompositeOptionalChildProperty<From, To> { self }
     
     public var fromId: From.IDValue? {
-        get { return self.idValue }
+        get { self.idValue }
         set { self.idValue = newValue }
     }
 
@@ -185,14 +184,13 @@ private struct CompositeOptionalChildEagerLoader<From, To>: EagerLoader
         builder.group(.or) { query in
             _ = parentKey.queryFilterIds(ids, in: query)
         }
-        if (self.withDeleted) {
+        if self.withDeleted {
             builder.withDeleted()
         }
-        let models = UnsafeTransfer(wrappedValue: models)
         return builder.all().map {
             let indexedResults = Dictionary(grouping: $0, by: { parentKey.referencedId(in: $0)! })
             
-            for model in models.wrappedValue {
+            for model in models {
                 model[keyPath: self.relationKey].value = indexedResults[model[keyPath: self.relationKey].idValue!]?.first
             }
         }

--- a/Sources/FluentKit/Properties/Group.swift
+++ b/Sources/FluentKit/Properties/Group.swift
@@ -15,7 +15,7 @@ public final class GroupProperty<Model, Value>: @unchecked Sendable
     public var value: Value?
 
     public var projectedValue: GroupProperty<Model, Value> {
-        return self
+        self
     }
 
     public var wrappedValue: Value {

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -33,29 +33,21 @@ public final class IDProperty<Model, Value>: @unchecked Sendable
     var cachedOutput: (any DatabaseOutput)?
 
     public var key: FieldKey {
-        return self.field.key
+        self.field.key
     }
 
     var inputValue: DatabaseQuery.Value? {
-        get {
-            return self.field.inputValue
-        }
-        set {
-            self.field.inputValue = newValue
-        }
+        get { self.field.inputValue }
+        set { self.field.inputValue = newValue }
     }
 
     public var projectedValue: IDProperty<Model, Value> {
-        return self
+        self
     }
     
     public var wrappedValue: Value? {
-        get {
-            return self.value
-        }
-        set {
-            self.value = newValue
-        }
+        get { self.value }
+        set { self.value = newValue }
     }
 
     /// Initializes an `ID` property with the key `.id` and type `UUID`.
@@ -131,7 +123,7 @@ extension IDProperty: AnyProperty { }
 extension IDProperty: Property {
     public var value: Value? {
         get {
-            return self.field.value ?? nil
+            self.field.value ?? nil
         }
         set {
             self.field.value = newValue

--- a/Sources/FluentKit/Properties/OptionalChild.swift
+++ b/Sources/FluentKit/Properties/OptionalChild.swift
@@ -1,5 +1,4 @@
 import NIOCore
-import NIOConcurrencyHelpers
 
 extension Model {
     public typealias OptionalChild<To> = OptionalChildProperty<Self, To>
@@ -44,11 +43,11 @@ public final class OptionalChildProperty<From, To>: @unchecked Sendable
     }
 
     public var projectedValue: OptionalChildProperty<From, To> {
-        return self
+        self
     }
     
     public var fromId: From.IDValue? {
-        get { return self.idValue }
+        get { self.idValue }
         set { self.idValue = newValue }
     }
 
@@ -203,12 +202,12 @@ private struct OptionalChildEagerLoader<From, To>: EagerLoader
         case .required(let required):
             builder.filter(required.appending(path: \.$id) ~~ Set(ids))
         }
-        if (self.withDeleted) {
+        if self.withDeleted {
             builder.withDeleted()
         }
-        let models = UnsafeTransfer(wrappedValue: models)
+        let models = models
         return builder.all().map {
-            for model in models.wrappedValue {
+            for model in models {
                 let id = model[keyPath: self.relationKey].idValue!
                 let children = $0.filter { child in
                     switch parentKey {

--- a/Sources/FluentKit/Properties/OptionalField.swift
+++ b/Sources/FluentKit/Properties/OptionalField.swift
@@ -20,12 +20,8 @@ public final class OptionalFieldProperty<Model, WrappedValue>: @unchecked Sendab
     }
 
     public var wrappedValue: WrappedValue? {
-        get {
-            self.value ?? nil
-        }
-        set {
-            self.value = .some(newValue)
-        }
+        get { self.value ?? nil }
+        set { self.value = .some(newValue) }
     }
 
     public init(key: FieldKey) {

--- a/Sources/FluentKit/Properties/Parent.swift
+++ b/Sources/FluentKit/Properties/Parent.swift
@@ -1,5 +1,4 @@
 import NIOCore
-import NIOConcurrencyHelpers
 import struct SQLKit.SomeCodingKey
 
 extension Model {
@@ -27,7 +26,7 @@ public final class ParentProperty<From, To>: @unchecked Sendable
     }
 
     public var projectedValue: ParentProperty<From, To> {
-        return self
+        self
     }
 
     public var value: To?
@@ -41,7 +40,7 @@ public final class ParentProperty<From, To>: @unchecked Sendable
     }
 
     public func query(on database: any Database) -> QueryBuilder<To> {
-        return To.query(on: database)
+        To.query(on: database)
             .filter(\._$id == self.id)
     }
 }
@@ -166,15 +165,15 @@ private struct ParentEagerLoader<From, To>: EagerLoader
     let withDeleted: Bool
 
     func run(models: [From], on database: any Database) -> EventLoopFuture<Void> {
-        let sets = UnsafeTransfer(wrappedValue: Dictionary(grouping: models, by: { $0[keyPath: self.relationKey].id }))
-        let builder = To.query(on: database).filter(\._$id ~~ Set(sets.wrappedValue.keys))
-        if (self.withDeleted) {
+        let sets = Dictionary(grouping: models, by: { $0[keyPath: self.relationKey].id })
+        let builder = To.query(on: database).filter(\._$id ~~ Set(sets.keys))
+        if self.withDeleted {
             builder.withDeleted()
         }
         return builder.all().flatMapThrowing {
             let parents = Dictionary(uniqueKeysWithValues: $0.map { ($0.id!, $0) })
 
-            for (parentId, models) in sets.wrappedValue {
+            for (parentId, models) in sets {
                 guard let parent = parents[parentId] else {
                     database.logger.debug(
                         "Missing parent model in eager-load lookup results.",

--- a/Sources/FluentKit/Properties/Property.swift
+++ b/Sources/FluentKit/Properties/Property.swift
@@ -131,7 +131,7 @@ extension AnyQueryableProperty where Self: QueryableProperty {
     /// "identical encoding for identical property types" rule (see
     /// ``QueryableProperty/queryValue(_:)-5df0n``).
     public func queryableValue() -> DatabaseQuery.Value? {
-        return self.value.map { Self.queryValue($0) }
+        self.value.map { Self.queryValue($0) }
     }
 }
 

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -27,7 +27,7 @@ public final class TimestampProperty<Model, Format>
     let format: Format
 
     public var projectedValue: TimestampProperty<Model, Format> {
-        return self
+        self
     }
 
     public var wrappedValue: Date? {
@@ -190,7 +190,7 @@ extension Fields {
     }
     
     func touchTimestamps(_ triggers: TimestampTrigger...) {
-        return self.touchTimestamps(triggers)
+        self.touchTimestamps(triggers)
     }
 
     private func touchTimestamps(_ triggers: [TimestampTrigger]) {

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join+DirectRelations.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join+DirectRelations.swift
@@ -7,7 +7,7 @@ extension QueryBuilder {
     ///
     ///     Planet.query(on: db)
     ///         .join(from: Planet.self, parent: \.$star)
-    ///         .filter(Star.self, \Star.$name == "Sun")
+    ///         .filter(Star.self, \Star.$name == "Sol")
     ///
     /// - Parameters:
     ///   - model: The `Model` to join from
@@ -29,7 +29,7 @@ extension QueryBuilder {
     ///
     ///     Planet.query(on: db)
     ///         .join(parent: \.$star)
-    ///         .filter(Star.self, \Star.$name == "Sun")
+    ///         .filter(Star.self, \Star.$name == "Sol")
     ///
     /// - Parameters:
     ///   - parent: The `ParentProperty` to join
@@ -49,7 +49,7 @@ extension QueryBuilder {
     ///
     ///     Planet.query(on: db)
     ///         .join(from: Planet.self, parent: \.$star)
-    ///         .filter(Star.self, \Star.$name == "Sun")
+    ///         .filter(Star.self, \Star.$name == "Sol")
     ///
     /// - Parameters:
     ///   - model: The `Model` to join from
@@ -71,7 +71,7 @@ extension QueryBuilder {
     ///
     ///     Planet.query(on: db)
     ///         .join(parent: \.$star)
-    ///         .filter(Star.self, \Star.$name == "Sun")
+    ///         .filter(Star.self, \Star.$name == "Sol")
     ///
     /// - Parameters:
     ///   - parent: The `OptionalParentProperty` to join

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -162,18 +162,18 @@ public final class QueryBuilder<Model>
             }
         }
         #else
-        nonisolated(unsafe) var partial: [Result<UnsafeTransfer<Model>, any Error>] = []
+        nonisolated(unsafe) var partial: [Result<Model, any Error>] = []
         partial.reserveCapacity(max)
         
         return self.all { row in
-            partial.append(row.map { .init(wrappedValue: $0) })
+            partial.append(row)
             if partial.count >= max {
-                closure(partial.map { $0.map { $0.wrappedValue } })
+                closure(partial)
                 partial.removeAll(keepingCapacity: true)
             }
         }.flatMapThrowing {
             if !partial.isEmpty {
-                closure(partial.map { $0.map { $0.wrappedValue } })
+                closure(partial)
             }
         }
         #endif

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -368,5 +368,5 @@ public final class QueryBuilder<Model>
 }
 
 #if swift(<6) || !$InferSendableFromCaptures
-extension Swift.KeyPath: @unchecked Sendable {}
+extension Swift.KeyPath: @unchecked Swift.Sendable {}
 #endif

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -330,7 +330,9 @@ public final class QueryBuilder<Model>
             break
         }
 
-        self.database.logger.debug("\(self.query)")
+        // N.B.: We use `self.query` here instead of `query` so that the logging reflects the query the user requested,
+        // without having to deal with the noise of us having added default fields, or doing deletedAt checks, etc.
+        self.database.logger.debug("Running query", metadata: self.query.describedByLoggingMetadata)
         self.database.history?.add(self.query)
 
         let loop = self.database.eventLoop

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Field.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Field.swift
@@ -17,4 +17,15 @@ extension DatabaseQuery.Field: CustomStringConvertible {
             return "custom(\(custom))"
         }
     }
+
+    var describedByLoggingMetadata: Logger.MetadataValue {
+        switch self {
+        case .path(let array, let schema):
+            return "\(schema).\(array.map(\.description).joined(separator: "->"))"
+        case .extendedPath(let array, let schema, let space):
+            return "\(space.map { "\($0)." } ?? "")\(schema).\(array.map(\.description).joined(separator: "->"))"
+        case .custom:
+            return .stringConvertible(self)
+        }
+    }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Filter.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Filter.swift
@@ -73,6 +73,19 @@ extension DatabaseQuery.Filter: CustomStringConvertible {
             return "custom(\(any))"
         }
     }
+
+    var describedByLoggingMetadata: Logger.MetadataValue {
+        switch self {
+        case .value(let field, let method, let value):
+            return ["field": field.describedByLoggingMetadata, "method": "\(method)", "value": value.describedByLoggingMetadata]
+        case .field(let field, let method, let field2):
+            return ["field1": field.describedByLoggingMetadata, "method": "\(method)", "field2": field2.describedByLoggingMetadata]
+        case .group(let array, let relation):
+            return ["group": .array(array.map(\.describedByLoggingMetadata)), "relation": "\(relation)"]
+        case .custom:
+            return .stringConvertible(self)
+        }
+    }
 }
 
 extension DatabaseQuery.Filter.Method: CustomStringConvertible {

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Filter.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Filter.swift
@@ -65,13 +65,10 @@ extension DatabaseQuery.Filter: CustomStringConvertible {
         switch self {
         case .value(let field, let method, let value):
             return "\(field) \(method) \(value)"
-        
         case .field(let fieldA, let method, let fieldB):
             return "\(fieldA) \(method) \(fieldB)"
-        
         case .group(let filters, let relation):
-            return filters.map{ "(\($0.description))" }.joined(separator: " \(relation) ")
-        
+            return filters.map { "(\($0))" }.joined(separator: " \(relation) ")
         case .custom(let any):
             return "custom(\(any))"
         }
@@ -83,20 +80,16 @@ extension DatabaseQuery.Filter.Method: CustomStringConvertible {
         switch self {
         case .equality(let inverse):
             return inverse ? "!=" : "="
-
         case .order(let inverse, let equality):
             if equality {
                 return inverse ? "<=" : ">="
             } else {
                 return inverse ? "<" : ">"
             }
-
         case .subset(let inverse):
             return inverse ? "!~~" : "~~"
-
         case .contains(let inverse, let contains):
             return inverse ? "!\(contains)" : "\(contains)"
-        
         case .custom(let any):
             return "custom(\(any))"
         }
@@ -108,10 +101,8 @@ extension DatabaseQuery.Filter.Method.Contains: CustomStringConvertible {
         switch self {
         case .prefix:
             return "startswith"
-        
         case .suffix:
             return "endswith"
-        
         case .anywhere:
             return "contains"
         }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Join.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Join.swift
@@ -51,7 +51,29 @@ extension DatabaseQuery.Join: CustomStringConvertible {
             return "custom(\(custom))"
         }
     }
-    
+
+    var describedByLoggingMetadata: Logger.MetadataValue {
+        switch self {
+        case .join(let schema, let alias, let method, let foreign, let local):
+            return .dictionary([
+                "schema": "\(schema)", "alias": alias.map { "\($0)" }, "method": "\(method)",
+                "foreign": foreign.describedByLoggingMetadata, "local": local.describedByLoggingMetadata
+            ].compactMapValues { $0 })
+        case .extendedJoin(let schema, let space, let alias, let method, let foreign, let local):
+            return .dictionary([
+                "schema": "\(schema)", "space": space.map { "\($0)" }, "alias": alias.map { "\($0)" }, "method": "\(method)",
+                "foreign": foreign.describedByLoggingMetadata, "local": local.describedByLoggingMetadata
+            ].compactMapValues { $0 })
+        case .advancedJoin(let schema, let space, let alias, let method, let filters):
+            return .dictionary([
+                "schema": "\(schema)", "space": space.map { "\($0)" }, "alias": alias.map { "\($0)" }, "method": "\(method)",
+                "filters": .array(filters.map(\.describedByLoggingMetadata))
+            ].compactMapValues { $0 })
+        case .custom:
+            return .stringConvertible(self)
+        }
+    }
+
     private func schemaDescription(space: String? = nil, schema: String, alias: String?) -> String {
         [space, schema].compactMap({ $0 }).joined(separator: ".") + (alias.map { " as \($0)" } ?? "")
     }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Sort.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Sort.swift
@@ -19,6 +19,15 @@ extension DatabaseQuery.Sort: CustomStringConvertible {
             return "custom(\(custom))"
         }
     }
+
+    var describedByLoggingMetadata: Logger.MetadataValue {
+        switch self {
+        case .sort(let field, let direction):
+            return ["field": field.describedByLoggingMetadata, "direction": "\(direction)"]
+        case .custom:
+            return .stringConvertible(self)
+        }
+    }
 }
 
 extension DatabaseQuery.Sort.Direction: CustomStringConvertible {

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Value.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Value.swift
@@ -15,14 +15,14 @@ extension DatabaseQuery.Value: CustomStringConvertible {
         switch self {
         case .bind(let encodable):
             if let convertible = encodable as? any CustomDebugStringConvertible {
-                return convertible.debugDescription
+                return String(reflecting: convertible)
             } else {
-                return "\(encodable)"
+                return String(describing: encodable)
             }
         case .dictionary(let dictionary):
-            return dictionary.description
+            return String(describing: dictionary)
         case .array(let array):
-            return array.description
+            return String(describing: array)
         case .enumCase(let string):
             return string
         case .null:

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Value.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Value.swift
@@ -33,4 +33,13 @@ extension DatabaseQuery.Value: CustomStringConvertible {
             return "custom(\(custom))"
         }
     }
+
+    var describedByLoggingMetadata: Logger.MetadataValue {
+        switch self {
+        case .dictionary(let d): return .dictionary(.init(uniqueKeysWithValues: d.map { ($0.description, $1.describedByLoggingMetadata) }))
+        case .array(let a): return .array(a.map(\.describedByLoggingMetadata))
+        default: return .stringConvertible(self)
+        }
+    }
+
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery.swift
@@ -32,23 +32,25 @@ extension DatabaseQuery: CustomStringConvertible {
         var parts = [
             "query",
             "\(self.action)",
+            "\(self.space.map { "\($0)." } ?? "")\(self.schema)",
         ]
-        if let space = self.space {
-            parts.append("\(space).\(self.schema)")
-        } else {
-            parts.append(self.schema)
-        }
         if self.isUnique {
             parts.append("unique")
         }
         if !self.fields.isEmpty {
             parts.append("fields=\(self.fields)")
         }
+        if !self.joins.isEmpty {
+            parts.append("joins=\(self.joins)")
+        }
         if !self.filters.isEmpty {
             parts.append("filters=\(self.filters)")
         }
         if !self.input.isEmpty {
             parts.append("input=\(self.input)")
+        }
+        if !self.sorts.isEmpty {
+            parts.append("sorts=\(self.sorts)")
         }
         if !self.limits.isEmpty {
             parts.append("limits=\(self.limits)")
@@ -60,23 +62,27 @@ extension DatabaseQuery: CustomStringConvertible {
     }
     
     var describedByLoggingMetadata: Logger.Metadata {
-        func valueMetadata(_ input: DatabaseQuery.Value) -> Logger.MetadataValue {
-            switch input {
-            case .dictionary(let d): return .dictionary(.init(uniqueKeysWithValues: d.map { ($0.description, valueMetadata($1)) }))
-            case .array(let a): return .array(a.map { valueMetadata($0) })
-            default: return .stringConvertible(input)
-            }
-        }
-
-        return [
+        var result: Logger.Metadata = [
             "action": "\(self.action)",
             "schema": "\(self.space.map { "\($0)." } ?? "")\(self.schema)",
-            "unique": "\(self.isUnique)",
-            "fields": .array(self.fields.map { .stringConvertible($0) }),
-            "filters": .array(self.filters.map { .stringConvertible($0) }),
-            "input": self.input.count == 1 ? valueMetadata(self.input.first!) : .array(self.input.map { valueMetadata($0) }),
-            "limits": .array(self.limits.map { .stringConvertible($0) }),
-            "offsets": .array(self.offsets.map { .stringConvertible($0) }),
         ]
+        switch self.action {
+        case .create, .update, .custom: result["input"] = .array(self.input.map(\.describedByLoggingMetadata))
+        default: break
+        }
+        switch self.action {
+        case .read, .aggregate, .custom:
+            result["unique"] = "\(self.isUnique)"
+            result["fields"] = .array(self.fields.map(\.describedByLoggingMetadata))
+            result["joins"] = .array(self.joins.map(\.describedByLoggingMetadata))
+            fallthrough
+        case .update, .delete:
+            result["filters"] = .array(self.filters.map(\.describedByLoggingMetadata))
+            result["sorts"] = .array(self.sorts.map(\.describedByLoggingMetadata))
+            result["limits"] = .array(self.limits.map { .stringConvertible($0) })
+            result["offsets"] = .array(self.offsets.map { .stringConvertible($0) })
+        default: break
+        }
+        return result
     }
 }

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -25,7 +25,6 @@ public struct DatabaseSchema: Sendable {
         case uint32
         case uint64
         
-        
         case bool
         
         public struct Enum: Sendable {

--- a/Sources/FluentKit/Schema/SchemaBuilder.swift
+++ b/Sources/FluentKit/Schema/SchemaBuilder.swift
@@ -1,6 +1,6 @@
 extension Database {
     public func schema(_ schema: String, space: String? = nil) -> SchemaBuilder {
-        return .init(database: self, schema: schema, space: space)
+        .init(database: self, schema: schema, space: space)
     }
 }
 

--- a/Sources/FluentKit/Utilities/OptionalType.swift
+++ b/Sources/FluentKit/Utilities/OptionalType.swift
@@ -11,7 +11,7 @@ public protocol OptionalType: AnyOptionalType {
 
 extension OptionalType {
     public static var wrappedType: Any.Type {
-        return Wrapped.self
+        Wrapped.self
     }
 }
 

--- a/Sources/FluentKit/Utilities/UnsafeMutableTransferBox.swift
+++ b/Sources/FluentKit/Utilities/UnsafeMutableTransferBox.swift
@@ -1,7 +1,3 @@
-struct UnsafeTransfer<Wrapped>: @unchecked Sendable {
-    var wrappedValue: Wrapped
-}
-
 @usableFromInline
 final class UnsafeMutableTransferBox<Wrapped>: @unchecked Sendable {
     @usableFromInline

--- a/Sources/FluentSQL/SQLJSONColumnPath+Deprecated.swift
+++ b/Sources/FluentSQL/SQLJSONColumnPath+Deprecated.swift
@@ -1,7 +1,7 @@
 import SQLKit
 import FluentKit
 
-/// A thin deprecated wrapper around ``SQLKit/SQLNestedSubpathExpression``.
+/// A thin deprecated wrapper around `SQLNestedSubpathExpression`.
 @available(*, deprecated, message: "Replaced by `SQLNestedSubpathExpression` in SQLKit")
 public struct SQLJSONColumnPath: SQLExpression {
     private var realExpression: SQLNestedSubpathExpression

--- a/Sources/FluentSQL/SQLList+Deprecated.swift
+++ b/Sources/FluentSQL/SQLList+Deprecated.swift
@@ -1,6 +1,6 @@
 import SQLKit
 
-/// This file provides a few extensions to SQLKit's ``SQLList`` which have the effect of mimicking
+/// This file provides a few extensions to SQLKit's `SQLList` which have the effect of mimicking
 /// the public API which was previously provided by a nearly-identical type of the same name in
 /// this module. The slightly differing behavior of the Fluent version had a tendency to cause
 /// confusion when both `FluentSQL` and `SQLKit` were imported in the same context; as such, the
@@ -9,7 +9,7 @@ import SQLKit
 /// Fluent implementation available. Whether the original or alternate serialization behavior is used
 /// is based on which initializer is used. The original SQLKit initializer, ``init(_:separator:)`` (or
 /// ``init(_:)``, taking the default value for the separator), gives the original and intended behavior
-/// (see ``SQLKit/SQLList`` for further details). The convenience intializer, ``init(items:separator:)``,
+/// (see `SQLList` for further details). The convenience intializer, ``init(items:separator:)``,
 /// enables the deprecated alternate behavior, which adds a space character before and after the separator.
 ///
 /// Examples:
@@ -25,7 +25,7 @@ import SQLKit
 ///     Alternate serialization: 1 ,  2 ,  3 ,  4 ,  5
 ///
 /// > Warning: These extensions are not recommended, as it was never intended for this behavior to be
-/// > public. Convert code using these extensions to invoke the original ``SQLKit/SQLList`` directly.
+/// > public. Convert code using these extensions to invoke the original `SQLList` directly.
 extension SQLKit.SQLList {
     @available(*, deprecated, message: "Use `expressions` instead.")
     public var items: [any SQLExpression] {

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -232,7 +232,7 @@ public struct SQLQueryConverter {
     private func aggregate(_ aggregate: DatabaseQuery.Aggregate, isUnique: Bool) -> any SQLExpression {
         switch aggregate {
         case .custom(let any):
-            return any as! any SQLExpression
+            return custom(any)
         case .field(let field, let method):
             let name: String
             

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -263,7 +263,7 @@ final class AsyncQueryBuilderTests: XCTestCase {
         let planets = try await Planet.query(on: test.db)
             .join(Star.self, on: \Star.$id == \Planet.$star.$id)
             .filter(\.$name, .custom("ilike"), "earth")
-            .filter(Star.self, \.$name, .custom("ilike"), "sun")
+            .filter(Star.self, \.$name, .custom("ilike"), "Sol")
             .all()
         XCTAssertEqual(planets.count, 0)
         XCTAssertNotNil(query.wrappedValue?.filters[1])
@@ -288,7 +288,7 @@ final class AsyncQueryBuilderTests: XCTestCase {
             }
             switch value {
             case .bind(let any as String):
-                XCTAssertEqual(any, "sun")
+                XCTAssertEqual(any, "Sol")
             default:
                 XCTFail("\(value)")
             }

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -155,7 +155,7 @@ final class QueryBuilderTests: XCTestCase {
         let planets = try Planet.query(on: test.db)
             .join(Star.self, on: \Star.$id == \Planet.$star.$id)
             .filter(\.$name, .custom("ilike"), "earth")
-            .filter(Star.self, \.$name, .custom("ilike"), "sun")
+            .filter(Star.self, \.$name, .custom("ilike"), "Sol")
             .all().wait()
         XCTAssertEqual(planets.count, 0)
         XCTAssertNotNil(query.wrappedValue?.filters[1])
@@ -180,7 +180,7 @@ final class QueryBuilderTests: XCTestCase {
             }
             switch value {
             case .bind(let any as String):
-                XCTAssertEqual(any, "sun")
+                XCTAssertEqual(any, "Sol")
             default: 
                 XCTFail("\(value)")
             }
@@ -193,10 +193,10 @@ final class QueryBuilderTests: XCTestCase {
         let db = DummyDatabaseForTestSQLSerializer()
         _ = try Planet.query(on: db)
             .join(Planet.self,  Star.self,
-                  on: .custom(#"LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun'"#))
+                  on: .custom(#"LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sol'"#))
             .all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
-        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "planets"."deleted_at" AS "planets_deleted_at", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id", "stars"."deleted_at" AS "stars_deleted_at" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sun' WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1) AND ("stars"."deleted_at" IS NULL OR "stars"."deleted_at" > $2)"#)
+        XCTAssertEqual(db.sqlSerializers.first?.sql, #"SELECT "planets"."id" AS "planets_id", "planets"."name" AS "planets_name", "planets"."star_id" AS "planets_star_id", "planets"."possible_star_id" AS "planets_possible_star_id", "planets"."deleted_at" AS "planets_deleted_at", "stars"."id" AS "stars_id", "stars"."name" AS "stars_name", "stars"."galaxy_id" AS "stars_galaxy_id", "stars"."deleted_at" AS "stars_deleted_at" FROM "planets" LEFT JOIN "stars" ON "stars"."id" = "planets"."id" AND "stars"."name" = 'Sol' WHERE ("planets"."deleted_at" IS NULL OR "planets"."deleted_at" > $1) AND ("stars"."deleted_at" IS NULL OR "stars"."deleted_at" > $2)"#)
     }
     
     func testComplexJoinOperators() throws {


### PR DESCRIPTION
This update contains the following fixes and changes:

- Logging (especially of Fluent queries) is now done in structured fashion using metadata, as [recommended for logging in libraries](https://www.swift.org/documentation/server/guides/libraries/log-levels.html).
- Several superfluous `Sendable` workarounds have been removed (they were never needed).
- Resolved several DocC warnings.
- When using eager loading with `@CompositeChildren` properties, specifying `withDeleted: true` now works (previously the flag was ignored).
- `query.aggregate(.custom(.sql(...)))` now works correctly (previously only plain strings were handled for custom aggregates)
- Fixed a `FluentBenchmarks` test so that it actually tests what it claims to.
- Fixed numerous `FluentBenchmarks` tests so they no longer crash if something goes wrong during migrations.
- `ISO8601TimestampFormat` now correctly respects the milliseconds setting on a case-by-case basis when used in both modes in the same application (the behavior was previously nondeterministic).