### PR TITLE
Fix arithmetic  overflow crash in request pagination

### DIFF
--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -136,10 +136,10 @@ public struct PageRequest: Decodable, Sendable {
     }
 
     var start: Int {
-        (self.page - 1) * self.per
+        (self.page - 1).multipliedReportingOverflow(by: self.per).partialValue
     }
 
     var end: Int {
-        self.page * self.per
+        self.page.multipliedReportingOverflow(by: self.per).partialValue
     }
 }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -140,6 +140,6 @@ public struct PageRequest: Decodable, Sendable {
     }
 
     var end: Int {
-        self.page.multipliedReportingOverflow(by: self.per).partialValue
+        self.page &* self.per
     }
 }

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Paginate.swift
@@ -136,7 +136,7 @@ public struct PageRequest: Decodable, Sendable {
     }
 
     var start: Int {
-        (self.page - 1).multipliedReportingOverflow(by: self.per).partialValue
+        (self.page - 1) &* self.per
     }
 
     var end: Int {

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -717,16 +717,16 @@ final class FluentKitTests: XCTestCase {
             .wait())
     }
     
-    func testPaginationDoesntCrashOnOverflow() throws {
+    func testPaginationDoesntCrashOnOverflow() async throws {
         let db = DummyDatabaseForTestSQLSerializer()
         let pageRequest1 = PageRequest(page: 1184467440737095516, per: 1184467440737095516)
         db.fakedRows.append([.init(["aggregate": 1])])
-        // This would crash on `Swift runtime failure: arithmetic overflow` if not handled
-        // so no point trying any XCTAssert
-        _ = try Planet2
+        let result = try await Planet2
             .query(on: db)
             .paginate(pageRequest1)
-            .wait()
+        XCTAssertEqual(result.metadata.page, 1184467440737095516)
+        XCTAssertEqual(result.metadata.per, 1184467440737095516)
+        XCTAssertEqual(result.metadata.total, 1)
     }
     
     func testModelsWithSpacesSpecified() throws {

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -717,6 +717,18 @@ final class FluentKitTests: XCTestCase {
             .wait())
     }
     
+    func testPaginationDoesntCrashOnOverflow() throws {
+        let db = DummyDatabaseForTestSQLSerializer()
+        let pageRequest1 = PageRequest(page: 1184467440737095516, per: 1184467440737095516)
+        db.fakedRows.append([.init(["aggregate": 1])])
+        // This would crash on `Swift runtime failure: arithmetic overflow` if not handled
+        // so no point trying any XCTAssert
+        _ = try Planet2
+            .query(on: db)
+            .paginate(pageRequest1)
+            .wait()
+    }
+    
     func testModelsWithSpacesSpecified() throws {
         let db = DummyDatabaseForTestSQLSerializer()
         try db.schema(AltPlanet.schema, space: AltPlanet.space)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
When paging request, providing large values for `page` and `per` params will cause an arithmetic overflow exception and crash the process

<!-- When this PR is merged, the title and body will be -->
Fixes a crash where trying to paginate with values that when multiplied cause an arithmetic overflow exception and crash the process. Following added unit tests provides an example.
```swift
    func testPaginationDoesntCrashOnOverflow() throws {
        let db = DummyDatabaseForTestSQLSerializer()
        let pageRequest1 = PageRequest(page: 1184467440737095516, per: 1184467440737095516)
        db.fakedRows.append([.init(["aggregate": 1])])
        // This would crash on `Swift runtime failure: arithmetic overflow` if not handled
        // so no point trying any XCTAssert
        _ = try Planet2
            .query(on: db)
            .paginate(pageRequest1)
            .wait()
    }
``` 
