### PR TITLE
Enable `Foo.query(on:).set(\.$foo.$bar, to: baz).update()` with `@Group` properties

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
   push: { branches: [ main ] }
 
 env:
-  LOG_LEVEL: info
   POSTGRES_HOSTNAME: 'psql-a'
   POSTGRES_HOSTNAME_A: 'psql-a'
   POSTGRES_HOSTNAME_B: 'psql-b'
@@ -50,7 +49,7 @@ jobs:
       contents: read
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:6.2-noble
+    container: swift:6.3-noble
     steps:
       - name: Check out package
         uses: actions/checkout@v6
@@ -68,7 +67,7 @@ jobs:
       contents: read
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:6.2-noble
+    container: swift:6.3-noble
     services:
       mysql-a: { image: 'mysql:9', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
       mysql-b: { image: 'mysql:9', env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database } }
@@ -89,7 +88,7 @@ jobs:
       contents: read
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:6.2-noble
+    container: swift:6.3-noble
     services:
       psql-a: { image: 'postgres:18', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
       psql-b: { image: 'postgres:18', env: { POSTGRES_USER: test_username, POSTGRES_PASSWORD: test_password, POSTGRES_DB: test_database, POSTGRES_HOST_AUTH_METHOD: scram-sha-256, POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 } }
@@ -110,7 +109,7 @@ jobs:
       contents: read
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:6.2-noble
+    container: swift:6.3-noble
     services:
       mongo-a: { image: 'mongo:8' }
       mongo-b: { image: 'mongo:8' }

--- a/Sources/FluentBenchmark/Tests/GroupTests.swift
+++ b/Sources/FluentBenchmark/Tests/GroupTests.swift
@@ -29,6 +29,20 @@ extension FluentBenchmarker {
             XCTAssertEqual(moon.planet.star.name, "Sol")
             XCTAssertEqual(moon.planet.star.galaxy.name, "Milky Way")
 
+            let moon1 = try FlatMoon.query(on: self.database).filter(\.$name == "Moon").all().wait()
+            XCTAssertEqual(moon1.count, 1)
+            XCTAssertEqual(moon1.first?.planet.type, .smallRocky)
+
+            // Test updating moons
+            try FlatMoon.query(on: self.database)
+                .set(\.$planet.$type, to: .dwarf)
+                .filter(\.$name == "Moon")
+                .update().wait()
+
+            let moon2 = try FlatMoon.query(on: self.database).filter(\.$name == "Moon").all().wait()
+            XCTAssertEqual(moon2.count, 1)
+            XCTAssertEqual(moon2.first?.planet.type, .dwarf)
+
             // Test JSON
             let json = prettyJSON(moon)
             self.database.logger.debug(json)
@@ -195,7 +209,7 @@ private struct FlatMoonSeed: Migration {
             )
         )
         let europa = FlatMoon(
-            name: "Moon",
+            name: "Europa",
             planet: .init(
                 name: "Jupiter",
                 type: .gasGiant,

--- a/Sources/FluentKit/Docs.docc/Resources/vapor-fluentkit-logo.svg
+++ b/Sources/FluentKit/Docs.docc/Resources/vapor-fluentkit-logo.svg
@@ -1,21 +1,25 @@
 <svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" id="technology">
   <defs>
   <style>
-    @media(prefers-color-scheme:dark){:root{--color-logo-shape:#000;--color-logo-base:#fff}}
-    body[data-color-scheme="dark"]{--color-logo-shape:#000;--color-logo-base:#fff}
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
   </style>
-  <path id="d" d="M6,47l58-47,58,47-58,45z" />
-  <path id="s" d="M6,47v12l58,45v-12z" />
-  <path id="h" d="m73.1,23.8c-.8,0-1.7.3-2.4.9l-9.1,7.3-3.9-3.1c-.7-.6-1.9-.6-2.6,0l-12.3,9.7c-.7.6-.8,1.5-.1,2.1l3.9,3.1-9.6,7.6c-1.6,1.2-1.8,2.6-.6,3.5l2.3,1.8,38.7-30.6-2.1-1.7c-.5-.5-1.3-.7-2.2-.6zm6.2,3.8-38.8,30.7,16.5,13.2c1,.8,2.3.9,3.5-.1l35.2-27.9c1.3-1,.8-2.1.1-2.7zm-22.9,4.4,2.5,2-9.7,7.7-2.6-2zm12.8,11.1.7,4.4,4.2-3.5c1.9-1.5,4.1.5,2.2,2.1l-4.2,3.5,4.9.9c2.2.4.8,3.5-1.3,3.1l-4.9-.9.7,4.4c.2,2.1-3.3,2.9-3.6,1l-.7-4.4-4.2,3.5c-1.9,1.5-4.1-.6-2.2-2.1l4.2-3.5-4.9-.9c-2.2-.4-.8-3.6,1.3-3.1l4.9.9-.7-4.4c-.3-2,3.3-3,3.6-1z" />
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m73.1,23.8c-.8,0-1.7.3-2.4.9l-9.1,7.3-3.9-3.1c-.7-.6-1.9-.6-2.6,0l-12.3,9.7c-.7.6-.8,1.5-.1,2.1l3.9,3.1-9.6,7.6c-1.6,1.2-1.8,2.6-.6,3.5l2.3,1.8,38.7-30.6-2.1-1.7c-.5-.5-1.3-.7-2.2-.6zm6.2,3.8-38.8,30.7,16.5,13.2c1,.8,2.3.9,3.5-.1l35.2-27.9c1.3-1,.8-2.1.1-2.7zm-22.9,4.4,2.5,2-9.7,7.7-2.6-2zm12.8,11.1.7,4.4,4.2-3.5c1.9-1.5,4.1.5,2.2,2.1l-4.2,3.5,4.9.9c2.2.4.8,3.5-1.3,3.1l-4.9-.9.7,4.4c.2,2.1-3.3,2.9-3.6,1l-.7-4.4-4.2,3.5c-1.9,1.5-4.1-.6-2.2-2.1l4.2-3.5-4.9-.9c-2.2-.4-.8-3.6,1.3-3.1l4.9.9-.7-4.4c-.3-2,3.3-3,3.6-1z"/>
   </defs>
-  <use href="#s" fill="#9ee0ff"/>
-  <use href="#s" fill="#6bd0ff" y="12"/>
-  <use href="#s" fill="#38c0ff" y="24"/>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
   <g transform="matrix(-1 0 0 1 128 0)">
-    <use href="#s" fill="#f29eff"/>
-    <use href="#s" fill="#eb6bff" y="12"/>
-    <use href="#s" fill="#e438ff" y="24"/>
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
   </g>
-  <use href="#d" style="fill:var(--color-logo-base,#000)"/>
-  <use href="#h" style="fill:var(--color-logo-shape,#fff)"/>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
 </svg>

--- a/Sources/FluentKit/Docs.docc/theme-settings.json
+++ b/Sources/FluentKit/Docs.docc/theme-settings.json
@@ -1,6 +1,6 @@
 {
   "theme": {
-    "aside": { "border-radius": "16px", "border-style": "double", "border-width": "3px" },
+    "aside": { "border-radius": "16px", "border-width": "3px", "border-style": "double" },
     "border-radius": "0",
     "button": { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
     "code":   { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
@@ -8,9 +8,9 @@
       "fluentkit": { "dark": "hsl(200, 75%, 85%)", "light": "hsl(200, 75%, 75%)" },
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-fluentkit) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-fluentkit)",
-      "documentation-intro-eyebrow": "white",
+      "hero-eyebrow": "white",
       "documentation-intro-figure": "white",
-      "documentation-intro-title": "white",
+      "hero-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }

--- a/Sources/FluentKit/Model/MirrorBypass.swift
+++ b/Sources/FluentKit/Model/MirrorBypass.swift
@@ -1,4 +1,4 @@
-#if compiler(<6.2)
+#if compiler(<6.4)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
@@ -24,7 +24,7 @@ internal struct _FastChildIterator: IteratorProtocol {
         deinit { self.freeFunc(self.ptr) }
     }
     
-    #if compiler(<6.2)
+    #if compiler(<6.4)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -34,7 +34,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     #endif
     private var lastNameBox: _CStringBox?
     
-    #if compiler(<6.2)
+    #if compiler(<6.4)
     fileprivate init(subject: AnyObject, type: Any.Type, childCount: Int) {
         self.subject = subject
         self.type = type
@@ -56,7 +56,7 @@ internal struct _FastChildIterator: IteratorProtocol {
     /// > Note: Ironically, in the fallback case that uses `Mirror` directly, preserving this semantic actually imposes
     /// > an _additional_ performance penalty.
     mutating func next() -> (name: UnsafePointer<CChar>?, child: Any)? {
-        #if compiler(<6.2)
+        #if compiler(<6.4)
         guard self.index < self.childCount else {
             self.lastNameBox = nil // ensure any lingering name gets freed
             return nil
@@ -92,7 +92,7 @@ internal struct _FastChildIterator: IteratorProtocol {
 }
 
 internal struct _FastChildSequence: Sequence {
-    #if compiler(<6.2)
+    #if compiler(<6.4)
     private let subject: AnyObject
     private let type: Any.Type
     private let childCount: Int
@@ -101,7 +101,7 @@ internal struct _FastChildSequence: Sequence {
     #endif
 
     init(subject: AnyObject) {
-        #if compiler(<6.2)
+        #if compiler(<6.4)
         self.subject = subject
         self.type = _getNormalizedType(subject, type: Swift.type(of: subject))
         self.childCount = _getChildCount(subject, type: self.type)
@@ -111,7 +111,7 @@ internal struct _FastChildSequence: Sequence {
     }
     
     func makeIterator() -> _FastChildIterator {
-        #if compiler(<6.2)
+        #if compiler(<6.4)
         _FastChildIterator(subject: self.subject, type: self.type, childCount: self.childCount)
         #else
         _FastChildIterator(iterator: self.children.makeIterator())

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Set.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Set.swift
@@ -42,6 +42,30 @@ extension QueryBuilder {
 
     @discardableResult
     public func set<Field>(
+        _ field: KeyPath<Model, GroupPropertyPath<Model, Field>>,
+        to value: Field.Value
+    ) -> Self
+        where Field: QueryableProperty
+    {
+        if self.query.input.isEmpty {
+            self.query.input = [.dictionary([:])]
+        }
+
+        switch self.query.input[0] {
+        case .dictionary(var existing):
+            let path = Model.path(for: field)
+            assert(path.count == 1, "Set on nested properties is not yet supported.")
+            existing[path[0]] = Field.queryValue(value)
+            self.query.input[0] = .dictionary(existing)
+        default:
+            fatalError()
+        }
+
+        return self
+    }
+
+    @discardableResult
+    public func set<Field>(
         _ field: KeyPath<Model, Field>,
         to value: Field.Value
     ) -> Self


### PR DESCRIPTION
**These changes are now available in [1.56.0](https://github.com/vapor/fluent-kit/releases/tag/1.56.0)**


It is now possible to use the `.set(_:to:)` modifier on a query builder when referencing a property contained within an `@Group` property, e.g.:

```swift
final class FlatMoon: Model, @unchecked Sendable {
    final class Planet: Fields, @unchecked Sendable {
        enum PlanetType: String, Codable { case smallRocky, gasGiant, dwarf }

        @Field(key: "name") var name: String
        @Field(key: "type") var type: PlanetType
    }

    static let schema = "moons"

    @ID(key: .id) var id: String?
    @Group(key: "planet") var planet: Planet

    init() {}
}

try await FlatMoon.query(on: self.database)
    .set(\.$planet.$type, to: .dwarf) // <-- this works now!
    .filter(\.$id == "Moon")
    .update()
```
Also enables the Mirror bypass for 6.3 because why not. 🙂

Thanks to @mattesmohr for reporting the problem!