### PR TITLE
Expose `Model._$idKeys` for a model's identifier field keys

### DIFF
--- a/Sources/FluentKit/Model/Model.swift
+++ b/Sources/FluentKit/Model/Model.swift
@@ -44,4 +44,17 @@ extension Model {
     public var _$id: ID<IDValue> {
         self.anyID as! ID<IDValue>
     }
+
+    /// The database ``FieldKey``(s) which make up this model's identifier.
+    ///
+    /// Returns a single key for models declared with `@ID`, or the complete set of composite
+    /// keys for models declared with `@CompositeID`. Like ``_$idExists``, this works for both
+    /// cases, whereas ``_$id`` traps when applied to a model using `@CompositeID`.
+    ///
+    /// > Note: This accessor exists for the same reason as ``_$idExists``: to avoid making the
+    /// > ``AnyID`` protocol and ``anyID`` property public, which can not be usefully conformed
+    /// > to from outside FluentKit.
+    public var _$idKeys: [FieldKey] {
+        self.anyID.keys
+    }
 }

--- a/Sources/FluentKit/Properties/ID.swift
+++ b/Sources/FluentKit/Properties/ID.swift
@@ -186,7 +186,7 @@ extension IDProperty: AnyCodableProperty {
 
 extension IDProperty: AnyID { }
 
-protocol AnyID: AnyObject {
+protocol AnyID: AnyDatabaseProperty {
     func generate()
     var exists: Bool { get set }
     var cachedOutput: (any DatabaseOutput)? { get set }

--- a/Tests/FluentKitTests/CompositeIDTests.swift
+++ b/Tests/FluentKitTests/CompositeIDTests.swift
@@ -370,6 +370,13 @@ final class CompositeIDTests: XCTestCase {
     func testCompositeOptionalParentNestedKeyPathFieldKey() {
         XCTAssertEqual(CompositeMoon()[keyPath: \.$progenitor.$normalizedOrdinal!.queryablePath][0].description, "nrm_ord")
     }
+
+    func testModelIDFieldKeys() {
+        // `@ID` resolves to its single key...
+        XCTAssertEqual(SolarSystem()._$idKeys, ["id"])
+        // ...and `@CompositeID` resolves to the full set of composite keys.
+        XCTAssertEqual(CompositePlanetTag()._$idKeys, ["planet_id", "tag_id"])
+    }
 }
 
 fileprivate func XCTAssertNilNil<V>(_ expression: @autoclosure () throws -> Optional<Optional<V>>, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {


### PR DESCRIPTION
**These changes are now available in [1.57.0](https://github.com/vapor/fluent-kit/releases/tag/1.57.0)**


Code that builds raw SQL against a model — e.g. an upsert with an `ON CONFLICT` target — needs the database ``FieldKey``s of the model's identifier, and must handle both `@ID` and `@CompositeID`. The only way to get them generically today is to reach the internal `anyID` property.

Add a public `_$idKeys: [FieldKey]` accessor, mirroring the existing `_$idExists` escape hatch: it works for both `@ID` and `@CompositeID`, whereas `_$id` traps on composite models. `AnyID` is refined to `AnyDatabaseProperty` — both `IDProperty` and `CompositeIDProperty` already conform — so the accessor reads `anyID.keys` without a cast while `AnyID` and `anyID` stay internal.

