### PR TITLE
Add async APIs for shutting down the databases

### DIFF
--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -57,6 +57,13 @@ extension Database {
 public protocol DatabaseDriver: Sendable {
     func makeDatabase(with context: DatabaseContext) -> any Database
     func shutdown()
+    func shutdownAsync() async
+}
+
+public extension DatabaseDriver {
+    func shutdownAsync() async {
+        shutdown()
+    }
 }
 
 public protocol DatabaseConfiguration: Sendable {


### PR DESCRIPTION
To enable removing calls to `.wait()` in the connection pools when in an async context
