### PR TITLE
feat(Migrations): added migration group protocol and method

### DIFF
--- a/Sources/FluentKit/Migration/Migrations.swift
+++ b/Sources/FluentKit/Migration/Migrations.swift
@@ -1,8 +1,12 @@
 import NIOConcurrencyHelpers
 
+public protocol MigrationsGroup {
+    var migrations : [any Migration] { get set }
+} 
+
 public final class Migrations: Sendable {
     let storage: NIOLockedValueBox<[DatabaseID?: [any Migration]]>
-    
+
     public init() {
         self.storage = .init([:])
     }
@@ -18,5 +22,11 @@ public final class Migrations: Sendable {
 
     public func add(_ migrations: [any Migration], to id: DatabaseID? = nil) {
         self.storage.withLockedValue { $0[id, default: []].append(contentsOf: migrations) }
+    }
+
+    public func addGroup(_ group: any MigrationsGroup, to id: DatabaseID? = nil) { 
+        for migration in group.migrations {
+            self.add(migration, to: id)
+        }
     }
 }


### PR DESCRIPTION
This is useful, because in big apps where there is hundreds of migrations, using `app.migrations.add` will make the `configure.swift` file really long. Instead, migration groups can be created for each model, and then simply adding the group to `app.migrations` using the `addGroup` method.
