### PR TITLE
Add the missing `.sql()` helpers for various DatabaseQuery types to FluentSQL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
         .library(name: "XCTFluent", targets: ["XCTFluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.79.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.32.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.20.0"),
     ],
@@ -26,7 +26,9 @@ let package = Package(
             name: "FluentKit",
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "AsyncKit", package: "async-kit"),
                 .product(name: "SQLKit", package: "sql-kit"),

--- a/Sources/FluentKit/Database/Database.swift
+++ b/Sources/FluentKit/Database/Database.swift
@@ -28,7 +28,7 @@ extension Database {
     public func query<Model>(_ model: Model.Type) -> QueryBuilder<Model>
         where Model: FluentKit.Model
     {
-        return .init(database: self)
+        .init(database: self)
     }
 }
 

--- a/Sources/FluentKit/Database/DatabaseOutput.swift
+++ b/Sources/FluentKit/Database/DatabaseOutput.swift
@@ -28,7 +28,7 @@ extension DatabaseOutput {
     }
 
     public func cascading(to output: any DatabaseOutput) -> any DatabaseOutput {
-        return CombinedOutput(first: self, second: output)
+        CombinedOutput(first: self, second: output)
     }
 }
 

--- a/Sources/FluentKit/Database/KeyPrefixingStrategy.swift
+++ b/Sources/FluentKit/Database/KeyPrefixingStrategy.swift
@@ -19,13 +19,13 @@ public enum KeyPrefixingStrategy: CustomStringConvertible, Sendable {
     public var description: String {
         switch self {
         case .none:
-            return ".useDefaultKeys"
+            ".useDefaultKeys"
         case .camelCase:
-            return ".camelCase"
+            ".camelCase"
         case .snakeCase:
-            return ".snakeCase"
+            ".snakeCase"
         case .custom(_):
-            return ".custom(...)"
+            ".custom(...)"
         }
     }
     
@@ -33,23 +33,23 @@ public enum KeyPrefixingStrategy: CustomStringConvertible, Sendable {
     public func apply(prefix: FieldKey, to key: FieldKey) -> FieldKey {
         switch self {
         case .none:
-            return .prefix(prefix, key)
+            .prefix(prefix, key)
         
         // This strategy converts `.id` and `.aggregate` keys (but not prefixes) into generic `.string()`s.
         case .camelCase:
             switch key {
             case .id, .aggregate, .string(_):
-                return .prefix(prefix, .string(key.description.withUppercasedFirstCharacter()))
+                .prefix(prefix, .string(key.description.withUppercasedFirstCharacter()))
 
             case .prefix(let originalPrefix, let originalSuffix):
-                return .prefix(self.apply(prefix: prefix, to: originalPrefix), originalSuffix)
+                .prefix(self.apply(prefix: prefix, to: originalPrefix), originalSuffix)
             }
 
         case .snakeCase:
-            return .prefix(.prefix(prefix, .string("_")), key)
+            .prefix(.prefix(prefix, .string("_")), key)
 
         case .custom(let closure):
-            return closure(prefix, key)
+            closure(prefix, key)
         }
     }
 }

--- a/Sources/FluentKit/Enum/EnumProperty.swift
+++ b/Sources/FluentKit/Enum/EnumProperty.swift
@@ -17,7 +17,7 @@ public final class EnumProperty<Model, Value>
     public let field: FieldProperty<Model, String>
 
     public var projectedValue: EnumProperty<Model, Value> {
-        return self
+        self
     }
 
     public var wrappedValue: Value {

--- a/Sources/FluentKit/Enum/OptionalEnumProperty.swift
+++ b/Sources/FluentKit/Enum/OptionalEnumProperty.swift
@@ -17,7 +17,7 @@ public final class OptionalEnumProperty<Model, WrappedValue>
     public let field: OptionalFieldProperty<Model, String>
 
     public var projectedValue: OptionalEnumProperty<Model, WrappedValue> {
-        return self
+        self
     }
 
     public var wrappedValue: WrappedValue? {

--- a/Sources/FluentKit/FluentError.swift
+++ b/Sources/FluentKit/FluentError.swift
@@ -12,17 +12,17 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible, CustomD
     public var description: String {
         switch self {
         case .idRequired:
-            return "ID required"
+            "ID required"
         case .missingField(let name):
-            return "field missing: \(name)"
+            "field missing: \(name)"
         case .relationNotLoaded(let name):
-            return "relation not loaded: \(name)"
+            "relation not loaded: \(name)"
         case .missingParent(let model, let parent, let key, let id):
-            return "parent missing: \(model).\(key): \(parent).\(id)"
+            "parent missing: \(model).\(key): \(parent).\(id)"
         case .invalidField(let name, let valueType, let error):
-            return "invalid field: '\(name)', type: \(valueType), error: \(String(describing: error))"
+            "invalid field: '\(name)', type: \(valueType), error: \(String(describing: error))"
         case .noResults:
-            return "Query returned no results"
+            "Query returned no results"
         }
     }
 
@@ -30,9 +30,9 @@ public enum FluentError: Error, LocalizedError, CustomStringConvertible, CustomD
     public var debugDescription: String {
         switch self {
         case .idRequired, .missingField(_), .relationNotLoaded(_), .missingParent(_, _, _, _), .noResults:
-            return self.description
+            self.description
         case .invalidField(let name, let valueType, let error):
-            return "invalid field: '\(name)', type: \(valueType), error: \(String(reflecting: error))"
+            "invalid field: '\(name)', type: \(valueType), error: \(String(reflecting: error))"
         }
     }
 
@@ -119,9 +119,9 @@ public enum SiblingsPropertyError: Error, LocalizedError, CustomStringConvertibl
     public var description: String {
         switch self {
         case .owningModelIdRequired(property: let property):
-            return "siblings relation \(property) is missing owning model's ID (owner likely unsaved)"
+            "siblings relation \(property) is missing owning model's ID (owner likely unsaved)"
         case .operandModelIdRequired(property: let property):
-            return "operant model for siblings relation \(property) has no ID (attach/detach/etc. model likely unsaved)"
+            "operant model for siblings relation \(property) has no ID (attach/detach/etc. model likely unsaved)"
         }
     }
     

--- a/Sources/FluentKit/Migration/Migration.swift
+++ b/Sources/FluentKit/Migration/Migration.swift
@@ -24,7 +24,7 @@ public protocol Migration: Sendable {
 
 extension Migration {
     public var name: String {
-        return defaultName
+        self.defaultName
     }
 
     internal var defaultName: String {

--- a/Sources/FluentKit/Migration/Migration.swift
+++ b/Sources/FluentKit/Migration/Migration.swift
@@ -28,7 +28,7 @@ extension Migration {
     }
 
     internal var defaultName: String {
-        #if compiler(<6)
+        #if compiler(<6.1)
         /// `String.init(reflecting:)` creates a `Mirror` unconditionally, but
         /// when the parameter is a metatype (such as is the case here), that
         /// mirror is never actually used for anything. Unfortunately, just

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -84,7 +84,8 @@ public struct Migrator: Sendable {
     
     public func previewRevertBatch() -> EventLoopFuture<[(any Migration, DatabaseID?)]> {
         self.migrators() { migrator in
-            return migrator.previewPrepareBatch().and(value: migrator.id)
+            // This is not correct, but can't be fixed as it would require changing this API's parameters.
+            migrator.previewPrepareBatch().and(value: migrator.id)
         }.map {
             $0.flatMap { migrations, id in migrations.map { ($0, id) } }
         }

--- a/Sources/FluentKit/Model/EagerLoad.swift
+++ b/Sources/FluentKit/Model/EagerLoad.swift
@@ -46,6 +46,6 @@ extension EagerLoadable {
         withDeleted: Bool,
         to builder: Builder
     ) where Builder: EagerLoadBuilder, Builder.Model == From {
-        return Self.eagerLoad(relationKey, to: builder)
+        Self.eagerLoad(relationKey, to: builder)
     }
 }

--- a/Sources/FluentKit/Model/Fields.swift
+++ b/Sources/FluentKit/Model/Fields.swift
@@ -160,8 +160,7 @@ extension Fields {
     ///
     /// Returns a dictionary of field keys and associated values representing all "pending"
     /// data - e.g. all fields (if any) which have been changed by something other than Fluent.
-    @_spi(FluentSQLSPI)
-    public/*package*/ func collectInput(withDefaultedValues defaultedValues: Bool = false) -> [FieldKey: DatabaseQuery.Value] {
+    package func collectInput(withDefaultedValues defaultedValues: Bool = false) -> [FieldKey: DatabaseQuery.Value] {
         let input = DictionaryInput(wantsUnmodifiedKeys: defaultedValues)
         self.input(to: input)
         return input.storage

--- a/Sources/FluentKit/Model/Model+CRUD.swift
+++ b/Sources/FluentKit/Model/Model+CRUD.swift
@@ -4,9 +4,9 @@ import protocol SQLKit.SQLDatabase
 extension Model {
     public func save(on database: any Database) -> EventLoopFuture<Void> {
         if self._$idExists {
-            return self.update(on: database)
+            self.update(on: database)
         } else {
-            return self.create(on: database)
+            self.create(on: database)
         }
     }
 
@@ -47,7 +47,7 @@ extension Model {
     }
 
     public func update(on database: any Database) -> EventLoopFuture<Void> {
-        return database.configuration.middleware.chainingTo(Self.self) { event, model, db in
+        database.configuration.middleware.chainingTo(Self.self) { event, model, db in
             try model.handle(event, on: db)
         }.handle(.update, self, on: database)
     }
@@ -97,7 +97,7 @@ extension Model {
     }
 
     public func restore(on database: any Database) -> EventLoopFuture<Void> {
-        return database.configuration.middleware.chainingTo(Self.self) { event, model, db in
+        database.configuration.middleware.chainingTo(Self.self) { event, model, db in
             try model.handle(event, on: db)
         }.handle(.restore, self, on: database)
     }
@@ -125,15 +125,15 @@ extension Model {
     private func handle(_ event: ModelEvent, on db: any Database) throws -> EventLoopFuture<Void> {
         switch event {
         case .create:
-            return _create(on: db)
+            _create(on: db)
         case .delete(let force):
-            return try _delete(force: force, on: db)
+            try _delete(force: force, on: db)
         case .restore:
-            return try _restore(on: db)
+            try _restore(on: db)
         case .softDelete:
-            return try _delete(force: false, on: db)
+            try _delete(force: false, on: db)
         case .update:
-            return try _update(on: db)
+            try _update(on: db)
         }
     }
 }
@@ -207,7 +207,7 @@ private struct SavedInput: DatabaseOutput {
     }
 
     func schema(_ schema: String) -> any DatabaseOutput {
-        return self
+        self
     }
     
     func contains(_ key: FieldKey) -> Bool {
@@ -253,6 +253,6 @@ private struct SavedInput: DatabaseOutput {
     }
 
     var description: String {
-        return self.input.description
+        self.input.description
     }
 }

--- a/Sources/FluentKit/Model/Schema.swift
+++ b/Sources/FluentKit/Model/Schema.swift
@@ -11,7 +11,7 @@ extension Schema {
         self.alias ?? self.schema
     }
     
-    static var spaceIfNotAliased: String? {
-        return self.alias == nil ? self.space : nil
+    public static var spaceIfNotAliased: String? {
+        self.alias == nil ? self.space : nil
     }
 }

--- a/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
+++ b/Sources/FluentKit/Properties/BooleanPropertyFormat.swift
@@ -35,9 +35,9 @@ public struct IntegerBooleanPropertyFormat<T: FixedWidthInteger & Codable & Send
     
     public func parse(_ value: T) -> Bool? {
         switch value {
-        case .zero: return false
-        case .zero.advanced(by: 1): return true
-        default: return nil
+        case .zero: false
+        case .zero.advanced(by: 1): true
+        default: nil
         }
     }
     
@@ -56,9 +56,9 @@ public struct OneZeroBooleanPropertyFormat: BooleanPropertyFormat {
     
     public func parse(_ value: String) -> Bool? {
         switch value {
-        case "0": return false
-        case "1": return true
-        default: return nil
+        case "0": false
+        case "1": true
+        default: nil
         }
     }
     
@@ -77,9 +77,9 @@ public struct YNBooleanPropertyFormat: BooleanPropertyFormat {
     
     public func parse(_ value: String) -> Bool? {
         switch value.lowercased() {
-        case "n": return false
-        case "y": return true
-        default: return nil
+        case "n": false
+        case "y": true
+        default: nil
         }
     }
     
@@ -99,9 +99,9 @@ public struct YesNoBooleanPropertyFormat: BooleanPropertyFormat {
     
     public func parse(_ value: String) -> Bool? {
         switch value.lowercased() {
-        case "no": return false
-        case "yes": return true
-        default: return nil
+        case "no": false
+        case "yes": true
+        default: nil
         }
     }
     
@@ -120,9 +120,9 @@ public struct OnOffBooleanPropertyFormat: BooleanPropertyFormat {
 
     public func parse(_ value: String) -> Bool? {
         switch value.lowercased() {
-        case "off": return false
-        case "on": return true
-        default: return nil
+        case "off": false
+        case "on": true
+        default: nil
         }
     }
         
@@ -141,9 +141,9 @@ public struct TrueFalseBooleanPropertyFormat: BooleanPropertyFormat {
     
     public func parse(_ value: String) -> Bool? {
         switch value.lowercased() {
-        case "false": return false
-        case "true": return true
-        default: return nil
+        case "false": false
+        case "true": true
+        default: nil
         }
     }
     

--- a/Sources/FluentKit/Properties/Field.swift
+++ b/Sources/FluentKit/Properties/Field.swift
@@ -52,9 +52,9 @@ extension FieldProperty: Property {
             if let value = self.inputValue {
                 switch value {
                 case .bind(let bind):
-                    bind as? Value
+                    (bind as? Value) ?? nil
                 case .enumCase(let string):
-                    string as? Value
+                    (string as? Value) ?? nil
                 case .default:
                     fatalError("Cannot access default field for '\(Model.self).\(key)' before it is initialized or fetched")
                 default:

--- a/Sources/FluentKit/Properties/Field.swift
+++ b/Sources/FluentKit/Properties/Field.swift
@@ -52,18 +52,18 @@ extension FieldProperty: Property {
             if let value = self.inputValue {
                 switch value {
                 case .bind(let bind):
-                    return bind as? Value
+                    bind as? Value
                 case .enumCase(let string):
-                    return string as? Value
+                    string as? Value
                 case .default:
                     fatalError("Cannot access default field for '\(Model.self).\(key)' before it is initialized or fetched")
                 default:
                     fatalError("Unexpected input value type for '\(Model.self).\(key)': \(value)")
                 }
             } else if let value = self.outputValue {
-                return value
+                value
             } else {
-                return nil
+                nil
             }
         }
         set {

--- a/Sources/FluentKit/Properties/FieldKey.swift
+++ b/Sources/FluentKit/Properties/FieldKey.swift
@@ -20,13 +20,13 @@ extension FieldKey: CustomStringConvertible {
     public var description: String {
         switch self {
         case .id:
-            return "id"
+            "id"
         case .string(let name):
-            return name
+            name
         case .aggregate:
-            return "aggregate"
+            "aggregate"
         case .prefix(let prefix, let key):
-            return prefix.description + key.description
+            prefix.description + key.description
         }
     }
 }

--- a/Sources/FluentKit/Properties/OptionalField.swift
+++ b/Sources/FluentKit/Properties/OptionalField.swift
@@ -39,20 +39,20 @@ extension OptionalFieldProperty: Property {
             if let value = self.inputValue {
                 switch value {
                 case .bind(let bind):
-                    return .some(bind as? WrappedValue)
+                    .some(bind as? WrappedValue)
                 case .enumCase(let string):
-                    return .some(string as? WrappedValue)
+                    .some(string as? WrappedValue)
                 case .default:
                     fatalError("Cannot access default field for '\(Model.self).\(key)' before it is initialized or fetched")
                 case .null:
-                    return .some(.none)
+                    .some(.none)
                 default:
                     fatalError("Unexpected input value type for '\(Model.self).\(key)': \(value)")
                 }
             } else if let value = self.outputValue {
-                return .some(value)
+                .some(value)
             } else {
-                return .none
+                .none
             }
         }
         set {

--- a/Sources/FluentKit/Properties/Relation.swift
+++ b/Sources/FluentKit/Properties/Relation.swift
@@ -27,9 +27,9 @@ extension Relation {
     /// - Returns: The loaded value.
     public func get(reload: Bool = false, on database: any Database) -> EventLoopFuture<RelatedValue> {
         if let value = self.value, !reload {
-            return database.eventLoop.makeSucceededFuture(value)
+            database.eventLoop.makeSucceededFuture(value)
         } else {
-            return self.load(on: database).flatMapThrowing {
+            self.load(on: database).flatMapThrowing {
                 guard let value = self.value else { // This should never actually happen, but just in case...
                     throw FluentError.relationNotLoaded(name: self.name)
                 }
@@ -54,8 +54,8 @@ public enum RelationParentKey<From, To>: Sendable
 extension RelationParentKey: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .optional(let keypath): return To.path(for: keypath.appending(path: \.$id)).description
-        case .required(let keypath): return To.path(for: keypath.appending(path: \.$id)).description
+        case .optional(let keypath): To.path(for: keypath.appending(path: \.$id)).description
+        case .required(let keypath): To.path(for: keypath.appending(path: \.$id)).description
         }
     }
 }
@@ -78,8 +78,8 @@ public enum CompositeRelationParentKey<From, To>: Sendable
     /// Use the stored key path to retrieve the appropriate parent ID from the given child model.
     internal func referencedId(in model: To) -> From.IDValue? {
         switch self {
-        case .required(let keypath): return model[keyPath: keypath].id
-        case .optional(let keypath): return model[keyPath: keypath].id
+        case .required(let keypath): model[keyPath: keypath].id
+        case .optional(let keypath): model[keyPath: keypath].id
         }
     }
     
@@ -109,8 +109,8 @@ public enum CompositeRelationParentKey<From, To>: Sendable
 extension CompositeRelationParentKey: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .required(let keypath): return To()[keyPath: keypath].prefix.description
-        case .optional(let keypath): return To()[keyPath: keypath].prefix.description
+        case .required(let keypath): To()[keyPath: keypath].prefix.description
+        case .optional(let keypath): To()[keyPath: keypath].prefix.description
         }
     }
 }

--- a/Sources/FluentKit/Properties/Timestamp.swift
+++ b/Sources/FluentKit/Properties/Timestamp.swift
@@ -82,11 +82,11 @@ extension TimestampProperty: Property {
         get {
             switch self.$timestamp.value {
                 case .some(.some(let timestamp)):
-                    return .some(self.format.parse(timestamp))
+                    .some(self.format.parse(timestamp))
                 case .some(.none):
-                    return .some(.none)
+                    .some(.none)
                 case .none:
-                    return .none
+                    .none
             }
         }
         set {

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Aggregate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Aggregate.swift
@@ -5,9 +5,9 @@ extension QueryBuilder {
 
     public func count() -> EventLoopFuture<Int> {
         if Model().anyID is any AnyQueryableProperty {
-            return self.count(\._$id)
+            self.count(\._$id)
         } else if let fieldsIDType = Model.IDValue.self as? any Fields.Type {
-            return self.aggregate(.count, fieldsIDType.keys.first!)
+            self.aggregate(.count, fieldsIDType.keys.first!)
         } else {
             fatalError("Model '\(Model.self)' has neither @ID nor @CompositeID, this is not valid.")
         }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Filter.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Filter.swift
@@ -2,21 +2,21 @@ extension QueryBuilder {
     // MARK: Filter
     
     @discardableResult
-    internal func filter(id: Model.IDValue) -> Self {
+    func filter(id: Model.IDValue) -> Self {
         if let fields = id as? any Fields {
-            return self.group(.and) { fields.input(to: QueryFilterInput(builder: $0)) }
+            self.group(.and) { fields.input(to: QueryFilterInput(builder: $0)) }
         } else {
-            return self.filter(\Model._$id == id)
+            self.filter(\Model._$id == id)
         }
     }
     
     @discardableResult
-    internal func filter(ids: [Model.IDValue]) -> Self {
+    func filter(ids: [Model.IDValue]) -> Self {
         guard let firstId = ids.first else { return self.limit(0) }
-        if firstId is any Fields {
-            return self.group(.or) { q in ids.forEach { id in q.group(.and) { (id as! any Fields).input(to: QueryFilterInput(builder: $0)) } } }
+        return if firstId is any Fields {
+            self.group(.or) { q in ids.forEach { id in q.group(.and) { (id as! any Fields).input(to: QueryFilterInput(builder: $0)) } } }
         } else {
-            return self.filter(\Model._$id ~~ ids)
+            self.filter(\Model._$id ~~ ids)
         }
     }
 

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -11,7 +11,7 @@ extension QueryBuilder {
     public func paginate(
         _ request: PageRequest
     ) -> EventLoopFuture<Page<Model>> {
-        page(withIndex: request.page, size: request.per)
+        self.page(withIndex: request.page, size: request.per)
     }
     
     /// Returns a single `Page` out of the complete result set.
@@ -95,9 +95,9 @@ public struct PageMetadata: Codable, Sendable {
     /// Creates a new `PageMetadata` instance.
     ///
     /// - Parameters:
-    ///.  - page: Current page number.
-    ///.  - per: Max items per page.
-    ///.  - total: Total number of items available.
+    ///   - page: Current page number.
+    ///   - per: Max items per page.
+    ///   - total: Total number of items available.
     public init(page: Int, per: Int, total: Int) {
         self.page = page
         self.per = per
@@ -113,19 +113,20 @@ public struct PageRequest: Decodable, Sendable {
     /// Max items per page.
     public let per: Int
 
-    enum CodingKeys: String, CodingKey {
-        case page = "page"
-        case per = "per"
+    private enum CodingKeys: String, CodingKey {
+        case page
+        case per
     }
 
-    /// `Decodable` conformance.
+    // See `Decodable.init(from:)`.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.page = try container.decodeIfPresent(Int.self, forKey: .page) ?? 1
         self.per = try container.decodeIfPresent(Int.self, forKey: .per) ?? 10
     }
 
-    /// Crates a new `PageRequest`
+    /// Crates a new `PageRequest`.
+    ///
     /// - Parameters:
     ///   - page: Page number to request. Starts at `1`.
     ///   - per: Max items per page.

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Range.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Range.swift
@@ -8,7 +8,7 @@ extension QueryBuilder {
     /// - returns: Query builder for chaining.
     @discardableResult
     public func range(_ range: Range<Int>) -> Self {
-        return self.range(lower: range.lowerBound, upper: range.upperBound - 1)
+        self.range(lower: range.lowerBound, upper: range.upperBound - 1)
     }
 
     /// Limits the results of this query to the specified range.
@@ -18,7 +18,7 @@ extension QueryBuilder {
     /// - returns: Query builder for chaining.
     @discardableResult
     public func range(_ range: PartialRangeThrough<Int>) -> Self {
-        return self.range(upper: range.upperBound)
+        self.range(upper: range.upperBound)
     }
 
     /// Limits the results of this query to the specified range.
@@ -28,7 +28,7 @@ extension QueryBuilder {
     /// - returns: Query builder for chaining.
     @discardableResult
     public func range(_ range: PartialRangeUpTo<Int>) -> Self {
-        return self.range(upper: range.upperBound - 1)
+        self.range(upper: range.upperBound - 1)
     }
 
     /// Limits the results of this query to the specified range.
@@ -38,7 +38,7 @@ extension QueryBuilder {
     /// - returns: Query builder for chaining.
     @discardableResult
     public func range(_ range: PartialRangeFrom<Int>) -> Self {
-        return self.range(lower: range.lowerBound)
+        self.range(lower: range.lowerBound)
     }
 
     /// Limits the results of this query to the specified range.
@@ -48,7 +48,7 @@ extension QueryBuilder {
     /// - returns: Query builder for chaining.
     @discardableResult
     public func range(_ range: ClosedRange<Int>) -> Self {
-        return self.range(lower: range.lowerBound, upper: range.upperBound)
+        self.range(lower: range.lowerBound, upper: range.upperBound)
     }
 
     /// Limits the results of this query to the specified range.

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Sort.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Sort.swift
@@ -83,8 +83,7 @@ extension QueryBuilder {
         _ field: DatabaseQuery.Field,
         _ direction: DatabaseQuery.Sort.Direction
     ) -> Self {
-        self.query.sorts.append(.sort(field, direction))
-        return self
+        self.sort(.sort(field, direction))
     }
 
     @discardableResult

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -180,7 +180,7 @@ public final class QueryBuilder<Model>
     }
 
     public func first() -> EventLoopFuture<Model?> {
-        return self.limit(1)
+        self.limit(1)
             .all()
             .map { $0.first }
     }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Action.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Action.swift
@@ -13,17 +13,17 @@ extension DatabaseQuery.Action: CustomStringConvertible {
     public var description: String {
         switch self {
         case .create:
-            return "create"
+            "create"
         case .read:
-            return "read"
+            "read"
         case .update:
-            return "update"
+            "update"
         case .delete:
-            return "delete"
+            "delete"
         case .aggregate(let aggregate):
-            return "aggregate(\(aggregate))"
+            "aggregate(\(aggregate))"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Aggregate.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Aggregate.swift
@@ -17,9 +17,9 @@ extension DatabaseQuery.Aggregate: CustomStringConvertible {
     public var description: String {
         switch self {
         case .field(let field, let method):
-            return "\(method)(\(field))"
+            "\(method)(\(field))"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 }
@@ -28,17 +28,17 @@ extension DatabaseQuery.Aggregate.Method: CustomStringConvertible {
     public var description: String {
         switch self {
         case .count:
-            return "count"
+            "count"
         case .sum:
-            return "sum"
+            "sum"
         case .average:
-            return "average"
+            "average"
         case .minimum:
-            return "minimum"
+            "minimum"
         case .maximum:
-            return "maximum"
+            "maximum"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Field.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Field.swift
@@ -10,22 +10,22 @@ extension DatabaseQuery.Field: CustomStringConvertible {
     public var description: String {
         switch self {
         case .path(let path, let schema):
-            return "\(schema)\(path)"
+            "\(schema)\(path)"
         case .extendedPath(let path, let schema, let space):
-            return "\(space.map { "\($0)." } ?? "")\(schema)\(path)"
+            "\(space.map { "\($0)." } ?? "")\(schema)\(path)"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 
     var describedByLoggingMetadata: Logger.MetadataValue {
         switch self {
         case .path(let array, let schema):
-            return "\(schema).\(array.map(\.description).joined(separator: "->"))"
+            "\(schema).\(array.map(\.description).joined(separator: "->"))"
         case .extendedPath(let array, let schema, let space):
-            return "\(space.map { "\($0)." } ?? "")\(schema).\(array.map(\.description).joined(separator: "->"))"
+            "\(space.map { "\($0)." } ?? "")\(schema).\(array.map(\.description).joined(separator: "->"))"
         case .custom:
-            return .stringConvertible(self)
+            .stringConvertible(self)
         }
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Filter.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Filter.swift
@@ -2,27 +2,27 @@ extension DatabaseQuery {
     public enum Filter: Sendable {
         public enum Method: Sendable {
             public static var equal: Method {
-                return .equality(inverse: false)
+                .equality(inverse: false)
             }
 
             public static var notEqual: Method {
-                return .equality(inverse: true)
+                .equality(inverse: true)
             }
 
             public static var greaterThan: Method {
-                return .order(inverse: false, equality: false)
+                .order(inverse: false, equality: false)
             }
 
             public static var greaterThanOrEqual: Method {
-                return .order(inverse: false, equality: true)
+                .order(inverse: false, equality: true)
             }
 
             public static var lessThan: Method {
-                return .order(inverse: true, equality: false)
+                .order(inverse: true, equality: false)
             }
 
             public static var lessThanOrEqual: Method {
-                return .order(inverse: true, equality: true)
+                .order(inverse: true, equality: true)
             }
 
             /// LHS is equal/not equal to RHS
@@ -64,26 +64,26 @@ extension DatabaseQuery.Filter: CustomStringConvertible {
     public var description: String {
         switch self {
         case .value(let field, let method, let value):
-            return "\(field) \(method) \(value)"
+            "\(field) \(method) \(value)"
         case .field(let fieldA, let method, let fieldB):
-            return "\(fieldA) \(method) \(fieldB)"
+            "\(fieldA) \(method) \(fieldB)"
         case .group(let filters, let relation):
-            return filters.map { "(\($0))" }.joined(separator: " \(relation) ")
+            filters.map { "(\($0))" }.joined(separator: " \(relation) ")
         case .custom(let any):
-            return "custom(\(any))"
+            "custom(\(any))"
         }
     }
 
     var describedByLoggingMetadata: Logger.MetadataValue {
         switch self {
         case .value(let field, let method, let value):
-            return ["field": field.describedByLoggingMetadata, "method": "\(method)", "value": value.describedByLoggingMetadata]
+            ["field": field.describedByLoggingMetadata, "method": "\(method)", "value": value.describedByLoggingMetadata]
         case .field(let field, let method, let field2):
-            return ["field1": field.describedByLoggingMetadata, "method": "\(method)", "field2": field2.describedByLoggingMetadata]
+            ["field1": field.describedByLoggingMetadata, "method": "\(method)", "field2": field2.describedByLoggingMetadata]
         case .group(let array, let relation):
-            return ["group": .array(array.map(\.describedByLoggingMetadata)), "relation": "\(relation)"]
+            ["group": .array(array.map(\.describedByLoggingMetadata)), "relation": "\(relation)"]
         case .custom:
-            return .stringConvertible(self)
+            .stringConvertible(self)
         }
     }
 }
@@ -92,19 +92,19 @@ extension DatabaseQuery.Filter.Method: CustomStringConvertible {
     public var description: String {
         switch self {
         case .equality(let inverse):
-            return inverse ? "!=" : "="
+            inverse ? "!=" : "="
         case .order(let inverse, let equality):
             if equality {
-                return inverse ? "<=" : ">="
+                inverse ? "<=" : ">="
             } else {
-                return inverse ? "<" : ">"
+                inverse ? "<" : ">"
             }
         case .subset(let inverse):
-            return inverse ? "!~~" : "~~"
+            inverse ? "!~~" : "~~"
         case .contains(let inverse, let contains):
-            return inverse ? "!\(contains)" : "\(contains)"
+            inverse ? "!\(contains)" : "\(contains)"
         case .custom(let any):
-            return "custom(\(any))"
+            "custom(\(any))"
         }
     }
 }
@@ -113,11 +113,11 @@ extension DatabaseQuery.Filter.Method.Contains: CustomStringConvertible {
     public var description: String {
         switch self {
         case .prefix:
-            return "startswith"
+            "startswith"
         case .suffix:
-            return "endswith"
+            "endswith"
         case .anywhere:
-            return "contains"
+            "contains"
         }
     }
 }
@@ -126,11 +126,11 @@ extension DatabaseQuery.Filter.Relation: CustomStringConvertible {
     public var description: String {
         switch self {
         case .and:
-            return "and"
+            "and"
         case .or:
-            return "or"
+            "or"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Join.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Join.swift
@@ -39,38 +39,38 @@ extension DatabaseQuery.Join: CustomStringConvertible {
     public var description: String {
         switch self {
         case .join(let schema, let alias, let method, let foreign, let local):
-            return "\(self.schemaDescription(schema: schema, alias: alias)) \(method) on \(foreign) == \(local)"
+            "\(self.schemaDescription(schema: schema, alias: alias)) \(method) on \(foreign) == \(local)"
 
         case .extendedJoin(let schema, let space, let alias, let method, let foreign, let local):
-            return "\(self.schemaDescription(space: space, schema: schema, alias: alias)) \(method) on \(foreign) == \(local)"
+            "\(self.schemaDescription(space: space, schema: schema, alias: alias)) \(method) on \(foreign) == \(local)"
 
         case .advancedJoin(let schema, let space, let alias, let method, let filters):
-            return "\(self.schemaDescription(space: space, schema: schema, alias: alias)) \(method) on \(filters)"
+            "\(self.schemaDescription(space: space, schema: schema, alias: alias)) \(method) on \(filters)"
 
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 
     var describedByLoggingMetadata: Logger.MetadataValue {
         switch self {
         case .join(let schema, let alias, let method, let foreign, let local):
-            return .dictionary([
+            .dictionary([
                 "schema": "\(schema)", "alias": alias.map { "\($0)" }, "method": "\(method)",
                 "foreign": foreign.describedByLoggingMetadata, "local": local.describedByLoggingMetadata
             ].compactMapValues { $0 })
         case .extendedJoin(let schema, let space, let alias, let method, let foreign, let local):
-            return .dictionary([
+            .dictionary([
                 "schema": "\(schema)", "space": space.map { "\($0)" }, "alias": alias.map { "\($0)" }, "method": "\(method)",
                 "foreign": foreign.describedByLoggingMetadata, "local": local.describedByLoggingMetadata
             ].compactMapValues { $0 })
         case .advancedJoin(let schema, let space, let alias, let method, let filters):
-            return .dictionary([
+            .dictionary([
                 "schema": "\(schema)", "space": space.map { "\($0)" }, "alias": alias.map { "\($0)" }, "method": "\(method)",
                 "filters": .array(filters.map(\.describedByLoggingMetadata))
             ].compactMapValues { $0 })
         case .custom:
-            return .stringConvertible(self)
+            .stringConvertible(self)
         }
     }
 
@@ -83,11 +83,11 @@ extension DatabaseQuery.Join.Method: CustomStringConvertible {
     public var description: String {
         switch self {
         case .inner:
-            return "inner"
+            "inner"
         case .left:
-            return "left"
+            "left"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Range.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Range.swift
@@ -14,9 +14,9 @@ extension DatabaseQuery.Limit: CustomStringConvertible {
     public var description: String {
         switch self {
         case .count(let count):
-            return "count(\(count))"
+            "count(\(count))"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 }
@@ -25,9 +25,9 @@ extension DatabaseQuery.Offset: CustomStringConvertible {
     public var description: String {
         switch self {
         case .count(let count):
-            return "count(\(count))"
+            "count(\(count))"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Range.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Range.swift
@@ -1,11 +1,21 @@
 extension DatabaseQuery {
     public enum Limit: Sendable {
         case count(Int)
+
+        /// Due to design limitations in SQLKit, it is not possible to provide a custom limit expression;
+        /// as such, it is in turn a design flaw of FluentKit that this enum exists at all. Any attempt to
+        /// use ``custom(_:)`` in a query unconditionally triggers a fatal error at runtime.
+        @available(*, deprecated, message: "`DatabaseQuery.Limit.custom(_:)` does not work.")
         case custom(any Sendable)
     }
 
     public enum Offset: Sendable {
         case count(Int)
+
+        /// Due to design limitations in SQLKit, it is not possible to provide a custom offset expression;
+        /// as such, it is in turn a design flaw of FluentKit that this enum exists at all. Any attempt to
+        /// use ``custom(_:)`` in a query unconditionally triggers a fatal error at runtime.
+        @available(*, deprecated, message: "`DatabaseQuery.Offset.custom(_:)` triggers a fatal error when used.")
         case custom(any Sendable)
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Sort.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Sort.swift
@@ -14,18 +14,18 @@ extension DatabaseQuery.Sort: CustomStringConvertible {
     public var description: String {
         switch self {
         case .sort(let field, let direction):
-            return "\(field) \(direction)"
+            "\(field) \(direction)"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 
     var describedByLoggingMetadata: Logger.MetadataValue {
         switch self {
         case .sort(let field, let direction):
-            return ["field": field.describedByLoggingMetadata, "direction": "\(direction)"]
+            ["field": field.describedByLoggingMetadata, "direction": "\(direction)"]
         case .custom:
-            return .stringConvertible(self)
+            .stringConvertible(self)
         }
     }
 }
@@ -34,11 +34,11 @@ extension DatabaseQuery.Sort.Direction: CustomStringConvertible {
     public var description: String {
         switch self {
         case .ascending:
-            return "ascending"
+            "ascending"
         case .descending:
-            return "descending"
+            "descending"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Value.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Value.swift
@@ -15,30 +15,33 @@ extension DatabaseQuery.Value: CustomStringConvertible {
         switch self {
         case .bind(let encodable):
             if let convertible = encodable as? any CustomDebugStringConvertible {
-                return String(reflecting: convertible)
+                String(reflecting: convertible)
             } else {
-                return String(describing: encodable)
+                String(describing: encodable)
             }
         case .dictionary(let dictionary):
-            return String(describing: dictionary)
+            String(describing: dictionary)
         case .array(let array):
-            return String(describing: array)
+            String(describing: array)
         case .enumCase(let string):
-            return string
+            string
         case .null:
-            return "nil"
+            "nil"
         case .default:
-            return "default"
+            "default"
         case .custom(let custom):
-            return "custom(\(custom))"
+            "custom(\(custom))"
         }
     }
 
     var describedByLoggingMetadata: Logger.MetadataValue {
         switch self {
-        case .dictionary(let d): return .dictionary(.init(uniqueKeysWithValues: d.map { ($0.description, $1.describedByLoggingMetadata) }))
-        case .array(let a): return .array(a.map(\.describedByLoggingMetadata))
-        default: return .stringConvertible(self)
+        case .dictionary(let d):
+            .dictionary(.init(uniqueKeysWithValues: d.map { ($0.description, $1.describedByLoggingMetadata) }))
+        case .array(let a):
+            .array(a.map(\.describedByLoggingMetadata))
+        default:
+            .stringConvertible(self)
         }
     }
 

--- a/Sources/FluentKit/Schema/DatabaseSchema.swift
+++ b/Sources/FluentKit/Schema/DatabaseSchema.swift
@@ -199,11 +199,9 @@ public struct DatabaseSchema: Sendable {
 extension DatabaseSchema.ConstraintDelete {
     /// For internal use only.
     ///
-    /// Do not use this type directly; it's only public because FluentSQL needs to be able to get at it.
-    /// The use of `@_spi` will be replaced with the `package` modifier once a suitable minimum version
-    /// of Swift becomes required.
-    @_spi(FluentSQLSPI)
-    public/*package*/ struct _ForeignKeyByNameExtension: Sendable {
-        public/*package*/ let name: String
+    /// This is used to signal FluentSQL's `SQLSchemaConverter` to apply additional syntax in the query. It is an
+    /// implementation detail of ``DatabaseSchema/ConstraintDelete/namedForeignKey(_:)``; see that method for details.
+    package struct _ForeignKeyByNameExtension: Sendable {
+        package let name: String
     }
 }

--- a/Sources/FluentSQL/ConverterUtilities.swift
+++ b/Sources/FluentSQL/ConverterUtilities.swift
@@ -2,13 +2,12 @@ import SQLKit
 
 func custom(_ any: Any) -> any SQLExpression {
     if let sql = any as? any SQLExpression {
-        return sql
+        sql
+    } else if let string = any as? String {
+        SQLRaw(string)
+    } else if let stringConvertible = any as? any CustomStringConvertible {
+        SQLRaw(stringConvertible.description)
+    } else {
+        fatalError("Could not convert \(any) to a SQL-compatible type.")
     }
-    if let string = any as? String {
-        return SQLRaw(string)
-    }
-    if let stringConvertible = any as? any CustomStringConvertible {
-        return SQLRaw(stringConvertible.description)
-    }
-    fatalError("Could not convert \(any) to a SQL-compatible type.")
 }

--- a/Sources/FluentSQL/DatabaseQuery+SQL.swift
+++ b/Sources/FluentSQL/DatabaseQuery+SQL.swift
@@ -1,12 +1,35 @@
 import FluentKit
 import SQLKit
 
-extension DatabaseQuery.Value {
-    @available(*, deprecated, renamed: "sql(unsafeRaw:)", message: "Renamed to `.sql(unsafeRaw:)`. Please use caution when embedding raw SQL.")
-    public static func sql(raw: String) -> Self {
-        .sql(unsafeRaw: raw)
+extension DatabaseQuery.Action {
+    public static func sql(unsafeRaw: String) -> Self {
+        .sql(SQLRaw(unsafeRaw))
     }
 
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: any SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseQuery.Aggregate {
+    public static func sql(unsafeRaw: String) -> Self {
+        .sql(SQLRaw(unsafeRaw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: any SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseQuery.Aggregate.Method {
     public static func sql(unsafeRaw: String) -> Self {
         .sql(SQLRaw(unsafeRaw))
     }
@@ -86,6 +109,34 @@ extension DatabaseQuery.Filter {
     }
 }
 
+extension DatabaseQuery.Filter.Method {
+    public static func sql(unsafeRaw: String) -> Self {
+        .sql(SQLRaw(unsafeRaw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: any SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseQuery.Filter.Relation {
+    public static func sql(unsafeRaw: String) -> Self {
+        .sql(SQLRaw(unsafeRaw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: any SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
 extension DatabaseQuery.Join {
     @available(*, deprecated, renamed: "sql(unsafeRaw:)", message: "Renamed to `.sql(unsafeRaw:)`. Please use caution when embedding raw SQL.")
     public static func sql(raw: String) -> Self {
@@ -104,6 +155,23 @@ extension DatabaseQuery.Join {
         .custom(expression)
     }
 }
+
+extension DatabaseQuery.Join.Method {
+    public static func sql(unsafeRaw: String) -> Self {
+        .sql(SQLRaw(unsafeRaw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: any SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+// `DatabaseQuery.Limit` and `DatabaseQuery.Offset` do not have `.sql()` extension methods because use
+// of the `.custom()` cases of these types triggers a `fatalError()` in `SQLQueryConverter`.
 
 extension DatabaseQuery.Sort {
     @available(*, deprecated, renamed: "sql(unsafeRaw:)", message: "Renamed to `.sql(unsafeRaw:)`. Please use caution when embedding raw SQL.")
@@ -137,6 +205,39 @@ extension DatabaseQuery.Sort {
         _ right: any SQLExpression
     ) -> Self {
         .sql(SQLBinaryExpression(left: left, op: op, right: right))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: any SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseQuery.Sort.Direction {
+    public static func sql(unsafeRaw: String) -> Self {
+        .sql(SQLRaw(unsafeRaw))
+    }
+
+    public static func sql(embed: SQLQueryString) -> Self {
+        .sql(embed)
+    }
+
+    public static func sql(_ expression: any SQLExpression) -> Self {
+        .custom(expression)
+    }
+}
+
+extension DatabaseQuery.Value {
+    @available(*, deprecated, renamed: "sql(unsafeRaw:)", message: "Renamed to `.sql(unsafeRaw:)`. Please use caution when embedding raw SQL.")
+    public static func sql(raw: String) -> Self {
+        .sql(unsafeRaw: raw)
+    }
+
+    public static func sql(unsafeRaw: String) -> Self {
+        .sql(SQLRaw(unsafeRaw))
     }
 
     public static func sql(embed: SQLQueryString) -> Self {

--- a/Sources/FluentSQL/SQLDatabase+Model.swift
+++ b/Sources/FluentSQL/SQLDatabase+Model.swift
@@ -66,15 +66,15 @@ extension DatabaseQuery.Value {
     /// really, but why add more fatal errors than we have to?).
     fileprivate var asSQLExpression: any SQLExpression {
         switch self {
-        case .bind(let value):   return SQLBind(value)
-        case .null:              return SQLLiteral.null
-        case .array(let values): return SQLGroupExpression(SQLKit.SQLList(values.map(\.asSQLExpression), separator: SQLRaw(",")))
-        case .default:           return SQLLiteral.default
-        case .enumCase(let str): return SQLLiteral.string(str)
+        case .bind(let value):   SQLBind(value)
+        case .null:              SQLLiteral.null
+        case .array(let values): SQLGroupExpression(SQLKit.SQLList(values.map(\.asSQLExpression), separator: SQLRaw(",")))
+        case .default:           SQLLiteral.default
+        case .enumCase(let str): SQLLiteral.string(str)
         case .custom(let any as any SQLExpression):
-                                 return any
+                                 any
         case .custom(let any as any CustomStringConvertible):
-                                 return SQLRaw(any.description)
+                                 SQLRaw(any.description)
         case .dictionary(_):     fatalError("Dictionary database values are unimplemented for SQL")
         case .custom(_):         fatalError("Unsupported custom database value")
         }

--- a/Sources/FluentSQL/SQLDatabase+Model.swift
+++ b/Sources/FluentSQL/SQLDatabase+Model.swift
@@ -1,5 +1,5 @@
 import SQLKit
-@_spi(FluentSQLSPI) import FluentKit
+import FluentKit
 
 extension SQLQueryFetcher {
     @available(*, deprecated, renamed: "first(decodingFluent:)", message: "Renamed to first(decodingFluent:)")

--- a/Sources/FluentSQL/SQLQueryConverter.swift
+++ b/Sources/FluentSQL/SQLQueryConverter.swift
@@ -146,33 +146,36 @@ public struct SQLQueryConverter {
     private func sort(_ sort: DatabaseQuery.Sort) -> any SQLExpression {
         switch sort {
         case .sort(let field, let direction):
-            return SQLOrderBy(expression: self.field(field), direction: self.direction(direction))
+            SQLOrderBy(expression: self.field(field), direction: self.direction(direction))
         case .custom(let any):
-            return custom(any)
+            custom(any)
         }
     }
 
     private func direction(_ direction: DatabaseQuery.Sort.Direction) -> any SQLExpression {
         switch direction {
-        case .ascending: return SQLDirection.ascending
-        case .descending: return SQLDirection.descending
-        case .custom(let any): return custom(any)
+        case .ascending:
+            SQLDirection.ascending
+        case .descending:
+            SQLDirection.descending
+        case .custom(let any):
+            custom(any)
         }
     }
     
     private func join(_ join: DatabaseQuery.Join) -> any SQLExpression {
         switch join {
         case .custom(let any):
-            return custom(any)
+            custom(any)
 
         case .join(let schema, let alias, let method, let foreign, let local):
-            return self.joinCondition(schema: schema, alias: alias, method: method, filters: [.field(foreign, .equal, local)])
+            self.joinCondition(schema: schema, alias: alias, method: method, filters: [.field(foreign, .equal, local)])
 
         case .extendedJoin(let schema, let space, let alias, let method, let foreign, let local):
-            return self.joinCondition(space: space, schema: schema, alias: alias, method: method, filters: [.field(foreign, .equal, local)])
+            self.joinCondition(space: space, schema: schema, alias: alias, method: method, filters: [.field(foreign, .equal, local)])
 
         case .advancedJoin(let schema, let space, let alias, let method, let filters):
-            return self.joinCondition(space: space, schema: schema, alias: alias, method: method, filters: filters)
+            self.joinCondition(space: space, schema: schema, alias: alias, method: method, filters: filters)
         }
     }
     
@@ -192,21 +195,23 @@ public struct SQLQueryConverter {
     
     private func joinMethod(_ method: DatabaseQuery.Join.Method) -> any SQLExpression {
         switch method {
-        case .inner: return SQLJoinMethod.inner
-        case .left: return SQLJoinMethod.left
+        case .inner:
+            SQLJoinMethod.inner
+        case .left:
+            SQLJoinMethod.left
         case .custom(let any):
-            return custom(any)
+            custom(any)
         }
     }
     
     private func field(_ field: DatabaseQuery.Field, aliased: Bool = false) -> any SQLExpression {
         switch field {
         case .custom(let any):
-            return custom(any)
+            custom(any)
         case .path(let path, let schema):
-            return self.fieldPath(path, schema: schema, aliased: aliased)
+            self.fieldPath(path, schema: schema, aliased: aliased)
         case .extendedPath(let path, let schema, let space):
-            return self.fieldPath(path, space: space, schema: schema, aliased: aliased)
+            self.fieldPath(path, space: space, schema: schema, aliased: aliased)
         }
     }
     
@@ -330,11 +335,11 @@ public struct SQLQueryConverter {
     private func relation(_ relation: DatabaseQuery.Filter.Relation) -> any SQLExpression {
         switch relation {
         case .and:
-            return SQLBinaryOperator.and
+            SQLBinaryOperator.and
         case .or:
-            return SQLBinaryOperator.or
+            SQLBinaryOperator.or
         case .custom(let any):
-            return custom(any)
+            custom(any)
         }
     }
 
@@ -342,50 +347,49 @@ public struct SQLQueryConverter {
         switch value {
         case .bind(let encodable):
             if let optional = encodable as? any AnyOptionalType, optional.wrappedValue == nil {
-                return SQLLiteral.null
+                SQLLiteral.null
             } else {
-                return SQLBind(encodable)
+                SQLBind(encodable)
             }
         case .null:
-            return SQLLiteral.null
+            SQLLiteral.null
         case .array(let values):
-            return SQLGroupExpression(SQLKit.SQLList(values.map(self.value), separator: SQLRaw(",")))
+            SQLGroupExpression(SQLKit.SQLList(values.map(self.value), separator: SQLRaw(",")))
         case .dictionary(let dictionary):
-            return SQLBind(EncodableDatabaseInput(input: dictionary))
+            SQLBind(EncodableDatabaseInput(input: dictionary))
         case .default:
-            return SQLLiteral.default
+            SQLLiteral.default
         case .enumCase(let string):
-            return SQLLiteral.string(string)
+            SQLLiteral.string(string)
         case .custom(let any):
-            return custom(any)
+            custom(any)
         }
     }
     
     private func method(_ method: DatabaseQuery.Filter.Method) -> any SQLExpression {
         switch method {
         case .equality(let inverse):
-            return inverse ? SQLBinaryOperator.notEqual : SQLBinaryOperator.equal
+            inverse ? SQLBinaryOperator.notEqual : SQLBinaryOperator.equal
         case .subset(let inverse):
-            return inverse ? SQLBinaryOperator.notIn : SQLBinaryOperator.in
+            inverse ? SQLBinaryOperator.notIn : SQLBinaryOperator.in
         case .order(let inverse, let equality):
             switch (inverse, equality) {
             case (false, false):
-                return SQLBinaryOperator.greaterThan
+                SQLBinaryOperator.greaterThan
             case (false, true):
-                return SQLBinaryOperator.greaterThanOrEqual
+                SQLBinaryOperator.greaterThanOrEqual
             case (true, false):
-                return SQLBinaryOperator.lessThan
+                SQLBinaryOperator.lessThan
             case (true, true):
-                return SQLBinaryOperator.lessThanOrEqual
+                SQLBinaryOperator.lessThanOrEqual
             }
         case .contains:
             fatalError("Contains filter method not supported at this scope.")
         case .custom(let any):
-            return custom(any)
+            custom(any)
         }
     }
 
-    @inline(__always)
     private func key(_ key: FieldKey) -> String { key.description }
 }
 

--- a/Sources/FluentSQL/SQLSchemaConverter.swift
+++ b/Sources/FluentSQL/SQLSchemaConverter.swift
@@ -1,5 +1,5 @@
 import SQLKit
-@_spi(FluentSQLSPI) import FluentKit
+import FluentKit
 
 public protocol SQLConverterDelegate {
     func customDataType(_ dataType: DatabaseSchema.DataType) -> (any SQLExpression)?
@@ -27,13 +27,13 @@ public struct SQLSchemaConverter {
     public func convert(_ schema: DatabaseSchema) -> any SQLExpression {
         let schema = self.delegate.beforeConvert(schema)
         
-        switch schema.action {
+        return switch schema.action {
         case .create:
-            return self.create(schema)
+            self.create(schema)
         case .delete:
-            return self.delete(schema)
+            self.delete(schema)
         case .update:
-            return self.update(schema)
+            self.update(schema)
         }
     }
     
@@ -55,9 +55,7 @@ public struct SQLSchemaConverter {
     }
     
     private func delete(_ schema: DatabaseSchema) -> any SQLExpression {
-        let delete = SQLDropTable(table: self.name(schema.schema, space: schema.space))
-    
-        return delete
+        SQLDropTable(table: self.name(schema.schema, space: schema.space))
     }
     
     private func create(_ schema: DatabaseSchema) -> any SQLExpression {
@@ -157,24 +155,24 @@ public struct SQLSchemaConverter {
     private func foreignKeyAction(_ action: DatabaseSchema.ForeignKeyAction) -> SQLForeignKeyAction {
         switch action {
         case .noAction:
-            return .noAction
+            .noAction
         case .restrict:
-            return .restrict
+            .restrict
         case .cascade:
-            return .cascade
+            .cascade
         case .setNull:
-            return .setNull
+            .setNull
         case .setDefault:
-            return .setDefault
+            .setDefault
         }
     }
     
     private func fieldDefinition(_ fieldDefinition: DatabaseSchema.FieldDefinition) -> any SQLExpression {
         switch fieldDefinition {
         case .custom(let any):
-            return custom(any)
+            custom(any)
         case .definition(let name, let dataType, let constraints):
-            return SQLColumnDefinition(
+            SQLColumnDefinition(
                 column: self.fieldName(name),
                 dataType: self.dataType(dataType),
                 constraints: constraints.map(self.fieldConstraint)
@@ -185,9 +183,9 @@ public struct SQLSchemaConverter {
     private func fieldUpdate(_ fieldDefinition: DatabaseSchema.FieldUpdate) -> any SQLExpression {
         switch fieldDefinition {
         case .custom(let any):
-            return custom(any)
+            custom(any)
         case .dataType(let name, let dataType):
-            return SQLAlterColumnDefinitionType(
+            SQLAlterColumnDefinitionType(
                 column: self.fieldName(name),
                 dataType: self.dataType(dataType)
             )
@@ -197,9 +195,9 @@ public struct SQLSchemaConverter {
     private func fieldName(_ fieldName: DatabaseSchema.FieldName) -> any SQLExpression {
         switch fieldName {
         case .key(let key):
-            return SQLIdentifier(self.key(key))
+            SQLIdentifier(self.key(key))
         case .custom(let any):
-            return custom(any)
+            custom(any)
         }
     }
     
@@ -208,69 +206,68 @@ public struct SQLSchemaConverter {
             return custom
         }
         
-        switch dataType {
+        return switch dataType {
         case .bool:
-            return SQLDataType.int
+            SQLDataType.int
         case .data:
-            return SQLDataType.blob
+            SQLDataType.blob
         case .date:
-            return SQLRaw("DATE")
+            SQLRaw("DATE")
         case .datetime:
-            return SQLRaw("TIMESTAMP")
+            SQLRaw("TIMESTAMP")
         case .int64:
-            return SQLRaw("BIGINT")
+            SQLRaw("BIGINT")
         case .string:
-            return SQLDataType.text
+            SQLDataType.text
         case .dictionary, .array:
-            return SQLRaw("JSON")
+            SQLRaw("JSON")
         case .uuid:
-            return SQLRaw("UUID")
+            SQLRaw("UUID")
         case .int8:
-            return SQLDataType.int
+            SQLDataType.int
         case .int16:
-            return SQLDataType.int
+            SQLDataType.int
         case .int32:
-            return SQLDataType.int
+            SQLDataType.int
         case .uint8:
-            return SQLDataType.int
+            SQLDataType.int
         case .uint16:
-            return SQLDataType.int
+            SQLDataType.int
         case .uint32:
-            return SQLDataType.int
+            SQLDataType.int
         case .uint64:
-            return SQLDataType.int
+            SQLDataType.int
         case .enum(let value):
-            return SQLEnumDataType(cases: value.cases)
+            SQLEnumDataType(cases: value.cases)
         case .time:
-            return SQLRaw("TIME")
+            SQLRaw("TIME")
         case .float:
-            return SQLRaw("FLOAT")
+            SQLRaw("FLOAT")
         case .double:
-            return SQLRaw("DOUBLE")
+            SQLRaw("DOUBLE")
         case .custom(let any):
-            return custom(any)
+            custom(any)
         }
     }
     
     private func fieldConstraint(_ fieldConstraint: DatabaseSchema.FieldConstraint) -> any SQLExpression {
         switch fieldConstraint {
         case .required:
-            return SQLColumnConstraintAlgorithm.notNull
+            SQLColumnConstraintAlgorithm.notNull
         case .identifier(let auto):
-            return SQLColumnConstraintAlgorithm.primaryKey(autoIncrement: auto)
+            SQLColumnConstraintAlgorithm.primaryKey(autoIncrement: auto)
         case .foreignKey(let schema, let space, let field, let onDelete, let onUpdate):
-            return SQLColumnConstraintAlgorithm.references(
+            SQLColumnConstraintAlgorithm.references(
                 self.name(schema, space: space),
                 self.fieldName(field),
                 onDelete: self.foreignKeyAction(onDelete),
                 onUpdate: self.foreignKeyAction(onUpdate)
             )
         case .custom(let any):
-            return custom(any)
+            custom(any)
         }
     }
 
-    @inline(__always)
     private func key(_ key: FieldKey) -> String { key.description }
 }
 

--- a/Sources/XCTFluent/TestDatabase.swift
+++ b/Sources/XCTFluent/TestDatabase.swift
@@ -228,19 +228,19 @@ public struct TestOutput: DatabaseOutput {
         func unpack(_ dbValue: DatabaseQuery.Value) -> Any? {
             switch dbValue {
             case .null:
-                return nil
+                nil
             case .enumCase(let value):
-                return value
+                value
             case .custom(let value):
-                return value
+                value
             case .bind(let value):
-                return value
+                value
             case .array(let array):
-                return array.map(unpack)
+                array.map(unpack)
             case .dictionary(let dictionary):
-                return dictionary.mapValues(unpack)
+                dictionary.mapValues(unpack)
             case .default:
-                return ""
+                ""
             }
         }
 


### PR DESCRIPTION
Adds `.sql(unsafeRaw:)`, `.sql(embed:)`, and `.sql(_:)` helpers for the following types to FluentSQL:
- `DatabaseQuery.Action`
- `DatabaseQuery.Aggregate`
- `DatabaseQuery.Aggregate.Method`
- `DatabaseQuery.Filter.Method`
- `DatabaseQuery.Filter.Relation`
- `DatabaseQuery.Join.Method`
- `DatabaseQuery.Sort.Direction`

Additional changes:
- `Schema.spaceIfNotAliased` is now `public` (it was previously `internal`).
- Updated the minimum version requirements for a couple of dependencies and made the `FluentKit` target's product dependencies more explicit.
- `DatabaseQuery.Limit.custom(_:)` and `DatabaseQuery.Offset.custom(_:)` are now deprecated, reflecting the fact that any use of them causes an unconditional `fatalError()`. Due to design limitations in SQLKit, it is not possible to implement them correctly instead of erroring.
- As promised, the use of `@_spi` has been removed in favor of the `package` access modifier now that we require Swift 5.9. This removes public symbols from the API, but because those symbols were SPI and had been explicitly documented as becoming non-public as of 5.9, this does not constitute a `semver-major` break. Anyone who was using the SPIs did so at their own risk.
- Fixed a missed `#if` condition for one of the bits of `Mirror` bypass logic (it still said `<6` instead of `<6.1`).
- A focused code formatting pass was made to remove lots of redundant uses of the `return` keyword, pretty much for the sole reason that I felt like doing it. Fixed a few incorrect comments and code style quirks along the way too, but only a few.