### PR TITLE
Enable the MirrorBypass logic in Swift 6

### DIFF
--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -1,4 +1,4 @@
-#if compiler(<6)
+#if compiler(<6.1)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
@@ -24,7 +24,7 @@ internal struct _FastChildIterator: IteratorProtocol {
         deinit { self.freeFunc(self.ptr) }
     }
     
-    #if compiler(<6)
+    #if compiler(<6.1)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -34,7 +34,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     #endif
     private var lastNameBox: _CStringBox?
     
-    #if compiler(<6)
+    #if compiler(<6.1)
     fileprivate init(subject: AnyObject, type: Any.Type, childCount: Int) {
         self.subject = subject
         self.type = type
@@ -48,7 +48,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     #endif
     
     init(subject: AnyObject) {
-        #if compiler(<6)
+        #if compiler(<6.1)
         let type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.init(
             subject: subject,
@@ -69,7 +69,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     /// > Note: Ironically, in the fallback case that uses `Mirror` directly, preserving this semantic actually imposes
     /// > an _additional_ performance penalty.
     mutating func next() -> (name: UnsafePointer<CChar>?, child: Any)? {
-        #if compiler(<6)
+        #if compiler(<6.1)
         guard self.index < self.childCount else {
             self.lastNameBox = nil // ensure any lingering name gets freed
             return nil
@@ -105,7 +105,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 }
 
 internal struct _FastChildSequence: Sequence {
-    #if compiler(<6)
+    #if compiler(<6.1)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -114,7 +114,7 @@ internal struct _FastChildSequence: Sequence {
     #endif
 
     init(subject: AnyObject) {
-        #if compiler(<6)
+        #if compiler(<6.1)
         self.subject = subject
         self.type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.childCount = _getChildCount(subject, type: self.type)
@@ -124,7 +124,7 @@ internal struct _FastChildSequence: Sequence {
     }
     
     func makeIterator() -> _FastChildIterator {
-        #if compiler(<6)
+        #if compiler(<6.1)
         _FastChildIterator(subject: self.subject, type: self.type, childCount: self.childCount)
         #else
         _FastChildIterator(iterator: self.children.makeIterator())


### PR DESCRIPTION
It turns out that the "bypass" for `Mirror` works fine in Swift 6, so let's use it.