### PR TITLE
Partial fix for nested keypaths through `@CompositeOptionalParent` properties

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
   linux-integration-sqlite:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.10-jammy
+    container: swift:6.0-noble
     steps:
       - name: Check out package
         uses: actions/checkout@v4
@@ -58,10 +58,10 @@ jobs:
   linux-integration-mysql:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.10-jammy
+    container: swift:6.0-noble
     services:
-      mysql-a: { image: 'mysql:8', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
-      mysql-b: { image: 'mysql:8', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
+      mysql-a: { image: 'mysql:9', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
+      mysql-b: { image: 'mysql:9', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
     steps:
       - name: Check out package
         uses: actions/checkout@v4
@@ -77,10 +77,10 @@ jobs:
   linux-integration-psql:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.10-jammy
+    container: swift:6.0-noble
     services:
-      psql-a: { image: 'postgres:16', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
-      psql-b: { image: 'postgres:16', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
+      psql-a: { image: 'postgres:17', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
+      psql-b: { image: 'postgres:17', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
     steps:
       - name: Check out package
         uses: actions/checkout@v4
@@ -96,7 +96,7 @@ jobs:
   linux-integration-mongo:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.10-jammy
+    container: swift:6.0-noble
     services:
       mongo-a: { image: 'mongo:6' }
       mongo-b: { image: 'mongo:6' }
@@ -115,3 +115,6 @@ jobs:
   unit-tests:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
     secrets: inherit
+    with:
+      with_musl: true
+      with_android: true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/fluent-kit/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/fluent-kit/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
 <a href="https://codecov.io/github/vapor/fluent-kit"><img src="https://img.shields.io/codecov/c/github/vapor/fluent-kit?style=plastic&logo=codecov&label=codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift58up.svg" alt="Swift 5.8+"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift59up.svg" alt="Swift 5.9+"></a>
 </p>
 
 <br>

--- a/Sources/FluentBenchmark/Tests/SchemaTests.swift
+++ b/Sources/FluentBenchmark/Tests/SchemaTests.swift
@@ -35,7 +35,7 @@ extension FluentBenchmarker {
             do {
                 try Category(name: "a").create(on: self.database).wait()
                 XCTFail("Duplicate save should have errored")
-            } catch let error as DatabaseError where error.isConstraintFailure {
+            } catch let error as any DatabaseError where error.isConstraintFailure {
                 // pass
             }
 
@@ -61,7 +61,7 @@ extension FluentBenchmarker {
             do {
                 try Category(name: "a").create(on: self.database).wait()
                 XCTFail("Duplicate save should have errored")
-            } catch let error as DatabaseError where error.isConstraintFailure {
+            } catch let error as any DatabaseError where error.isConstraintFailure {
                 // pass
             }
 

--- a/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
+++ b/Sources/FluentBenchmark/Tests/SoftDeleteTests.swift
@@ -92,7 +92,7 @@ extension FluentBenchmarker {
             )
 
             // Delete all models
-            sleep(1)
+            Thread.sleep(forTimeInterval: 1.0)
             try Trash.query(on: self.database).delete().wait()
 
             // Make sure the `.deletedAt` value doesn't change.

--- a/Sources/FluentBenchmark/Tests/UniqueTests.swift
+++ b/Sources/FluentBenchmark/Tests/UniqueTests.swift
@@ -18,7 +18,7 @@ extension FluentBenchmarker {
             do {
                 try Foo(bar: "a", baz: 1).save(on: self.database).wait()
                 XCTFail("should have failed")
-            } catch let error where error is DatabaseError {
+            } catch let error where error is any DatabaseError {
                 // pass
             }
         }

--- a/Sources/FluentKit/Docs.docc/theme-settings.json
+++ b/Sources/FluentKit/Docs.docc/theme-settings.json
@@ -8,6 +8,9 @@
       "fluentkit": { "dark": "hsl(200, 75%, 85%)", "light": "hsl(200, 75%, 75%)" },
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-fluentkit) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-fluentkit)",
+      "documentation-intro-eyebrow": "white",
+      "documentation-intro-figure": "white",
+      "documentation-intro-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }

--- a/Sources/FluentKit/Properties/CompositeOptionalParent.swift
+++ b/Sources/FluentKit/Properties/CompositeOptionalParent.swift
@@ -111,7 +111,7 @@ public final class CompositeOptionalParentProperty<From, To>: @unchecked Sendabl
     public subscript<Nested>(dynamicMember keyPath: KeyPath<To.IDValue, Nested>) -> Nested?
         where Nested: Property
     {
-        self.id?[keyPath: keyPath]
+        (self.id ?? To.IDValue())[keyPath: keyPath]
     }
 }
 

--- a/Sources/FluentSQL/Docs.docc/theme-settings.json
+++ b/Sources/FluentSQL/Docs.docc/theme-settings.json
@@ -8,6 +8,9 @@
       "fluentkit": { "dark": "hsl(200, 75%, 85%)", "light": "hsl(200, 75%, 75%)" },
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-fluentkit) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-fluentkit)",
+      "documentation-intro-eyebrow": "white",
+      "documentation-intro-figure": "white",
+      "documentation-intro-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }

--- a/Sources/XCTFluent/Docs.docc/theme-settings.json
+++ b/Sources/XCTFluent/Docs.docc/theme-settings.json
@@ -8,6 +8,9 @@
       "fluentkit": { "dark": "hsl(200, 75%, 85%)", "light": "hsl(200, 75%, 75%)" },
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-fluentkit) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-fluentkit)",
+      "documentation-intro-eyebrow": "white",
+      "documentation-intro-figure": "white",
+      "documentation-intro-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }

--- a/Tests/FluentKitTests/CompositeIDTests.swift
+++ b/Tests/FluentKitTests/CompositeIDTests.swift
@@ -366,6 +366,10 @@ final class CompositeIDTests: XCTestCase {
         let moon3_1 = try unjsonString(#"{"id":\#(moonJId),"name":"B","orbiting":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}}},"planetoid":{"id":{"normalizedOrdinal":1,"solarSystem":{"id":\#(sysJId)}},"name":"A"},"progenitor":{"id":null}}"#, as: CompositeMoon.self)
         XCTAssertNilNil(moon3_1.$planetoid.value)
     }
+
+    func testCompositeOptionalParentNestedKeyPathFieldKey() {
+        XCTAssertEqual(CompositeMoon()[keyPath: \.$progenitor.$normalizedOrdinal!.queryablePath][0].description, "nrm_ord")
+    }
 }
 
 fileprivate func XCTAssertNilNil<V>(_ expression: @autoclosure () throws -> Optional<Optional<V>>, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -792,7 +792,9 @@ final class FluentKitTests: XCTestCase {
         XCTAssertEqual(db.sqlSerializers.count, 1)
         XCTAssertEqual(db.sqlSerializers.first?.sql, #"INSERT INTO "foos" ("id", "opt") VALUES ($1, DEFAULT), ($2, NULL), ($3, $4)"#)
     }
-    
+
+    // Disabled because it doesn't really tell much of anything useful.
+    /*
     func testFieldsPropertiesPerformance() throws {
         measure {
             let model = LotsOfFields()
@@ -801,6 +803,7 @@ final class FluentKitTests: XCTestCase {
             }
         }
     }
+    */
 }
 
 final class User: Model, @unchecked Sendable {


### PR DESCRIPTION
As with `@CompositeParent`, keypaths through `@CompositeOptionalParent` can refer to properties of the target model's composite `IDValue`. However, the `subscript(dynamicMember:)` accessor of `@CompositeOptionalParent` which enables this functionality returns an optional value, and the result is always `nil` if the relation has not been loaded.

This was caused by an oversight during the original implementation of the composite relation properties: The accessor should not be returning an optional value, nor should the result ever be `nil` regardless of whether or not the relation is loaded. We can't fix the fact that it returns an optional without breaking public API, so callers still have to add a `!` in the nested keypaths. But we can at least make the accessor useful by fixing it to never return `nil`, which is what this PR does. A test is also included.

Also updates the CI while we're at it.

Example (omits some boilerplate for brevity):
```swift
final class ParentModel: Model, @unchecked Sendable {
    final class IDValue: Fields, @unchecked Sendable {
        @Field(key: "foo")
        var foo: String
    }

    @CompositeID var id: IDValue?
}

final class ChildModel: Model, @unchecked Sendable {
    @ID
    var id: UUID?

    @CompositeOptionalParent(prefix: "parent")
    var parent: ParentModel?
}

// This would previously print `nil`.
print(ChildModel()[keyPath: \ChildModel.$parent.$foo?.queryablePath][0]) // prints Optional("foo")
```