### PR TITLE
joined

### DIFF
--- a/Sources/FluentKit/Model/AnyModel.swift
+++ b/Sources/FluentKit/Model/AnyModel.swift
@@ -14,17 +14,31 @@ extension AnyModel {
         
         return "\(Self.self)(\(info.isEmpty ? ":" : info.map { "\($0): \($1)" }.joined(separator: ", ")))"
     }
+  
+  public func layout<Joined>(_ model: Joined.Type) throws -> Joined
+      where Joined: Schema
+  {
+      guard let output = self.anyID.cachedOutput else {
+          fatalError("Can only access joined models using models fetched from database (from \(Self.self) to \(Joined.self)).")
+      }
+      let joined = Joined()
+      try joined.output(from: output.qualifiedSchema(space: Joined.spaceIfNotAliased, Joined.schemaOrAlias))
+      return joined
+  }
 
     // MARK: Joined
 
     public func joined<Joined>(_ model: Joined.Type) throws -> Joined
-        where Joined: Schema
+        where Joined: Schema & Model
     {
         guard let output = self.anyID.cachedOutput else {
             fatalError("Can only access joined models using models fetched from database (from \(Self.self) to \(Joined.self)).")
         }
         let joined = Joined()
         try joined.output(from: output.qualifiedSchema(space: Joined.spaceIfNotAliased, Joined.schemaOrAlias))
+        guard (try? joined.requireID()) != nil else {
+            fatalError("Can only access joined models using models fetched from database (from \(Self.self) to \(Joined.self)).")
+        }
         return joined
     }
 


### PR DESCRIPTION
joined try concession is misleading, expecting a throw if model does not exists. yet works flawlessly event model not in query. this separation between layout and joined keeps existing functionality and extends it by desired behaviour to disrupt execution once result does not meet expectation. layout is a plain copy of the function joined and its intend is to retrieve the layout of any model as a fluent object. ion the otherhand joined should retrieve the model from a query and throw once this not happens.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
