### PR TITLE
Upgrade Async Kit to 1.20.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.3"),
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.20.0"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.3"),
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.20.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Currently Fluent SQLite driver silently depends on features (specifically the `shutdownAsync` function) introduced in Async Kit 1.20.0. That dependency is transient, without specifying Async Kit in the SQLite driver's Package.swift, causing a compilation error when an earlier version (like 1.19.0) is used.

It would probably be more correct to specifically add that dependency in the SQLite driver's Package.swift, but personally I don't see anything wrong with just updating it here.