### PR TITLE
Slightly improve the way database queries are represented in logging metadata

### DIFF
--- a/Sources/FluentKit/Query/Database/DatabaseQuery+Range.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery+Range.swift
@@ -31,6 +31,15 @@ extension DatabaseQuery.Limit: CustomStringConvertible {
     }
 }
 
+extension DatabaseQuery.Limit {
+    var describedByLoggingMetadata: Logger.MetadataValue {
+        switch self {
+        case .count(let count): .stringConvertible(count)
+        default: "custom"
+        }
+    }
+}
+
 extension DatabaseQuery.Offset: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -38,6 +47,15 @@ extension DatabaseQuery.Offset: CustomStringConvertible {
             "count(\(count))"
         case .custom(let custom):
             "custom(\(custom))"
+        }
+    }
+}
+
+extension DatabaseQuery.Offset {
+    var describedByLoggingMetadata: Logger.MetadataValue {
+        switch self {
+        case .count(let count): .stringConvertible(count)
+        default: "custom"
         }
     }
 }

--- a/Sources/FluentKit/Query/Database/DatabaseQuery.swift
+++ b/Sources/FluentKit/Query/Database/DatabaseQuery.swift
@@ -72,15 +72,15 @@ extension DatabaseQuery: CustomStringConvertible {
         }
         switch self.action {
         case .read, .aggregate, .custom:
-            result["unique"] = "\(self.isUnique)"
+            result["unique"] = .stringConvertible(self.isUnique)
             result["fields"] = .array(self.fields.map(\.describedByLoggingMetadata))
             result["joins"] = .array(self.joins.map(\.describedByLoggingMetadata))
             fallthrough
         case .update, .delete:
             result["filters"] = .array(self.filters.map(\.describedByLoggingMetadata))
             result["sorts"] = .array(self.sorts.map(\.describedByLoggingMetadata))
-            result["limits"] = .array(self.limits.map { .stringConvertible($0) })
-            result["offsets"] = .array(self.offsets.map { .stringConvertible($0) })
+            result["limits"] = .array(self.limits.map(\.describedByLoggingMetadata))
+            result["offsets"] = .array(self.offsets.map(\.describedByLoggingMetadata))
         default: break
         }
         return result

--- a/Tests/FluentKitTests/TestUtilities.swift
+++ b/Tests/FluentKitTests/TestUtilities.swift
@@ -39,7 +39,7 @@ func assertLastQuery(
 }
 
 func env(_ name: String) -> String? {
-    return ProcessInfo.processInfo.environment[name]
+    ProcessInfo.processInfo.environment[name]
 }
 
 let isLoggingConfigured: Bool = {


### PR DESCRIPTION
While this has no visible impact when using the "default" `StreamLogHandler`, it becomes quite visible when using smarter log handlers which respect the structural representation afforded by `Logger.MetadataValue`.

For example, with `StreamLogHandler`, with or without these changes, a given query might get logged like this:
```
2025-04-14T06:53:04-0500 debug test : action=update filters=["[\"relation\": \"and\", \"group\": \"[\\\"[\\\\\\\"value\\\\\\\": \\\\\\\"00000000-0000-0000-0000-000000000000\\\\\\\", \\\\\\\"field\\\\\\\": \\\\\\\"composite+planet.system_id\\\\\\\", \\\\\\\"method\\\\\\\": \\\\\\\"=\\\\\\\"]\\\", \\\"[\\\\\\\"field\\\\\\\": \\\\\\\"composite+planet.nrm_ord\\\\\\\", \\\\\\\"method\\\\\\\": \\\\\\\"=\\\\\\\", \\\\\\\"value\\\\\\\": \\\\\\\"1\\\\\\\"]\\\"]\"]"] input=["[\"name\": \"AA\"]"] limits=[] offsets=[] schema=composite+planet sorts=[] [FluentKit] Running query
```

With a smarter log handler (an only slightly modified version of `StreamLogHandler` in fact), but without these changes, it looks like this:
```
2025-04-14T06:58:36-0500 debug test : action="update" filters=[[group: [[field: "composite+planet.system_id", method: "=", value: "00000000-0000-0000-0000-000000000000"], [field: "composite+planet.nrm_ord", method: "=", value: "1"]], relation: "and"]] input=[[name: ""AA""]] limits=[] offsets=[] schema="composite+planet" sorts=[] [FluentKit] Running query
```

Notice that `"1"` is in quotes and `""AA""` is double-quoted. But with these changes, and the modified handler, the log now looks like this:
```
2025-04-14T06:59:29-0500 debug test : action="update" filters=[[group: [[field: "composite+planet.system_id", method: "=", value: "00000000-0000-0000-0000-000000000000"], [field: "composite+planet.nrm_ord", method: "=", value: 1]], relation: "and"]] input=[[name: "AA"]] limits=[] offsets=[] schema="composite+planet" sorts=[] [FluentKit] Running query
```
