### PR TITLE
Remove the spurious dependency on AsyncKit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
   linux-integration-sqlite:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:6.0-noble
+    container: swift:6.1-noble
     steps:
       - name: Check out package
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
   linux-integration-mysql:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:6.0-noble
+    container: swift:6.1-noble
     services:
       mysql-a: { image: 'mysql:9', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
       mysql-b: { image: 'mysql:9', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
@@ -77,7 +77,7 @@ jobs:
   linux-integration-psql:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:6.0-noble
+    container: swift:6.1-noble
     services:
       psql-a: { image: 'postgres:17', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
       psql-b: { image: 'postgres:17', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
@@ -96,7 +96,7 @@ jobs:
   linux-integration-mongo:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:6.0-noble
+    container: swift:6.1-noble
     services:
       mongo-a: { image: 'mongo:6' }
       mongo-b: { image: 'mongo:6' }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -78,5 +78,6 @@ var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
     .enableUpcomingFeature("DisableOutwardActorInference"),
+    .enableUpcomingFeature("MemberImportVisibility"),
     .enableExperimentalFeature("StrictConcurrency=complete"),
 ] }

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.32.0"),
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.20.0"),
     ],
     targets: [
         .target(
@@ -30,7 +29,6 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "AsyncKit", package: "async-kit"),
                 .product(name: "SQLKit", package: "sql-kit"),
             ],
             swiftSettings: swiftSettings

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vapor/fluent-kit/assets/1130717/1da9ba22-253a-43ba-ac03-5cecf0075c30">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vapor/fluent-kit/assets/1130717/89800da9-2651-4fff-900a-be8f691bedb9">
-  <img src="https://github.com/vapor/fluent-kit/assets/1130717/89800da9-2651-4fff-900a-be8f691bedb9" height="96" alt="FluentKit">
-</picture> 
+<img src="https://design.vapor.codes/images/vapor-fluentkit.svg" height="96" alt="FluentKit">
 <br>
 <br>
 <a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
@@ -11,7 +7,7 @@
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/fluent-kit/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/fluent-kit/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
 <a href="https://codecov.io/github/vapor/fluent-kit"><img src="https://img.shields.io/codecov/c/github/vapor/fluent-kit?style=plastic&logo=codecov&label=codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift59up.svg" alt="Swift 5.9+"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+"></a>
 </p>
 
 <br>

--- a/Sources/FluentBenchmark/SolarSystem/GalacticJurisdiction.swift
+++ b/Sources/FluentBenchmark/SolarSystem/GalacticJurisdiction.swift
@@ -84,12 +84,14 @@ public struct GalacticJurisdictionSeed: Migration {
                 ("Messier 82", "None", 0),
                 ("Messier 82", "Military", 1),
             ]
-            .sequencedFlatMapEach(on: database.eventLoop) { galaxyName, jurisdictionName, rank in
-                GalacticJurisdiction.init(id: try! .init(
-                    galaxy: galaxies.first(where: { $0.name == galaxyName })!,
-                    jurisdiction: jurisdictions.first(where: { $0.title == jurisdictionName })!,
-                    rank: rank
-                )).create(on: database)
+            .reduce(database.eventLoop.makeSucceededVoidFuture()) { future, data in
+                future.flatMap {
+                    GalacticJurisdiction.init(id: try! .init(
+                        galaxy: galaxies.first(where: { $0.name == data.0 })!,
+                        jurisdiction: jurisdictions.first(where: { $0.title == data.1 })!,
+                        rank: data.2
+                    )).create(on: database)
+                }
             }
         }
     }

--- a/Sources/FluentBenchmark/SolarSystem/Governor.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Governor.swift
@@ -57,7 +57,7 @@ public struct GovernorSeed: Migration {
                 case "Earth":
                     governor = .init(name: "Jane Doe")
                 default:
-                    return database.eventLoop.future(())
+                    return database.eventLoop.makeSucceededVoidFuture()
                 }
                 return planet.$governor.create(governor!, on: database)
             }, on: database.eventLoop)

--- a/Sources/FluentBenchmark/SolarSystem/SolarSystem.swift
+++ b/Sources/FluentBenchmark/SolarSystem/SolarSystem.swift
@@ -1,4 +1,3 @@
-import AsyncKit
 import FluentKit
 import NIOCore
 
