### PR TITLE
Relax generic constraint of array operator from `Collection` to `Sequence`

### DIFF
--- a/Sources/FluentKit/Operators/ValueOperators+Array.swift
+++ b/Sources/FluentKit/Operators/ValueOperators+Array.swift
@@ -3,7 +3,7 @@
 public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -> ModelValueFilter<Model>
     where Model: FluentKit.Schema,
         Field: QueryableProperty,
-        Values: Collection,
+        Values: Sequence,
         Values.Element == Field.Value
 {
     lhs ~~ .array(rhs.map { Field.queryValue($0) })
@@ -14,7 +14,7 @@ public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: Codable,
-        Values: Collection,
+        Values: Sequence,
         Values.Element == Field.Value.Wrapped
 {
     lhs ~~ .array(rhs.map { Field.queryValue(.init($0)) })
@@ -23,7 +23,7 @@ public func ~~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
 public func !~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -> ModelValueFilter<Model>
     where Model: FluentKit.Schema,
         Field: QueryableProperty,
-        Values: Collection,
+        Values: Sequence,
         Values.Element == Field.Value
 {
     lhs !~ .array(rhs.map { Field.queryValue($0) })
@@ -34,7 +34,7 @@ public func !~ <Model, Field, Values>(lhs: KeyPath<Model, Field>, rhs: Values) -
         Field: QueryableProperty,
         Field.Value: OptionalType,
         Field.Value.Wrapped: Codable,
-        Values: Collection,
+        Values: Sequence,
         Values.Element == Field.Value.Wrapped
 {
     lhs !~ .array(rhs.map { Field.queryValue(.init($0)) })


### PR DESCRIPTION
# Changes

The array operator `~~` is currently defined to take a `Collection` as its right-hand side operand, but a `Sequence` is sufficient, so this constraint is relaxed.

# Motivation

With this change, it becomes convenient to use the operator with values like some `Sequence`, for example:

```swift
func users(ids: some Sequence<Int>) async throws -> [User] {
  try await User.query(on: db)
    .filter(\.id ~~ ids)
    .all()
}
```

In server-side data manipulation logic, it’s common to use `Sequences` that are not `Collections`, such as `.uniqued()` from `swift-algorithms`, so being able to use `some Sequence` is convenient.

# Compatibility

Since `Collection` is a sub-protocol of `Sequence`, this change to the generic signature is a pure relaxation and remains fully source-compatible.