### PR TITLE
Be more specific about which model's ID property is missing in error message

### DIFF
--- a/Sources/FluentKit/Model/AnyModel.swift
+++ b/Sources/FluentKit/Model/AnyModel.swift
@@ -40,6 +40,6 @@ extension AnyModel {
                 return idChild
             }
         }
-        fatalError("id property must be declared using @ID or @CompositeID")
+        fatalError("id property for model \(Self.self) must be declared using @ID or @CompositeID")
     }
 }


### PR DESCRIPTION
If a model's `id` property is missing or incorrectly declared, the `fatalError()` which is triggered now includes the name of the model in question.