@@ -36,7 +35,7 @@ public struct SolarSystem: Migration {
             all = migrations
         }
 
-        return all.sequencedFlatMapEach(on: database.eventLoop) { $0.prepare(on: database) }
+        return all.reduce(database.eventLoop.makeSucceededVoidFuture()) { f, m in f.flatMap { m.prepare(on: database) } }
     }
 
     public func revert(on database: any Database) -> EventLoopFuture<Void> {
@@ -47,6 +46,6 @@ public struct SolarSystem: Migration {
             all = migrations
         }
 
-        return all.reversed().sequencedFlatMapEach(on: database.eventLoop) { $0.revert(on: database) }
+        return all.reversed().reduce(database.eventLoop.makeSucceededVoidFuture()) { f, m in f.flatMap { m.revert(on: database) } }
     }
 }

--- a/Sources/FluentBenchmark/Tests/CompositeIDTests.swift
+++ b/Sources/FluentBenchmark/Tests/CompositeIDTests.swift
@@ -242,11 +242,11 @@ public struct CompositeIDModelSeed: Migration {
     public init() {}
     
     public func prepare(on database: any Database) -> EventLoopFuture<Void> {
-        [
+        EventLoopFuture.andAllSucceed([
             CompositeIDModel(name: "A", dimensions: 1, additionalInfo: nil),
             CompositeIDModel(name: "A", dimensions: 2, additionalInfo: nil),
             CompositeIDModel(name: "B", dimensions: 1, additionalInfo: nil),
-        ].map { $0.create(on: database) }.flatten(on: database.eventLoop)
+        ].map { $0.create(on: database) }, on: database.eventLoop)
     }
     
     public func revert(on database: any Database) -> EventLoopFuture<Void> {

--- a/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
+++ b/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
@@ -1,6 +1,7 @@
-import XCTest
-import SQLKit
 import FluentKit
+import FluentSQL
+import SQLKit
+import XCTest
 
 extension FluentBenchmarker {
     public func testCompositeRelations() throws {

--- a/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
+++ b/Sources/FluentBenchmark/Tests/CompositeRelationTests.swift
@@ -216,11 +216,11 @@ final class CompositeIDParentModel: Model, @unchecked Sendable {
 
     struct ModelSeed: Migration {
         func prepare(on database: any Database) -> EventLoopFuture<Void> {
-            [
+            EventLoopFuture.andAllSucceed([
                 CompositeIDParentModel(name: "A", dimensions: 1),
                 CompositeIDParentModel(name: "B", dimensions: 1),
                 CompositeIDParentModel(name: "C", dimensions: 1),
-            ].map { $0.create(on: database) }.flatten(on: database.eventLoop)
+            ].map { $0.create(on: database) }, on: database.eventLoop)
         }
         
         func revert(on database: any Database) -> EventLoopFuture<Void> {

--- a/Sources/FluentBenchmark/Tests/FilterTests.swift
+++ b/Sources/FluentBenchmark/Tests/FilterTests.swift
@@ -289,7 +289,7 @@ private struct FooEnumMigration: Migration {
             .case("bar")
             .case("baz")
             .create()
-            .transform(to: ())
+            .map { _ in }
     }
 
     func revert(on database: any Database) -> EventLoopFuture<Void> {

--- a/Sources/FluentBenchmark/Tests/ModelTests.swift
+++ b/Sources/FluentBenchmark/Tests/ModelTests.swift
@@ -1,8 +1,9 @@
 import FluentKit
+import FluentSQL
 import Foundation
 import NIOCore
-import XCTest
 import SQLKit
+import XCTest
 
 extension FluentBenchmarker {
     public func testModel() throws {

--- a/Sources/FluentBenchmark/Tests/SQLTests.swift
+++ b/Sources/FluentBenchmark/Tests/SQLTests.swift
@@ -1,10 +1,11 @@
 import FluentKit
+import FluentSQL
 import Foundation
 import NIOCore
 import NIOPosix
-import XCTest
 import SQLKit
 import SQLKitBenchmark
+import XCTest
 
 extension FluentBenchmarker {
     public func testSQL() throws {

--- a/Sources/FluentBenchmark/Tests/SchemaTests.swift
+++ b/Sources/FluentBenchmark/Tests/SchemaTests.swift
@@ -232,7 +232,7 @@ struct DeleteTableMigration: Migration {
     let name: String
     
     func prepare(on database: any Database) -> EventLoopFuture<Void> {
-        database.eventLoop.future()
+        database.eventLoop.makeSucceededVoidFuture()
     }
     
     func revert(on database: any Database) -> EventLoopFuture<Void> {

--- a/Sources/FluentKit/Docs.docc/theme-settings.json
+++ b/Sources/FluentKit/Docs.docc/theme-settings.json
@@ -15,7 +15,7 @@
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }
     },
-    "icons": { "technology": "/fluentkit/images/vapor-fluentkit-logo.svg" }
+    "icons": { "technology": "/fluentkit/images/FluentKit/vapor-fluentkit-logo.svg" }
   },
   "features": {
     "quickNavigation": { "enable": true },

--- a/Sources/FluentKit/Migration/Migration.swift
+++ b/Sources/FluentKit/Migration/Migration.swift
@@ -28,7 +28,7 @@ extension Migration {
     }
 
     internal var defaultName: String {
-        #if compiler(<6.1)
+        #if compiler(<6.2)
         /// `String.init(reflecting:)` creates a `Mirror` unconditionally, but
         /// when the parameter is a metatype (such as is the case here), that
         /// mirror is never actually used for anything. Unfortunately, just

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AsyncKit
 import Logging
+import NIOConcurrencyHelpers
 import NIOCore
 
 public struct Migrator: Sendable {

--- a/Sources/FluentKit/Migration/Migrator.swift
+++ b/Sources/FluentKit/Migration/Migrator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AsyncKit
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -42,27 +41,27 @@ public struct Migrator: Sendable {
     // MARK: Setup
     
     public func setupIfNeeded() -> EventLoopFuture<Void> {
-        self.migrators() { $0.setupIfNeeded() }.transform(to: ())
+        self.migrators() { $0.setupIfNeeded() }.map { _ in }
     }
     
     // MARK: Prepare
     
     public func prepareBatch() -> EventLoopFuture<Void> {
-        self.migrators() { $0.prepareBatch() }.transform(to: ())
+        self.migrators() { $0.prepareBatch() }.map { _ in }
     }
     
     // MARK: Revert
     
     public func revertLastBatch() -> EventLoopFuture<Void> {
-        self.migrators() { $0.revertLastBatch() }.transform(to: ())
+        self.migrators() { $0.revertLastBatch() }.map { _ in }
     }
     
     public func revertBatch(number: Int) -> EventLoopFuture<Void> {
-        self.migrators() { $0.revertBatch(number: number) }.transform(to: ())
+        self.migrators() { $0.revertBatch(number: number) }.map { _ in }
     }
     
     public func revertAllBatches() -> EventLoopFuture<Void> {
-        self.migrators() { $0.revertAllBatches() }.transform(to: ())
+        self.migrators() { $0.revertAllBatches() }.map { _ in }
     }
     
     // MARK: Preview
@@ -100,13 +99,12 @@ public struct Migrator: Sendable {
         }
     }
 
-    private func migrators<Result>(
+    private func migrators<Result: Sendable>(
         _ handler: (DatabaseMigrator) -> EventLoopFuture<Result>
     ) -> EventLoopFuture<[Result]> {
-        self.migrations.storage.withLockedValue { $0 }.map {
+        EventLoopFuture.whenAllSucceed(self.migrations.storage.withLockedValue { $0 }.map {
             handler(.init(id: $0, database: self.databaseFactory($0), migrations: $1, migrationLogLevel: self.migrationLogLevel))
-        }
-        .flatten(on: self.eventLoop)
+        }, on: self.eventLoop)
     }
 }
 
@@ -151,7 +149,11 @@ private final class DatabaseMigrator: Sendable {
 
     func prepareBatch() -> EventLoopFuture<Void> {
         self.lastBatchNumber().flatMap { batch in
-            self.unpreparedMigrations().sequencedFlatMapEach { self.prepare($0, batch: batch + 1) }
+            self.unpreparedMigrations().flatMapWithEventLoop {
+                $0.reduce($1.makeSucceededVoidFuture()) { future, migration in
+                    future.flatMap { self.prepare(migration, batch: batch + 1) }
+                }
+            }
         }
     }
 
@@ -162,11 +164,11 @@ private final class DatabaseMigrator: Sendable {
     }
 
     func revertBatch(number: Int) -> EventLoopFuture<Void> {
-        self.preparedMigrations(batch: number).sequencedFlatMapEach { self.revert($0) }
+        self.preparedMigrations(batch: number).flatMapWithEventLoop { $0.reduce($1.makeSucceededVoidFuture()) { f, m in f.flatMap { self.revert(m) } } }
     }
 
     func revertAllBatches() -> EventLoopFuture<Void> {
-        self.preparedMigrations().sequencedFlatMapEach { self.revert($0) }
+        self.preparedMigrations().flatMapWithEventLoop { $0.reduce($1.makeSucceededVoidFuture()) { f, m in f.flatMap { self.revert(m) } } }
     }
 
     // MARK: Preview

--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -1,4 +1,4 @@
-#if compiler(<6.1)
+#if compiler(<6.2)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
@@ -24,7 +24,7 @@ internal struct _FastChildIterator: IteratorProtocol {
         deinit { self.freeFunc(self.ptr) }
     }
     
-    #if compiler(<6.1)
+    #if compiler(<6.2)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -34,7 +34,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     #endif
     private var lastNameBox: _CStringBox?
     
-    #if compiler(<6.1)
+    #if compiler(<6.2)
     fileprivate init(subject: AnyObject, type: Any.Type, childCount: Int) {
         self.subject = subject
         self.type = type
@@ -47,19 +47,6 @@ internal struct _FastChildIterator: IteratorProtocol {
     }
     #endif
     
-    init(subject: AnyObject) {
-        #if compiler(<6.1)
-        let type = _getNormalizedType(subject, type: Swift.type(of: subject))
-        self.init(
-            subject: subject,
-            type: type,
-            childCount: _getChildCount(subject, type: type)
-        )
-        #else
-        self.init(iterator: Mirror(reflecting: subject).children.makeIterator())
-        #endif
-    }
-    
     /// The `name` pointer returned by this iterator has a rather unusual lifetime guarantee - it shall remain valid
     /// until either the proceeding call to `next()` or the end of the iterator's scope. This admittedly bizarre
     /// semantic is a concession to the fact that this entire API is intended to bypass the massive speed penalties of
@@ -69,7 +56,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     /// > Note: Ironically, in the fallback case that uses `Mirror` directly, preserving this semantic actually imposes
     /// > an _additional_ performance penalty.
     mutating func next() -> (name: UnsafePointer<CChar>?, child: Any)? {
-        #if compiler(<6.1)
+        #if compiler(<6.2)
         guard self.index < self.childCount else {
             self.lastNameBox = nil // ensure any lingering name gets freed
             return nil
@@ -105,7 +92,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 }
 
 internal struct _FastChildSequence: Sequence {
-    #if compiler(<6.1)
+    #if compiler(<6.2)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -114,7 +101,7 @@ internal struct _FastChildSequence: Sequence {
     #endif
 
     init(subject: AnyObject) {
-        #if compiler(<6.1)
+        #if compiler(<6.2)
         self.subject = subject
         self.type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.childCount = _getChildCount(subject, type: self.type)
@@ -124,7 +111,7 @@ internal struct _FastChildSequence: Sequence {
     }
     
     func makeIterator() -> _FastChildIterator {
-        #if compiler(<6.1)
+        #if compiler(<6.2)
         _FastChildIterator(subject: self.subject, type: self.type, childCount: self.childCount)
         #else
         _FastChildIterator(iterator: self.children.makeIterator())

--- a/Sources/FluentKit/Query/Builder/QueryBuilder.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder.swift
@@ -1,4 +1,3 @@
-import AsyncKit
 import NIOCore
 
 public final class QueryBuilder<Model>
@@ -260,8 +259,10 @@ public final class QueryBuilder<Model>
                     return $1.makeSucceededFuture(())
                 }
                 // run eager loads
-                return loaders.sequencedFlatMapEach(on: $1) { loader in
-                    loader.anyRun(models: all.map { $0 }, on: db)
+                return loaders.reduce($1.makeSucceededVoidFuture()) { future, loader in
+                    future.flatMap {
+                        loader.anyRun(models: all.map { $0 }, on: db)
+                    }
                 }
             }
         } else {

--- a/Sources/FluentSQL/Docs.docc/theme-settings.json
+++ b/Sources/FluentSQL/Docs.docc/theme-settings.json
@@ -15,7 +15,7 @@
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }
     },
-    "icons": { "technology": "/fluentkit/images/vapor-fluentkit-logo.svg" }
+    "icons": { "technology": "/fluentsql/images/FluentSQL/vapor-fluentkit-logo.svg" }
   },
   "features": {
     "quickNavigation": { "enable": true },

--- a/Sources/FluentSQL/SQLDatabase+Model.swift
+++ b/Sources/FluentSQL/SQLDatabase+Model.swift
@@ -8,7 +8,7 @@ extension SQLQueryFetcher {
     }
     
     public func first<Model: FluentKit.Model>(decodingFluent: Model.Type) -> EventLoopFuture<Model?> {
-        self.first().optionalFlatMapThrowing { row in try row.decode(fluentModel: Model.self) }
+        self.first().flatMapThrowing { row in try row?.decode(fluentModel: Model.self) }
     }
 
     @available(*, deprecated, renamed: "all(decodingFluent:)", message: "Renamed to all(decodingFluent:)")
@@ -17,7 +17,7 @@ extension SQLQueryFetcher {
     }
     
     public func all<Model: FluentKit.Model>(decodingFluent: Model.Type) -> EventLoopFuture<[Model]> {
-        self.all().flatMapEachThrowing { row in try row.decode(fluentModel: Model.self) }
+        self.all().flatMapThrowing { rows in try rows.map { row in try row.decode(fluentModel: Model.self) } }
     }
 }
 

--- a/Sources/XCTFluent/Docs.docc/theme-settings.json
+++ b/Sources/XCTFluent/Docs.docc/theme-settings.json
@@ -15,7 +15,7 @@
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }
     },
-    "icons": { "technology": "/fluentkit/images/vapor-fluentkit-logo.svg" }
+    "icons": { "technology": "/xctfluent/images/XCTFluent/vapor-fluentkit-logo.svg" }
   },
   "features": {
     "quickNavigation": { "enable": true },

--- a/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
+++ b/Tests/FluentKitTests/AsyncTests/AsyncQueryBuilderTests.swift
@@ -1,8 +1,9 @@
 import FluentKit
 import FluentBenchmark
-import XCTest
 import Foundation
+import SQLKit
 import XCTFluent
+import XCTest
 
 final class AsyncQueryBuilderTests: XCTestCase {
     override class func setUp() {

--- a/Tests/FluentKitTests/QueryBuilderTests.swift
+++ b/Tests/FluentKitTests/QueryBuilderTests.swift
@@ -1,8 +1,9 @@
 import FluentKit
 import FluentBenchmark
-import XCTest
 import Foundation
+import SQLKit
 import XCTFluent
+import XCTest
 
 final class QueryBuilderTests: XCTestCase {
     override class func setUp() {

--- a/Tests/FluentKitTests/TestUtilities.swift
+++ b/Tests/FluentKitTests/TestUtilities.swift
@@ -1,5 +1,6 @@
-import XCTest
 import Logging
+import SQLKit
+import XCTest
 
 class DbQueryTestCase: XCTestCase {
     var db = DummyDatabaseForTestSQLSerializer()


### PR DESCRIPTION
Although each of the Fluent database drivers depends on `AsyncKit` for (poor) connection pooling, `FluentKit` itself does not need any of `AsyncKit`'s services. It was only being used for some simple `EventLoopFuture` utilities, and wasn't even being reexported (thankfully). This removes the completely unnecessary dependency altogether.

Additional changes:
- The minimum required Swift version is now 5.10
- The code is now `MemberImportVisibility`-correct
- The `MirrorBypass` logic is now enabled in Swift 6.1