### PR TITLE
fix: handle nil CompositeIDProperty value during database insert

### DIFF
--- a/Sources/FluentKit/Properties/CompositeID.swift
+++ b/Sources/FluentKit/Properties/CompositeID.swift
@@ -51,7 +51,9 @@ extension CompositeIDProperty: AnyDatabaseProperty {
     }
 
     public func input(to input: any DatabaseInput) {
-        self.value!.input(to: input)
+        if let value = self.value {
+            value.input(to: input)
+        }
     }
 
     public func output(from output: any DatabaseOutput) throws {


### PR DESCRIPTION
The CompositeIDProperty was force-unwrapping its value during database input, which would crash if the value was nil. This could happen during initial inserts where the composite ID is meant to be set by a database trigger. Now checks if value exists before attempting to input it.